### PR TITLE
对话页大改造 + 黑白主题 + 文件上传下载

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"ttmux-web/ttmux"
@@ -161,7 +162,14 @@ func (a *API) Send(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
-	a.text(c, "send", b.Sess, b.Msg)
+	// 分两步注入：先字面文本(-l，不解释按键名)，停顿一下，再单独回车。
+	// 否则像 Codex 这类 TUI 会把「文本+回车」当成一次粘贴，把回车并进去变成换行而非提交。
+	if _, err := a.TT.Run("send-keys", "-t", b.Sess, "-l", b.Msg); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(err.Error())}})
+		return
+	}
+	time.Sleep(90 * time.Millisecond)
+	a.text(c, "send-keys", "-t", b.Sess, "Enter")
 }
 
 func (a *API) Spawn(c *gin.Context) {

--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -150,17 +150,20 @@ func (a *API) ClaudeStatus(c *gin.Context) {
 // ── JSONL → 可渲染对话 ──
 
 type cBlock struct {
-	Kind    string `json:"kind"`              // text | thinking | tool_use | tool_result
-	Text    string `json:"text,omitempty"`    // text/thinking/tool_result 文本
-	Name    string `json:"name,omitempty"`    // tool_use 工具名
-	Input   string `json:"input,omitempty"`   // tool_use 入参(JSON 字符串)
-	IsError bool   `json:"isError,omitempty"` // tool_result 是否报错
+	Kind      string `json:"kind"`                // text | thinking | tool_use | tool_result
+	Text      string `json:"text,omitempty"`      // text/thinking/tool_result 文本
+	Name      string `json:"name,omitempty"`      // tool_use 工具名
+	Input     string `json:"input,omitempty"`     // tool_use 入参(JSON 字符串)
+	ID        string `json:"id,omitempty"`        // tool_use 的 id（供前端把结果挂到调用下）
+	ToolUseID string `json:"toolUseId,omitempty"` // tool_result 对应的 tool_use id
+	IsError   bool   `json:"isError,omitempty"`   // tool_result 是否报错
 }
 
 type cMsg struct {
 	Role   string   `json:"role"` // user | assistant | tool
 	Blocks []cBlock `json:"blocks"`
 	Ts     string   `json:"ts,omitempty"`
+	ID     string   `json:"id,omitempty"` // 行 uuid，供前端做稳定 key（保住折叠态）
 }
 
 const blockCap = 6000 // 单块文本上限，避免巨大 tool 输出撑爆响应
@@ -188,11 +191,17 @@ func rawContentText(raw json.RawMessage) string {
 	if json.Unmarshal(raw, &arr) == nil {
 		var b strings.Builder
 		for _, x := range arr {
-			b.WriteString(x.Text)
+			switch x.Type {
+			case "image":
+				b.WriteString("[图片]\n")
+			default:
+				b.WriteString(x.Text)
+			}
 		}
-		return b.String()
+		return strings.TrimRight(b.String(), "\n")
 	}
-	return ""
+	// 其它结构（对象等）：原样回退为紧凑 JSON，至少不丢信息
+	return string(raw)
 }
 
 // parseLine 把一行 JSONL 解析成 cMsg；非对话行（mode/snapshot/system 等）返回 nil。
@@ -200,6 +209,7 @@ func parseLine(line string) *cMsg {
 	var raw struct {
 		Type    string `json:"type"`
 		Ts      string `json:"timestamp"`
+		UUID    string `json:"uuid"`
 		Message struct {
 			Role    string          `json:"role"`
 			Content json.RawMessage `json:"content"`
@@ -219,18 +229,20 @@ func parseLine(line string) *cMsg {
 		if str == "" {
 			return nil
 		}
-		return &cMsg{Role: "user", Ts: raw.Ts, Blocks: []cBlock{{Kind: "text", Text: clip(str)}}}
+		return &cMsg{Role: "user", Ts: raw.Ts, ID: raw.UUID, Blocks: []cBlock{{Kind: "text", Text: clip(str)}}}
 	}
 
 	// 否则是块数组
 	var arr []struct {
-		Type     string          `json:"type"`
-		Text     string          `json:"text"`
-		Thinking string          `json:"thinking"`
-		Name     string          `json:"name"`
-		Input    json.RawMessage `json:"input"`
-		Content  json.RawMessage `json:"content"`
-		IsError  bool            `json:"is_error"`
+		Type      string          `json:"type"`
+		Text      string          `json:"text"`
+		Thinking  string          `json:"thinking"`
+		Name      string          `json:"name"`
+		Input     json.RawMessage `json:"input"`
+		Content   json.RawMessage `json:"content"`
+		ID        string          `json:"id"`
+		ToolUseID string          `json:"tool_use_id"`
+		IsError   bool            `json:"is_error"`
 	}
 	if json.Unmarshal(raw.Message.Content, &arr) != nil {
 		return nil
@@ -248,17 +260,19 @@ func parseLine(line string) *cMsg {
 			if t := strings.TrimSpace(b.Thinking); t != "" {
 				blocks = append(blocks, cBlock{Kind: "thinking", Text: clip(t)})
 			}
+		case "redacted_thinking":
+			blocks = append(blocks, cBlock{Kind: "thinking", Text: "（思考内容已加密，无法展示）"})
 		case "tool_use":
-			blocks = append(blocks, cBlock{Kind: "tool_use", Name: b.Name, Input: clip(string(b.Input))})
+			blocks = append(blocks, cBlock{Kind: "tool_use", Name: b.Name, Input: clip(string(b.Input)), ID: b.ID})
 		case "tool_result":
 			role = "tool"
-			blocks = append(blocks, cBlock{Kind: "tool_result", Text: clip(rawContentText(b.Content)), IsError: b.IsError})
+			blocks = append(blocks, cBlock{Kind: "tool_result", Text: clip(rawContentText(b.Content)), ToolUseID: b.ToolUseID, IsError: b.IsError})
 		}
 	}
 	if len(blocks) == 0 {
 		return nil
 	}
-	return &cMsg{Role: role, Ts: raw.Ts, Blocks: blocks}
+	return &cMsg{Role: role, Ts: raw.Ts, ID: raw.UUID, Blocks: blocks}
 }
 
 // ClaudeTranscript GET /sessions/:name/transcript?file=...&offset=N
@@ -298,6 +312,9 @@ func (a *API) ClaudeTranscript(c *gin.Context) {
 			continue
 		}
 		if m := parseLine(sc.Text()); m != nil {
+			if m.ID == "" { // uuid 缺失时用行号兜底，保证稳定 key
+				m.ID = strconv.Itoa(n)
+			}
 			msgs = append(msgs, *m)
 		}
 	}

--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -161,6 +161,7 @@ func parseCodexItem(payload json.RawMessage, ts string) *cMsg {
 		Arguments string          `json:"arguments"`
 		Input     string          `json:"input"`
 		Output    json.RawMessage `json:"output"`
+		CallID    string          `json:"call_id"`
 	}
 	if json.Unmarshal(payload, &p) != nil {
 		return nil
@@ -197,12 +198,12 @@ func parseCodexItem(payload json.RawMessage, ts string) *cMsg {
 		}
 		return &cMsg{Role: "assistant", Ts: ts, Blocks: []cBlock{{Kind: "thinking", Text: clip(t)}}}
 	case "function_call":
-		return &cMsg{Role: "assistant", Ts: ts, Blocks: []cBlock{{Kind: "tool_use", Name: p.Name, Input: clip(p.Arguments)}}}
+		return &cMsg{Role: "assistant", Ts: ts, Blocks: []cBlock{{Kind: "tool_use", Name: p.Name, Input: clip(p.Arguments), ID: p.CallID}}}
 	case "custom_tool_call":
-		return &cMsg{Role: "assistant", Ts: ts, Blocks: []cBlock{{Kind: "tool_use", Name: p.Name, Input: clip(p.Input)}}}
+		return &cMsg{Role: "assistant", Ts: ts, Blocks: []cBlock{{Kind: "tool_use", Name: p.Name, Input: clip(p.Input), ID: p.CallID}}}
 	case "function_call_output", "custom_tool_call_output":
 		out := codexOutputText(p.Output)
-		return &cMsg{Role: "tool", Ts: ts, Blocks: []cBlock{{Kind: "tool_result", Text: clip(out), IsError: codexOutputIsError(out)}}}
+		return &cMsg{Role: "tool", Ts: ts, Blocks: []cBlock{{Kind: "tool_result", Text: clip(out), ToolUseID: p.CallID, IsError: codexOutputIsError(out)}}}
 	}
 	return nil
 }
@@ -282,6 +283,9 @@ func (a *API) CodexTranscript(c *gin.Context) {
 			continue
 		}
 		if m := parseCodexLine(sc.Text()); m != nil {
+			if m.ID == "" { // 行号作稳定 key（前端窗口化/折叠态持久化用）
+				m.ID = strconv.Itoa(n)
+			}
 			msgs = append(msgs, *m)
 		}
 	}

--- a/backend/api/files.go
+++ b/backend/api/files.go
@@ -4,11 +4,13 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -98,5 +100,62 @@ func (a *API) FileRaw(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "NOT_FILE"}})
 		return
 	}
+	if c.Query("dl") != "" { // 强制下载（附件），带原文件名
+		c.FileAttachment(p, filepath.Base(p))
+		return
+	}
 	c.File(p)
+}
+
+// uniquePath 目标已存在时在扩展名前加 (1)/(2)… 避免覆盖。
+func uniquePath(p string) string {
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return p
+	}
+	ext := filepath.Ext(p)
+	base := strings.TrimSuffix(p, ext)
+	for i := 1; ; i++ {
+		cand := fmt.Sprintf("%s (%d)%s", base, i, ext)
+		if _, err := os.Stat(cand); os.IsNotExist(err) {
+			return cand
+		}
+	}
+}
+
+// Upload POST /upload —— multipart 上传文件到指定目录(dir)。
+// form: dir=<绝对目录> + 一个或多个 files=<文件>。返回保存后的绝对路径。
+func (a *API) Upload(c *gin.Context) {
+	dir := filepath.Clean(c.PostForm("dir"))
+	if dir == "" || !filepath.IsAbs(dir) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_PATH"}})
+		return
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "NOT_DIR"}})
+		return
+	}
+	form, err := c.MultipartForm()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_FORM", "message": err.Error()}})
+		return
+	}
+	files := form.File["files"]
+	if len(files) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "NO_FILE"}})
+		return
+	}
+	saved := []string{}
+	for _, fh := range files {
+		name := filepath.Base(fh.Filename) // 去掉任何路径成分，防穿越
+		if name == "" || name == "." || name == ".." {
+			continue
+		}
+		dest := uniquePath(filepath.Join(dir, name))
+		if err := c.SaveUploadedFile(fh, dest); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "WRITE_ERROR", "message": err.Error()}})
+			return
+		}
+		saved = append(saved, dest)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"dir": dir, "saved": saved}})
 }

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -61,7 +61,8 @@ func New(cfg Config) *gin.Engine {
 		g.GET("/fs", h.FS)
 		g.GET("/files", h.Files)      // 文件侧栏：列目录
 		g.GET("/file", h.File)        // 文件侧栏：读文件
-		g.GET("/file/raw", h.FileRaw) // 文件侧栏：原始字节（图片预览）
+		g.GET("/file/raw", h.FileRaw) // 文件侧栏：原始字节（图片预览 / ?dl=1 下载）
+		g.POST("/upload", h.Upload)   // 上传文件到指定目录（拖拽到对话框 / 文件侧栏）
 
 		g.GET("/sessions", h.Sessions)
 		g.POST("/sessions", h.NewSession)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
+        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1988,6 +1989,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2015,6 +2029,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2026,6 +2056,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -2176,6 +2215,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -3880,6 +3934,23 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -4157,6 +4228,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   Layout, Menu, Button, Card, List, Tag, Form, Input, Select, Segmented,
-  Statistic, Row, Col, Space, Popconfirm, Empty, Modal, Grid, App as AntApp, Typography, Spin, Tooltip, Dropdown, Checkbox, Progress,
+  Statistic, Row, Col, Space, Popconfirm, Empty, Modal, Grid, App as AntApp, Typography, Spin, Tooltip, Dropdown, Checkbox, Progress, AutoComplete,
 } from 'antd'
 import { QRCodeSVG } from 'qrcode.react'
 import { api, setUnauthorizedHandler } from './api'
@@ -16,6 +16,8 @@ import CodexChat from './CodexChat'
 import FileBrowser from './FileBrowser'
 import BrowserView from './BrowserView'
 import Swarm from './Swarm'
+import UpdateBanner from './UpdateBanner'
+import { useThemeMode } from './theme'
 
 interface ClaudeInfo { running: boolean; file?: string; dir?: string }
 
@@ -98,6 +100,10 @@ export default function App() {
   const tab = route.split('/')[0]                                  // 基础页（swarm/leave → swarm）
   const swarmSub = tab === 'swarm' && route.includes('/') ? decodeURIComponent(route.slice(route.indexOf('/') + 1)) : '' // 深链选中的蜂群
   const go = (k: string) => { location.hash = '#/' + k } // hash 路由：/#/xxx
+  const { mode, toggle: toggleTheme } = useThemeMode()
+  const themeIcon = mode === 'dark'
+    ? svg(<><circle cx="12" cy="12" r="4.2" /><path d="M12 2v2.2M12 19.8V22M4.2 4.2l1.6 1.6M18.2 18.2l1.6 1.6M2 12h2.2M19.8 12H22M4.2 19.8l1.6-1.6M18.2 5.8l1.6-1.6" /></>)
+    : svg(<><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" /></>)
   const [collapsed, setCollapsed] = useState(false)
   const screens = useBreakpoint()
   const hasSider = !!screens.md
@@ -218,18 +224,19 @@ export default function App() {
 
   const menu = (
     <Menu
-      theme="dark" mode="inline" selectedKeys={[tab]} onClick={(e) => go(e.key)}
+      theme={mode} mode="inline" selectedKeys={[tab]} onClick={(e) => go(e.key)}
       items={NAV.map((n) => ({ key: n.key, icon: ICONS[n.key], label: n.label }))}
       style={{ borderInlineEnd: 0, background: 'transparent' }}
     />
   )
 
   return (
-    <Layout style={{ minHeight: '100dvh', background: '#0d1117' }}>
+    <Layout style={{ minHeight: '100dvh', background: 'var(--bg-base)' }}>
+      <UpdateBanner />
       {hasSider && !dockMax && (
         <Sider collapsible trigger={null} collapsed={collapsed} collapsedWidth={64}
-          breakpoint="lg" onBreakpoint={(b) => setCollapsed(b)} width={208} theme="dark"
-          style={{ position: 'sticky', top: 0, height: '100dvh', background: '#0d1117', borderRight: '1px solid #21262d' }}>
+          breakpoint="lg" onBreakpoint={(b) => setCollapsed(b)} width={208} theme={mode}
+          style={{ position: 'sticky', top: 0, height: '100dvh', background: 'var(--bg-base)', borderRight: '1px solid var(--border-subtle)' }}>
           <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 11, padding: collapsed ? '18px 0 16px' : '18px 18px 16px', justifyContent: collapsed ? 'center' : 'flex-start' }}>
               <img src="/logo-mark.svg" width={34} height={34} alt="Roam"
@@ -238,30 +245,34 @@ export default function App() {
                 <div style={{ lineHeight: 1.15 }}>
                   <div style={{
                     fontWeight: 800, fontSize: 19, letterSpacing: 0.5,
-                    background: 'linear-gradient(180deg,#f5f7fa 0%,#c3c9d1 46%,#9aa1ab 56%,#e7ebef 100%)',
+                    background: 'var(--brand-grad)',
                     WebkitBackgroundClip: 'text', backgroundClip: 'text', WebkitTextFillColor: 'transparent',
                   }}>Roam</div>
-                  <div style={{ color: '#6e7681', fontSize: 10, letterSpacing: 1.5 }}>ANYWHERE · ANYTIME</div>
+                  <div style={{ color: 'var(--text-dimmer)', fontSize: 10, letterSpacing: 1.5 }}>ANYWHERE · ANYTIME</div>
                 </div>
               )}
             </div>
             <div style={{ flex: 1, overflowY: 'auto' }}>{menu}</div>
             {/* 底部：全屏（上）+ 折叠 + 退出（下），始终竖向堆叠 */}
-            <div style={{ borderTop: '1px solid #21262d', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div style={{ borderTop: '1px solid var(--border-subtle)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <Button type="text" block onClick={toggleTheme} style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }}
+                title={mode === 'dark' ? '切换浅色' : '切换深色'}>
+                {collapsed ? themeIcon : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{themeIcon}{mode === 'dark' ? '浅色主题' : '深色主题'}</span>}
+              </Button>
               {fsSupported && (
-                <Button type="text" block onClick={toggleFs} style={{ color: '#8b949e', textAlign: collapsed ? 'center' : 'left' }}
+                <Button type="text" block onClick={toggleFs} style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }}
                   title={isFs ? '退出全屏' : '全屏'}>
                   {collapsed ? fsIcon : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{fsIcon}{isFs ? '退出全屏' : '全屏'}</span>}
                 </Button>
               )}
-              <Button type="text" block onClick={() => setCollapsed((c) => !c)} style={{ color: '#8b949e' }}
+              <Button type="text" block onClick={() => setCollapsed((c) => !c)} style={{ color: 'var(--text-dim)' }}
                 title={collapsed ? '展开导航' : '折叠导航'}>
                 {svg(collapsed
                   ? <><polyline points="9 6 15 12 9 18" /></>
                   : <><polyline points="15 6 9 12 15 18" /></>)}
               </Button>
               <Popconfirm title="确定退出登录？" okText="退出" cancelText="取消" onConfirm={logout} placement="topRight">
-                <Button type="text" block style={{ color: '#8b949e', textAlign: collapsed ? 'center' : 'left' }} title="退出登录">
+                <Button type="text" block style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }} title="退出登录">
                   {collapsed ? svg(<><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></>) : '退出登录'}
                 </Button>
               </Popconfirm>
@@ -271,7 +282,7 @@ export default function App() {
       )}
 
       {/* 主区：左侧页面 + 右侧可停靠终端栏（桌面）。开终端时页面向左压缩。*/}
-      <Layout style={{ background: '#0d1117' }}>
+      <Layout style={{ background: 'var(--bg-base)' }}>
         <div style={{ display: 'flex', height: '100dvh', minHeight: 0 }}>
           <Content style={{
             // 终端弹出时左侧页面压窄到 300；继续向左扩展(dockMax)则收到 0、被终端遮住
@@ -288,15 +299,15 @@ export default function App() {
           {/* 角标把手：上半 ◂ 向左扩展（关→开→遮住会话列表），下半 ▸ 向右收起 */}
           {hasSider && terms.length > 0 && (
             <div style={{
-              flex: '0 0 22px', background: '#161b22', borderLeft: '1px solid #30363d',
-              display: 'flex', flexDirection: 'column', color: anyClaude ? '#d2a8ff' : '#8b949e', userSelect: 'none',
+              flex: '0 0 22px', background: 'var(--bg-container)', borderLeft: '1px solid var(--border)',
+              display: 'flex', flexDirection: 'column', color: anyClaude ? '#d2a8ff' : 'var(--text-dim)', userSelect: 'none',
             }}>
               {/* 上半：向左扩展 */}
               <div onClick={() => (dockOpen ? setDockMax(true) : setDockOpen(true))}
                 title={!dockOpen ? '展开终端' : '向左扩展（遮住会话列表）'}
                 style={{
                   flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 8,
-                  borderBottom: '1px solid #30363d', cursor: dockMax ? 'default' : 'pointer', opacity: dockMax ? 0.3 : 1,
+                  borderBottom: '1px solid var(--border)', cursor: dockMax ? 'default' : 'pointer', opacity: dockMax ? 0.3 : 1,
                 }}>
                 <span style={{ fontSize: 13 }}>◂</span>
                 <span style={{ writingMode: 'vertical-rl', letterSpacing: 2, fontSize: 12 }}>{anyClaude ? '🤖 终端' : '终端'}</span>
@@ -319,7 +330,7 @@ export default function App() {
             <div style={{
               flex: dockOpen ? 1 : '0 0 0px', minWidth: dockOpen ? 480 : 0,
               width: dockOpen ? 'auto' : 0, overflow: 'hidden', transition: 'flex-basis .2s, min-width .2s',
-              display: 'flex', flexDirection: 'column', background: '#06090d',
+              display: 'flex', flexDirection: 'column', background: 'var(--bg-term)',
             }}>
               {termPane}
             </div>
@@ -328,31 +339,31 @@ export default function App() {
       </Layout>
 
       {isMobile && (
-        <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, display: 'flex', background: '#161b22', borderTop: '1px solid #30363d', zIndex: 50, paddingBottom: 'env(safe-area-inset-bottom)' }}>
+        <nav style={{ position: 'fixed', bottom: 0, left: 0, right: 0, display: 'flex', background: 'var(--bg-container)', borderTop: '1px solid var(--border)', zIndex: 50, paddingBottom: 'env(safe-area-inset-bottom)' }}>
           {NAV.map((n) => (
             <button key={n.key} onClick={() => go(n.key)}
-              style={{ flex: 1, border: 0, background: 'none', color: tab === n.key ? '#58a6ff' : '#8b949e', padding: '8px 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, fontSize: 11 }}>
+              style={{ flex: 1, border: 0, background: 'none', color: tab === n.key ? '#58a6ff' : 'var(--text-dim)', padding: '8px 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, fontSize: 11 }}>
               {ICONS[n.key]}{n.label}
             </button>
           ))}
-          {fsSupported && (
-            <button onClick={toggleFs}
-              style={{ flex: 1, border: 0, background: 'none', color: '#8b949e', padding: '8px 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, fontSize: 11 }}>
-              {fsIcon}{isFs ? '退出' : '全屏'}
-            </button>
-          )}
-          <Popconfirm title="确定退出登录？" okText="退出" cancelText="取消" onConfirm={logout} placement="top">
+          {/* 主题/全屏/退出折叠进「更多」，省出底栏空间 */}
+          <Dropdown placement="top" trigger={['click']} menu={{ items: [
+            { key: 'theme', icon: themeIcon, label: mode === 'dark' ? '浅色主题' : '深色主题', onClick: toggleTheme },
+            ...(fsSupported ? [{ key: 'fs', icon: fsIcon, label: isFs ? '退出全屏' : '全屏', onClick: toggleFs }] : []),
+            { type: 'divider' as const },
+            { key: 'logout', danger: true, label: '退出登录', onClick: () => Modal.confirm({ title: '确定退出登录？', okText: '退出', cancelText: '取消', okButtonProps: { danger: true }, onOk: logout }) },
+          ] }}>
             <button
-              style={{ flex: 1, border: 0, background: 'none', color: '#8b949e', padding: '8px 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, fontSize: 11 }}>
-              {svg(<><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></>)}退出
+              style={{ flex: 1, border: 0, background: 'none', color: 'var(--text-dim)', padding: '8px 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, fontSize: 11 }}>
+              {svg(<><circle cx="5" cy="12" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="19" cy="12" r="1.6" /></>)}更多
             </button>
-          </Popconfirm>
+          </Dropdown>
         </nav>
       )}
 
       {/* 手机/平板：全屏会话覆盖层（桌面用右侧停靠栏，不走这里）*/}
       {isMobile && overlay && (
-        <div style={{ position: 'fixed', inset: 0, zIndex: 100, background: '#06090d', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'var(--bg-term)', display: 'flex', flexDirection: 'column' }}>
           {termPane}
         </div>
       )}
@@ -387,7 +398,7 @@ function SoloTerminal({ name }: { name: string }) {
   }, [name])
 
   return (
-    <div style={{ position: 'fixed', inset: 0, background: '#06090d', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ position: 'fixed', inset: 0, background: 'var(--bg-term)', display: 'flex', flexDirection: 'column' }}>
       <TerminalPane
         terms={[name]} active={name} setActive={() => {}} closeTerm={() => window.close()}
         fontSize={fontSize} setFontSize={setFontSize}
@@ -414,6 +425,9 @@ function TerminalPane(props: {
   const { message } = AntApp.useApp()
   const st = active ? statusMap[active] : undefined
   const dot = st === 'connected' ? '#3fb950' : st === 'connecting' ? '#d29922' : '#f85149'
+  // 当前标签是否在 Claude/Codex 对话视图：此时聊天 UI 自带输入框，
+  // 终端那条移动输入条 + 快捷键栏要隐藏，否则手机上会出现两个输入框。
+  const inChat = !!active && ((claudeView[active] && claudeMap[active]?.running) || (codexView[active] && codexMap[active]?.running))
 
   // 移动端可靠输入：xterm 隐藏 textarea 在软键盘/输入法「合成/预测词」下会把字留在
   // 合成缓冲里不提交，onData 不触发 → 打完字发不出去。触摸设备改用独立输入框：整行送 PTY。
@@ -440,10 +454,10 @@ function TerminalPane(props: {
 
   if (terms.length === 0) {
     return (
-      <div style={{ flex: 1, display: 'grid', placeItems: 'center', color: '#8b949e' }}>
+      <div style={{ flex: 1, display: 'grid', placeItems: 'center', color: 'var(--text-dim)' }}>
         <div style={{ textAlign: 'center' }}>
           <div style={{ fontSize: 40 }}>▸</div>
-          <div>点击「会话」或「任务」里的 <b style={{ color: '#e6edf3' }}>终端</b> 进入命令行</div>
+          <div>点击「会话」或「任务」里的 <b style={{ color: 'var(--text-bright)' }}>终端</b> 进入命令行</div>
         </div>
       </div>
     )
@@ -452,26 +466,26 @@ function TerminalPane(props: {
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
       {/* 标签栏 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid #30363d', overflowX: 'auto' }}>
-        {onCollapse && <Button size="small" type="text" style={{ color: '#8b949e' }} onClick={onCollapse}>✕ 收起</Button>}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid var(--border)', overflowX: 'auto' }}>
+        {onCollapse && <Button size="small" type="text" style={{ color: 'var(--text-dim)' }} onClick={onCollapse}>✕ 收起</Button>}
         {terms.map((t) => (
           <span key={t} onClick={() => setActive(t)}
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', borderRadius: 8, cursor: 'pointer', whiteSpace: 'nowrap',
-              background: t === active ? '#1f6feb33' : 'transparent', border: t === active ? '1px solid #1f6feb' : '1px solid #30363d', color: '#e6edf3',
+              background: t === active ? '#1f6feb33' : 'transparent', border: t === active ? '1px solid #1f6feb' : '1px solid var(--border)', color: 'var(--text-bright)',
             }}>
             <i style={{ width: 7, height: 7, borderRadius: '50%', background: (statusMap[t] === 'connected' ? '#3fb950' : statusMap[t] === 'connecting' ? '#d29922' : '#f85149') }} />
             {claudeMap[t]?.running && <span title="正在运行 Claude Code">🤖</span>}
             {codexMap[t]?.running && <span title="正在运行 Codex" style={{ color: '#10a37f' }}>✸</span>}
             {t}
-            <a onClick={(e) => { e.stopPropagation(); closeTerm(t) }} style={{ color: '#8b949e' }}>×</a>
+            <a onClick={(e) => { e.stopPropagation(); closeTerm(t) }} style={{ color: 'var(--text-dim)' }}>×</a>
           </span>
         ))}
       </div>
 
       {/* 工具栏 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid #21262d' }}>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: '#8b949e', fontSize: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)' }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-dim)', fontSize: 12 }}>
           <i style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
           {st === 'connected' ? '已连接' : st === 'connecting' ? '连接中' : '已断开'}
         </span>
@@ -538,8 +552,9 @@ function TerminalPane(props: {
         )}
       </div>
 
-      {/* 移动端文字输入框：软键盘/输入法在 xterm 里会丢字，这里整行可靠发送到 PTY */}
-      {isTouch && (
+      {/* 移动端文字输入框：软键盘/输入法在 xterm 里会丢字，这里整行可靠发送到 PTY。
+          对话视图(Claude/Codex)有自己的输入框，这里隐藏避免双输入框。 */}
+      {isTouch && !inChat && (
         <div style={{ display: 'flex', gap: 6, padding: '8px 8px 0' }}>
           <Input
             value={line}
@@ -553,13 +568,15 @@ function TerminalPane(props: {
         </div>
       )}
 
-      {/* 快捷键栏 */}
-      <div style={{ display: 'flex', gap: 6, padding: 8, borderTop: '1px solid #30363d', overflowX: 'auto' }}>
-        <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
-        {KEYS.map(([label, seq]) => (
-          <Button key={label} onMouseDown={noBlur} onClick={() => tapKey(seq)} style={{ flex: '0 0 auto' }}>{label}</Button>
-        ))}
-      </div>
+      {/* 快捷键栏：对话视图下隐藏（聊天 UI 不需要终端控制键，且避免与其输入区挤占） */}
+      {!inChat && (
+        <div style={{ display: 'flex', gap: 6, padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
+          <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
+          {KEYS.map(([label, seq]) => (
+            <Button key={label} onMouseDown={noBlur} onClick={() => tapKey(seq)} style={{ flex: '0 0 auto' }}>{label}</Button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -576,16 +593,16 @@ function Login({ onOk }: { onOk: () => void }) {
   useEffect(() => { api('GET', '/pubconfig').then((r) => setTotp(!!r?.data?.totp)).catch(() => {}) }, [])
 
   return (
-    <div style={{ height: '100dvh', display: 'grid', placeItems: 'center', padding: 16, background: '#0d1117' }}>
+    <div style={{ height: '100dvh', display: 'grid', placeItems: 'center', padding: 16, background: 'var(--bg-base)' }}>
       <Card style={{ width: 'min(360px,92vw)' }}>
         <div style={{ textAlign: 'center', marginBottom: 18 }}>
           <img src="/logo-mark.svg" width={64} height={64} alt="Roam" style={{ borderRadius: 14 }} />
           <div style={{
             fontSize: 30, fontWeight: 800, letterSpacing: 1, marginTop: 12,
-            background: 'linear-gradient(180deg,#f5f7fa 0%,#c3c9d1 46%,#9aa1ab 56%,#e7ebef 100%)',
+            background: 'var(--brand-grad)',
             WebkitBackgroundClip: 'text', backgroundClip: 'text', WebkitTextFillColor: 'transparent',
           }}>Roam</div>
-          <div style={{ color: '#6e7681', fontSize: 12, marginTop: 4, letterSpacing: 0.5 }}>Code anywhere, anytime.</div>
+          <div style={{ color: 'var(--text-dimmer)', fontSize: 12, marginTop: 4, letterSpacing: 0.5 }}>Code anywhere, anytime.</div>
         </div>
         <Form
           initialValues={{ password: saved, remember: !!saved }}
@@ -636,12 +653,12 @@ function StatTile({ icon, label, value, accent, onClick }: {
 }) {
   return (
     <Card size="small" hoverable={!!onClick} onClick={onClick}
-      style={{ cursor: onClick ? 'pointer' : 'default', background: '#161b22', borderColor: '#21262d' }}>
+      style={{ cursor: onClick ? 'pointer' : 'default', background: 'var(--bg-container)', borderColor: 'var(--border-subtle)' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <div style={{ width: 40, height: 40, borderRadius: 10, flex: '0 0 auto', display: 'grid', placeItems: 'center', color: accent, background: accent + '22' }}>{icon}</div>
         <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 24, fontWeight: 700, lineHeight: 1.1, color: '#e6edf3' }}>{value}</div>
-          <div style={{ color: '#8b949e', fontSize: 12 }}>{label}</div>
+          <div style={{ fontSize: 24, fontWeight: 700, lineHeight: 1.1, color: 'var(--text-bright)' }}>{value}</div>
+          <div style={{ color: 'var(--text-dim)', fontSize: 12 }}>{label}</div>
         </div>
       </div>
     </Card>
@@ -661,17 +678,17 @@ function Overview({ go, openTerm, kanna }: { go: (k: string) => void; openTerm: 
 
   const aliveMembers = swarms.reduce((n, x) => n + (x.alive || 0), 0)
   const pendingMembers = swarms.reduce((n, x) => n + (x.pending || 0), 0)
-  const chip = { color: '#8b949e', background: '#0d1117', border: '1px solid #21262d', fontSize: 12 }
+  const chip = { color: 'var(--text-dim)', background: 'var(--bg-base)', border: '1px solid var(--border-subtle)', fontSize: 12 }
 
   return (
     <Space direction="vertical" size={14} style={{ width: '100%' }}>
       {/* Hero */}
-      <div style={{ borderRadius: 14, padding: '22px 24px', background: 'linear-gradient(135deg,#161b22 0%,#0d1117 100%)', border: '1px solid #21262d' }}>
+      <div style={{ borderRadius: 14, padding: '22px 24px', background: 'linear-gradient(135deg,var(--bg-container) 0%,var(--bg-base) 100%)', border: '1px solid var(--border-subtle)' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
           <img src="/logo-mark.svg" width={48} height={48} alt="Roam" style={{ flex: '0 0 auto', borderRadius: 12, boxShadow: '0 2px 8px rgba(0,0,0,.5)' }} />
           <div style={{ flex: 1, minWidth: 200 }}>
-            <div style={{ fontSize: 22, fontWeight: 800, color: '#e6edf3' }}>欢迎回来{kanna ? '，' + kanna : ''} 👋</div>
-            <div style={{ color: '#8b949e', fontSize: 13, marginTop: 4 }}>多终端 · 蜂群编排 · 一起干活</div>
+            <div style={{ fontSize: 22, fontWeight: 800, color: 'var(--text-bright)' }}>欢迎回来 👋</div>
+            <div style={{ color: 'var(--text-dim)', fontSize: 13, marginTop: 4 }}>多终端 · 蜂群编排 · 一起干活</div>
           </div>
           <Space wrap>
             <Button type="primary" onClick={() => go('sessions')}>进入会话</Button>
@@ -701,16 +718,16 @@ function Overview({ go, openTerm, kanna }: { go: (k: string) => void; openTerm: 
               <Space direction="vertical" size={10} style={{ width: '100%' }}>
                 {swarms.slice(0, 5).map((s: any) => (
                   <div key={s.id || s.name} onClick={() => go('swarm')}
-                    style={{ cursor: 'pointer', padding: '10px 12px', borderRadius: 10, background: '#0d1117', border: '1px solid #21262d' }}>
+                    style={{ cursor: 'pointer', padding: '10px 12px', borderRadius: 10, background: 'var(--bg-base)', border: '1px solid var(--border-subtle)' }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <span style={{ fontWeight: 600, color: '#e6edf3' }}>{s.name}</span>
+                      <span style={{ fontWeight: 600, color: 'var(--text-bright)' }}>{s.name}</span>
                       <SwarmStatusTag status={s.status} />
                       {s.supervisor && <Text type="secondary" style={{ fontSize: 12 }}>◆{s.supervisor}</Text>}
                       <span style={{ flex: 1 }} />
-                      <span style={{ color: '#8b949e', fontSize: 12, whiteSpace: 'nowrap' }}>{s.alive}/{s.total} 活{s.pending ? ` · +${s.pending} 待` : ''}</span>
+                      <span style={{ color: 'var(--text-dim)', fontSize: 12, whiteSpace: 'nowrap' }}>{s.alive}/{s.total} 活{s.pending ? ` · +${s.pending} 待` : ''}</span>
                     </div>
-                    <div style={{ color: '#8b949e', fontSize: 12, marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.goal || '(无目标)'}</div>
-                    <Progress percent={s.total ? Math.round((s.alive / s.total) * 100) : 0} showInfo={false} size="small" strokeColor="#d2a8ff" trailColor="#21262d" style={{ marginBottom: 0, marginTop: 6 }} />
+                    <div style={{ color: 'var(--text-dim)', fontSize: 12, marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.goal || '(无目标)'}</div>
+                    <Progress percent={s.total ? Math.round((s.alive / s.total) * 100) : 0} showInfo={false} size="small" strokeColor="#d2a8ff" trailColor="var(--border-subtle)" style={{ marginBottom: 0, marginTop: 6 }} />
                   </div>
                 ))}
               </Space>
@@ -723,7 +740,7 @@ function Overview({ go, openTerm, kanna }: { go: (k: string) => void; openTerm: 
               <List size="small" dataSource={sessions.slice(0, 6)} renderItem={(s: any) => (
                 <List.Item actions={[<a key="t" onClick={() => openTerm(s.name)}>终端</a>]}>
                   <List.Item.Meta
-                    title={<span style={{ color: '#e6edf3' }}>{s.name}</span>}
+                    title={<span style={{ color: 'var(--text-bright)' }}>{s.name}</span>}
                     description={`${s.windows} 窗口 · ${s.attached == 1 ? '已连接' : '空闲'}`} />
                 </List.Item>
               )} />
@@ -802,21 +819,43 @@ function Tasks({ openTerm, kanna }: { openTerm: (n: string) => void; kanna?: str
 }
 
 // ── 服务器目录选择器 ──
+// 最近用过的工作目录（localStorage 持久化），作为目录选择器的快捷候选
+const RECENT_DIRS_KEY = 'ttmux_recent_dirs'
+function recentDirs(): string[] { try { return JSON.parse(localStorage.getItem(RECENT_DIRS_KEY) || '[]') } catch { return [] } }
+export function pushRecentDir(d: string) {
+  if (!d || !d.trim()) return
+  try { localStorage.setItem(RECENT_DIRS_KEY, JSON.stringify([d.trim(), ...recentDirs().filter((x) => x !== d.trim())].slice(0, 8))) } catch {}
+}
+
 function DirPicker({ open, start, onPick, onClose }: { open: boolean; start?: string; onPick: (p: string) => void; onClose: () => void }) {
   const [data, setData] = useState<any>({ path: '', parent: '', dirs: [] })
+  const [recent, setRecent] = useState<string[]>([])
   const { message } = AntApp.useApp()
   const load = (p?: string) => api('GET', '/fs' + (p !== undefined ? '?path=' + encodeURIComponent(p) : '')).then((r) => setData(r.data)).catch((e) => message.error(e.message))
-  useEffect(() => { if (open) load(start || undefined) }, [open])
+  useEffect(() => { if (open) { setRecent(recentDirs()); load(start || undefined) } }, [open])
   const enter = (d: string) => load((data.path === '/' ? '' : data.path) + '/' + d)
+  const choose = (p: string) => { pushRecentDir(p); onPick(p) }
   return (
     <Modal open={open} onCancel={onClose} title="选择工作目录" zIndex={1100}
-      footer={[<Button key="c" onClick={onClose}>取消</Button>, <Button key="o" type="primary" onClick={() => onPick(data.path)}>选择此目录</Button>]}>
-      <div style={{ fontFamily: 'monospace', color: '#8b949e', marginBottom: 8, wordBreak: 'break-all' }}>{data.path || '…'}</div>
+      footer={[<Button key="c" onClick={onClose}>取消</Button>, <Button key="o" type="primary" onClick={() => choose(data.path)}>选择此目录</Button>]}>
+      {/* 快捷候选：家目录 + 最近用过的目录 */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
+        <Tag style={{ cursor: 'pointer', margin: 0 }} onClick={() => load(undefined)}>🏠 家目录</Tag>
+        {recent.map((d) => (
+          <Tooltip key={d} title={d}>
+            <Tag color="blue" style={{ cursor: 'pointer', margin: 0, maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis' }}
+              onClick={() => load(d)} onDoubleClick={() => choose(d)}>
+              {d.split('/').filter(Boolean).pop() || d}
+            </Tag>
+          </Tooltip>
+        ))}
+      </div>
+      <div style={{ fontFamily: 'monospace', color: 'var(--text-dim)', marginBottom: 8, wordBreak: 'break-all' }}>{data.path || '…'}</div>
       <List size="small" style={{ maxHeight: '50vh', overflow: 'auto' }}
         dataSource={['..', ...(data.dirs || [])]}
         renderItem={(d: string) => (
           <List.Item style={{ cursor: 'pointer' }} onClick={() => (d === '..' ? load(data.parent) : enter(d))}>
-            <span style={{ color: d === '..' ? '#8b949e' : '#e6edf3' }}>{d === '..' ? '↑ 上级目录' : '▸ ' + d}</span>
+            <span style={{ color: d === '..' ? 'var(--text-dim)' : 'var(--text-bright)' }}>{d === '..' ? '↑ 上级目录' : '▸ ' + d}</span>
           </List.Item>
         )} />
     </Modal>
@@ -832,7 +871,7 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
   useEffect(() => { if (open) { setName(''); setDir('') } }, [open])
   const ok = async () => {
     if (!name.trim()) return message.error('请输入名称')
-    try { await api('POST', '/sessions', { name: name.trim(), dir: dir.trim() }); message.success('已创建'); onClose(); onDone(name.trim()) }
+    try { await api('POST', '/sessions', { name: name.trim(), dir: dir.trim() }); pushRecentDir(dir); message.success('已创建'); onClose(); onDone(name.trim()) }
     catch (e: any) { message.error(e.message) }
   }
   return (
@@ -841,7 +880,10 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
         <Space direction="vertical" style={{ width: '100%' }}>
           <Input placeholder="会话名称，如 work" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
           <Space.Compact style={{ width: '100%' }}>
-            <Input placeholder="工作目录（可空，默认家目录）" value={dir} onChange={(e) => setDir(e.target.value)} />
+            <AutoComplete style={{ flex: 1 }} value={dir} onChange={setDir}
+              options={recentDirs().map((d) => ({ value: d }))}
+              filterOption={(input, opt) => String(opt?.value).toLowerCase().includes(input.toLowerCase())}
+              placeholder="工作目录（可空，默认家目录；聚焦看最近）" />
             <Button onClick={() => setPick(true)}>浏览…</Button>
           </Space.Compact>
         </Space>
@@ -856,10 +898,36 @@ function Sessions({ openTerm }: { openTerm: (n: string) => void }) {
   const [list, setList] = useState<any[]>([])
   const [cc, setCc] = useState<Record<string, boolean>>({})
   const [cx, setCx] = useState<Record<string, boolean>>({})
+  const [swarmMap, setSwarmMap] = useState<Record<string, { swarm: string; role: string }>>({})
   const [newOpen, setNewOpen] = useState(false)
   const { message } = AntApp.useApp()
   const load = () => api('GET', '/sessions').then(setList).catch(() => {})
   useEffect(() => { load(); const t = setInterval(load, 3000); return () => clearInterval(t) }, [])
+  // 拉取蜂群拓扑：哪些会话其实是蜂群的指挥/成员。会话页和蜂群页看到的是同一批 tmux 会话，
+  // 这里据成员的真实 session 名(非前缀猜测)打标，并据此拦住「关闭」误把成员当完成解锁下游。
+  useEffect(() => {
+    let stop = false
+    const loadSwarms = async () => {
+      try {
+        const swarms = await api('GET', '/swarms')
+        if (!Array.isArray(swarms)) return
+        const map: Record<string, { swarm: string; role: string }> = {}
+        await Promise.all(swarms.map(async (sw: any) => {
+          try {
+            const st = await api('GET', `/swarms/${encodeURIComponent(sw.name)}`)
+            if (st?.supervisor) map[st.supervisor] = { swarm: sw.name, role: 'master' }
+            for (const m of (st?.members || [])) {
+              if (m?.session) map[m.session] = { swarm: sw.name, role: m.role === 'master' ? 'master' : 'worker' }
+            }
+          } catch {}
+        }))
+        if (!stop) setSwarmMap(map)
+      } catch {}
+    }
+    loadSwarms()
+    const t = setInterval(loadSwarms, 8000)
+    return () => { stop = true; clearInterval(t) }
+  }, [])
   // 标注哪些会话在跑 Claude Code
   useEffect(() => {
     let stop = false
@@ -872,26 +940,85 @@ function Sessions({ openTerm }: { openTerm: (n: string) => void }) {
     return () => { stop = true; clearInterval(t) }
   }, [list])
   const kill = async (n: string) => { try { await api('DELETE', '/sessions/' + encodeURIComponent(n)); message.success('已关闭'); load() } catch (e: any) { message.error(e.message) } }
+  const goSwarm = (sw: string) => { location.hash = '#/swarm/' + encodeURIComponent(sw) }
+
+  // ── 筛选 / 搜索 ──
+  const [q, setQ] = useState('')
+  const [filter, setFilter] = useState<'all' | 'claude' | 'codex' | 'swarm' | 'idle'>('all')
+  const ql = q.trim().toLowerCase()
+  const isSwarm = (s: any) => !!swarmMap[s.name]
+  // 默认不展示蜂群会话（它们有专门的蜂群页）；仅「蜂群」筛选时才列出
+  const match = (s: any, f: typeof filter) => {
+    if (f === 'swarm') return isSwarm(s)
+    if (isSwarm(s)) return false
+    switch (f) {
+      case 'claude': return !!cc[s.name]
+      case 'codex': return !!cx[s.name]
+      case 'idle': return !cc[s.name] && !cx[s.name]
+      default: return true
+    }
+  }
+  const filtered = list.filter((s: any) => (!ql || s.name.toLowerCase().includes(ql)) && match(s, filter))
+  const cnt = (f: typeof filter) => list.filter((s: any) => match(s, f)).length
+
   return (
-    <Card title="会话" extra={<Button type="primary" onClick={() => setNewOpen(true)}>+ 新建会话</Button>}>
-      {list.length === 0 ? <Empty description="无活跃会话" /> : (
-        <List dataSource={list} renderItem={(s: any) => (
-          <List.Item actions={[
-            <a key="t" onClick={() => openTerm(s.name)}>终端</a>,
-            <Popconfirm key="k" title={`关闭 ${s.name}？`} onConfirm={() => kill(s.name)}><a style={{ color: '#f85149' }}>关闭</a></Popconfirm>,
-          ]}>
-            <List.Item.Meta
-              title={
-                <Space size={6}>
-                  <span>{s.name}</span>
-                  {cc[s.name] && <Tag color="purple" style={{ margin: 0 }}>🤖 Claude</Tag>}
-                  {cx[s.name] && <Tag color="green" style={{ margin: 0 }}>✸ Codex</Tag>}
-                </Space>
-              }
-              description={`${s.windows} 窗口 · ${s.attached == 1 ? '已连接' : '空闲'}`} />
-          </List.Item>
-        )} />
-      )}
+    <Card
+      title={<Space size={8}>会话<Tag style={{ margin: 0 }}>{cnt('all')}</Tag></Space>}
+      extra={<Button type="primary" onClick={() => setNewOpen(true)}>+ 新建会话</Button>}
+    >
+      {/* 工具条：搜索 + 类型筛选 */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'center', marginBottom: 14 }}>
+        <Input allowClear value={q} onChange={(e) => setQ(e.target.value)} placeholder="搜索会话名…"
+          style={{ width: 220, maxWidth: '100%' }}
+          prefix={svg(<><circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></>)} />
+        <Segmented value={filter} onChange={(v) => setFilter(v as any)} options={[
+          { label: `全部 ${cnt('all')}`, value: 'all' },
+          { label: `Claude ${cnt('claude')}`, value: 'claude' },
+          { label: `Codex ${cnt('codex')}`, value: 'codex' },
+          { label: `蜂群 ${cnt('swarm')}`, value: 'swarm' },
+          { label: `空闲 ${cnt('idle')}`, value: 'idle' },
+        ]} />
+      </div>
+
+      {list.length === 0 ? <Empty description="无活跃会话" />
+        : filtered.length === 0 ? <Empty description="无匹配会话" />
+          : (
+            <List dataSource={filtered} renderItem={(s: any) => {
+              const sw = swarmMap[s.name]
+              const connected = s.attached == 1
+              const agent = cc[s.name] ? 'claude' : cx[s.name] ? 'codex' : null
+              return (
+                // 整行点击直接进入终端；右侧操作区 stopPropagation 不触发进入
+                <List.Item style={{ padding: '10px 8px', cursor: 'pointer' }} onClick={() => openTerm(s.name)}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', width: '100%' }}>
+                    <i style={{ width: 8, height: 8, borderRadius: '50%', flex: '0 0 8px', background: connected ? '#3fb950' : 'var(--text-dimmer)' }} />
+                    <span style={{ fontWeight: 600, color: 'var(--text-bright)' }} title={s.name}>{s.name}</span>
+                    {sw && <Tag color="blue" style={{ margin: 0 }}>蜂群:{sw.swarm}{sw.role === 'master' ? '·指挥' : ''}</Tag>}
+                    {cc[s.name] && <Tag color="purple" style={{ margin: 0 }}>🤖 Claude</Tag>}
+                    {cx[s.name] && <Tag color="green" style={{ margin: 0 }}>✸ Codex</Tag>}
+                    {!sw && !agent && <Tag style={{ margin: 0 }}>{connected ? '已连接' : '空闲'}</Tag>}
+                    <span style={{ color: 'var(--text-dim)', fontSize: 12 }}>{s.windows} 窗口</span>
+                    <div onClick={(e) => e.stopPropagation()} style={{ marginLeft: 'auto', display: 'flex', gap: 14, alignItems: 'center' }}>
+                      {sw && <a onClick={() => goSwarm(sw.swarm)}>蜂群页</a>}
+                      {sw ? (
+                        <Popconfirm
+                          title="直接关闭蜂群会话？"
+                          description={<div style={{ maxWidth: 280 }}>这是蜂群 <b>{sw.swarm}</b> 的{sw.role === 'master' ? '指挥' : '成员'}。从这里关闭只是 kill 会话，蜂群会据此把它当作「已完成」并解锁下游依赖，可能脱节。建议到蜂群页管理。</div>}
+                          okText="仍要关闭" okButtonProps={{ danger: true }} cancelText="取消"
+                          onConfirm={() => kill(s.name)}>
+                          <a style={{ color: '#f85149' }}>关闭</a>
+                        </Popconfirm>
+                      ) : (
+                        <Popconfirm title={`关闭 ${s.name}？`} onConfirm={() => kill(s.name)}>
+                          <a style={{ color: '#f85149' }}>关闭</a>
+                        </Popconfirm>
+                      )}
+                    </div>
+                  </div>
+                </List.Item>
+              )
+            }} />
+          )}
       <NewSessionModal open={newOpen} onClose={() => setNewOpen(false)} onDone={(name) => { load(); openTerm(name) }} />
     </Card>
   )
@@ -929,7 +1056,7 @@ function EnvPage() {
         {list.length === 0 ? <Empty description="无环境变量" /> : (
           <List dataSource={list} renderItem={(kv: any) => (
             <List.Item actions={[<Popconfirm key="d" title="删除？" onConfirm={async () => { try { await api('DELETE', '/env/' + encodeURIComponent(kv.key)); message.success('已删除'); load() } catch (e: any) { message.error(e.message) } }}><a style={{ color: '#f85149' }}>删除</a></Popconfirm>]}>
-              <List.Item.Meta title={<code>{kv.key}</code>} description={<code style={{ color: '#8b949e' }}>{kv.value}</code>} />
+              <List.Item.Meta title={<code>{kv.key}</code>} description={<code style={{ color: 'var(--text-dim)' }}>{kv.value}</code>} />
             </List.Item>
           )} />
         )}
@@ -994,16 +1121,16 @@ function TwoFactorCard() {
 
         {/* 开启流程：扫码 → 输码确认 */}
         {setup && (
-          <div style={{ padding: 16, background: '#0d1117', borderRadius: 8 }}>
+          <div style={{ padding: 16, background: 'var(--bg-base)', borderRadius: 8 }}>
             <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'flex-start' }}>
               <div style={{ background: '#fff', padding: 10, borderRadius: 8 }}><QRCodeSVG value={setup.uri} size={168} /></div>
               <div style={{ flex: 1, minWidth: 240 }}>
-                <div style={{ color: '#8b949e', fontSize: 12, marginBottom: 4 }}>① 用 Authenticator 扫码，或手动输入密钥：</div>
+                <div style={{ color: 'var(--text-dim)', fontSize: 12, marginBottom: 4 }}>① 用 Authenticator 扫码，或手动输入密钥：</div>
                 <Space.Compact style={{ width: '100%', marginBottom: 10 }}>
                   <Input readOnly value={setup.secret} />
                   <Button onClick={() => copy(setup.secret)}>复制</Button>
                 </Space.Compact>
-                <div style={{ color: '#8b949e', fontSize: 12, marginBottom: 4 }}>② 输入 App 上显示的 6 位码确认：</div>
+                <div style={{ color: 'var(--text-dim)', fontSize: 12, marginBottom: 4 }}>② 输入 App 上显示的 6 位码确认：</div>
                 <Space.Compact style={{ width: '100%' }}>
                   <Input value={code} onChange={(e) => setCode(e.target.value)} placeholder="6 位动态码" inputMode="numeric" maxLength={6} onPressEnter={confirmEnable} />
                   <Button type="primary" loading={busy} onClick={confirmEnable}>确认开启</Button>
@@ -1016,10 +1143,10 @@ function TwoFactorCard() {
 
         {/* 查看当前二维码（已开启时给新设备加） */}
         {qr && (
-          <div style={{ padding: 16, background: '#0d1117', borderRadius: 8, display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
+          <div style={{ padding: 16, background: 'var(--bg-base)', borderRadius: 8, display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
             <div style={{ background: '#fff', padding: 10, borderRadius: 8 }}><QRCodeSVG value={qr.uri} size={168} /></div>
             <div style={{ flex: 1, minWidth: 240 }}>
-              <div style={{ color: '#8b949e', fontSize: 12, marginBottom: 4 }}>扫码把当前密钥加入新设备：</div>
+              <div style={{ color: 'var(--text-dim)', fontSize: 12, marginBottom: 4 }}>扫码把当前密钥加入新设备：</div>
               <Space.Compact style={{ width: '100%' }}><Input readOnly value={qr.secret} /><Button onClick={() => copy(qr.secret)}>复制</Button></Space.Compact>
             </div>
           </div>
@@ -1117,7 +1244,7 @@ function CollectModal({ group, onClose }: { group: string | null; onClose: () =>
   }, [group])
   return (
     <Modal open={!!group} onCancel={onClose} footer={null} title={`收集: ${group || ''}`} width="min(720px,94vw)">
-      <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '60vh', overflow: 'auto', background: '#06090d', padding: 12, borderRadius: 8, fontSize: 12.5 }}>{text}</pre>
+      <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: '60vh', overflow: 'auto', background: 'var(--bg-term)', padding: 12, borderRadius: 8, fontSize: 12.5 }}>{text}</pre>
     </Modal>
   )
 }

--- a/frontend/src/BrowserView.tsx
+++ b/frontend/src/BrowserView.tsx
@@ -20,7 +20,7 @@ function BrowserTab({ tab, active, onSelect, onClose }: {
         display: 'flex', alignItems: 'center', gap: 6, width: 150, flex: '0 0 auto', height: 28,
         padding: '0 8px', borderRadius: 6, cursor: 'pointer', userSelect: 'none', fontSize: 12,
         background: active ? '#283039' : 'transparent',
-        color: active ? '#e6edf3' : '#9aa4ae',
+        color: active ? 'var(--text-bright)' : '#9aa4ae',
         border: '1px solid ' + (active ? '#3d444d' : 'transparent'),
       }}
     >
@@ -30,7 +30,7 @@ function BrowserTab({ tab, active, onSelect, onClose }: {
       <span
         onClick={(e) => { e.stopPropagation(); onClose() }}
         onMouseDown={(e) => e.stopPropagation()}
-        style={{ flex: '0 0 auto', width: 16, height: 16, lineHeight: '15px', textAlign: 'center', borderRadius: 4, color: '#8b949e' }}
+        style={{ flex: '0 0 auto', width: 16, height: 16, lineHeight: '15px', textAlign: 'center', borderRadius: 4, color: 'var(--text-dim)' }}
       >×</span>
     </div>
   )
@@ -50,7 +50,7 @@ function TabBar({ tabs, active, onSelect, onClose, onAdd, extra }: {
         <button
           onClick={onAdd}
           title="新建标签"
-          style={{ flex: '0 0 auto', width: 28, height: 28, border: 'none', background: 'transparent', color: '#8b949e', cursor: 'pointer', fontSize: 16, borderRadius: 6 }}
+          style={{ flex: '0 0 auto', width: 28, height: 28, border: 'none', background: 'transparent', color: 'var(--text-dim)', cursor: 'pointer', fontSize: 16, borderRadius: 6 }}
         >+</button>
       </div>
       <div style={{ flex: '0 0 auto' }}>{extra}</div>
@@ -349,13 +349,13 @@ export default function BrowserView() {
                     onClick={() => changeQuality(o.value)}
                     style={on
                       ? { background: '#1f6feb', borderColor: '#1f6feb', color: '#fff', fontWeight: 700, boxShadow: '0 0 0 2px rgba(31,111,235,.35)', zIndex: 1 }
-                      : { background: 'transparent', borderColor: '#30363d', color: '#8b949e' }}
+                      : { background: 'transparent', borderColor: 'var(--border)', color: 'var(--text-dim)' }}
                   >{o.label}</Button>
                 )
               })}
             </Space.Compact>
             <Tag color={connected ? 'green' : 'red'} style={{ marginInlineEnd: 0 }}>{connected ? '已连接' : '未连接'}</Tag>
-            <span style={{ color: '#8b949e', fontSize: 12, whiteSpace: 'nowrap' }}>
+            <span style={{ color: 'var(--text-dim)', fontSize: 12, whiteSpace: 'nowrap' }}>
               {quality === 'auto' && levelName ? <span style={{ color: '#58a6ff' }}>{levelName} ·</span> : null}
               {cell(latency == null ? '—' : latency + 'ms', 48)} ·{cell(fmtRate(bw), 70)} ·{cell(fps + 'fps', 42)}
             </span>

--- a/frontend/src/ClaudeChat.tsx
+++ b/frontend/src/ClaudeChat.tsx
@@ -1,154 +1,26 @@
-// Claude Code 对话面板 —— 读会话的 JSONL 记录渲染成对话气泡，输入框经 ttmux send 注入。
-// 渲染风格参考 sugyan/claude-code-webui：user 右、assistant 左、thinking 折叠、工具调用卡片。
-import { useEffect, useRef, useState } from 'react'
-import { Button, Input } from 'antd'
-import { api } from './api'
-import FileBrowser from './FileBrowser'
-import Markdown from './Markdown'
-import { PromptPanel } from './prompt'
-
-interface Block { kind: string; text?: string; name?: string; input?: string; isError?: boolean }
-interface Msg { role: string; blocks: Block[]; ts?: string }
-
-// 工具入参精简成一行摘要（command / file_path / pattern 等优先）
-function toolSummary(input?: string): string {
-  if (!input) return ''
-  try {
-    const o = JSON.parse(input)
-    const key = ['command', 'file_path', 'path', 'pattern', 'query', 'prompt', 'description'].find((k) => o[k])
-    const v = key ? String(o[key]) : JSON.stringify(o)
-    return v.length > 120 ? v.slice(0, 120) + '…' : v
-  } catch { return input.slice(0, 120) }
-}
-
-function ToolUse({ b }: { b: Block }) {
-  return (
-    <div style={{ border: '1px solid #30363d', borderRadius: 8, background: '#0d1117', padding: '6px 10px', fontSize: 12.5 }}>
-      <span style={{ color: '#d2a8ff', fontWeight: 600 }}>⚙ {b.name}</span>
-      {toolSummary(b.input) && <span style={{ color: '#8b949e', marginLeft: 8, fontFamily: 'ui-monospace, monospace' }}>{toolSummary(b.input)}</span>}
-    </div>
-  )
-}
-
-function Collapsible({ label, text, color, mono }: { label: string; text?: string; color: string; mono?: boolean }) {
-  const [open, setOpen] = useState(false)
-  if (!text) return null
-  return (
-    <div style={{ fontSize: 12 }}>
-      <a onClick={() => setOpen((o) => !o)} style={{ color }}>{open ? '▾' : '▸'} {label}</a>
-      {open && <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '4px 0 0', maxHeight: 320, overflow: 'auto', background: '#0d1117', padding: 8, borderRadius: 6, fontFamily: mono ? 'ui-monospace, monospace' : 'inherit', color: '#c9d1d9' }}>{text}</pre>}
-    </div>
-  )
-}
-
-function Bubble({ m }: { m: Msg }) {
-  const isUser = m.role === 'user'
-  const isTool = m.role === 'tool'
-  const align = isUser ? 'flex-end' : 'flex-start'
-  const bg = isUser ? '#1f6feb' : isTool ? 'transparent' : '#161b22'
-  const border = isUser ? 'none' : '1px solid #30363d'
-  const maxW = isTool ? '100%' : '86%'
-  return (
-    <div style={{ display: 'flex', justifyContent: align, margin: '6px 0' }}>
-      <div style={{ maxWidth: maxW, width: isTool ? '100%' : 'auto', background: bg, border, borderRadius: 12, padding: isTool ? 0 : '8px 12px', color: isUser ? '#fff' : '#e6edf3', display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {m.blocks.map((b, i) => {
-          if (b.kind === 'text') return <Markdown key={i} accent={isUser ? '#cfe1ff' : '#58a6ff'}>{b.text || ''}</Markdown>
-          if (b.kind === 'thinking') return <Collapsible key={i} label="思考过程" text={b.text} color="#8b949e" />
-          if (b.kind === 'tool_use') return <ToolUse key={i} b={b} />
-          if (b.kind === 'tool_result') return <Collapsible key={i} label={b.isError ? '⚠ 工具输出（错误）' : '工具输出'} text={b.text} color={b.isError ? '#f85149' : '#8b949e'} mono />
-          return null
-        })}
-      </div>
-    </div>
-  )
-}
+// Claude Code 对话面板（容器）：拉转录 → 把 tool_result 按 id 挂回 tool_use → 交给 ChatShell 渲染。
+// 渲染/工具卡片在 chat/ClaudeMessage，外壳在 chat/ChatShell，共用件在 chat/blocks。
+import { useMemo } from 'react'
+import { ChatShell } from './chat/ChatShell'
+import { Typing } from './chat/blocks'
+import { ClaudeBubble } from './chat/ClaudeMessage'
+import { useTranscript, isPending, pairToolResults } from './chat/useTranscript'
 
 export default function ClaudeChat({ name, file, dir, onBack }: { name: string; file?: string; dir?: string; onBack: () => void }) {
-  const [msgs, setMsgs] = useState<Msg[]>([])
-  const [input, setInput] = useState('')
-  const [sending, setSending] = useState(false)
-  const [err, setErr] = useState('')
-  const [showFiles, setShowFiles] = useState(false)
-  const offsetRef = useRef(0)
-  const fileRef = useRef<string | undefined>(file)
-  const boxRef = useRef<HTMLDivElement>(null)
-  const atBottom = useRef(true)
-
-  useEffect(() => {
-    let stop = false
-    offsetRef.current = 0
-    fileRef.current = file
-    setMsgs([])
-    const poll = async () => {
-      try {
-        const q = new URLSearchParams({ offset: String(offsetRef.current) })
-        if (fileRef.current) q.set('file', fileRef.current)
-        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/transcript?${q.toString()}`)
-        const d = r.data
-        if (stop) return
-        if (d.file) fileRef.current = d.file
-        if (d.messages?.length) { setMsgs((m) => [...m, ...d.messages]); offsetRef.current = d.nextOffset }
-        else if (typeof d.nextOffset === 'number') offsetRef.current = d.nextOffset
-      } catch (e: any) { if (!stop) setErr(e.message) }
-    }
-    poll()
-    const t = setInterval(poll, 2000)
-    return () => { stop = true; clearInterval(t) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name])
-
-  useEffect(() => {
-    if (atBottom.current && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
-  }, [msgs])
-
-  const onScroll = () => {
-    const el = boxRef.current
-    if (el) atBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
-  }
-
-  const send = async () => {
-    const text = input.trim()
-    if (!text || sending) return
-    setSending(true); setErr('')
-    try { await api('POST', '/tasks/_/send', { sess: name, msg: text }); setInput(''); atBottom.current = true }
-    catch (e: any) { setErr(e.message) }
-    finally { setSending(false) }
-  }
+  const { msgs, err } = useTranscript(name, file, 'transcript')
+  const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
+  const pending = isPending(view)
 
   return (
-    <div style={{ display: 'flex', height: '100%', background: '#06090d' }}>
-      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-        {/* 头 */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: '1px solid #30363d' }}>
-          <span style={{ color: '#d2a8ff', fontWeight: 600 }}>🤖 Claude Code</span>
-          <span style={{ color: '#8b949e', fontSize: 12 }}>{name}</span>
-          <span style={{ flex: 1 }} />
-          <Button size="small" type={showFiles ? 'primary' : 'default'} onClick={() => setShowFiles((s) => !s)}>📁 文件</Button>
-          <Button size="small" onClick={onBack}>切回终端 ▸</Button>
-        </div>
-        {/* 对话 */}
-        <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '8px 12px' }}>
-          {msgs.length === 0 && <div style={{ color: '#8b949e', textAlign: 'center', marginTop: 30 }}>加载对话记录…</div>}
-          {msgs.map((m, i) => <Bubble key={i} m={m} />)}
-        </div>
-        {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
-        <PromptPanel name={name} accent="#d2a8ff" />
-        {/* 输入 */}
-        {err && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{err}</div>}
-        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid #30363d' }}>
-          <Input.TextArea
-            value={input} onChange={(e) => setInput(e.target.value)}
-            autoSize={{ minRows: 1, maxRows: 5 }} placeholder="给 Claude 发消息（Enter 发送，Shift+Enter 换行）"
-            onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
-          />
-          <Button type="primary" loading={sending} onClick={send}>发送</Button>
-        </div>
-      </div>
-      {showFiles && (
-        <div style={{ flex: '0 0 clamp(200px, 32%, 300px)', minWidth: 0 }}>
-          <FileBrowser dir={dir} accent="#d2a8ff" onClose={() => setShowFiles(false)} />
-        </div>
-      )}
-    </div>
+    <ChatShell
+      name={name} dir={dir} accent="#d2a8ff" error={err}
+      title={<span style={{ color: '#d2a8ff', fontWeight: 600 }}>🤖 Claude Code</span>}
+      placeholder="给 Claude 发消息（Enter 发送，Shift+Enter 换行）"
+      onBack={onBack}
+      messages={view}
+      renderMessage={(m, i) => <ClaudeBubble key={m.id || i} m={m} results={results} />}
+      pending={pending ? <Typing color="#d2a8ff" /> : undefined}
+      busy={pending}
+    />
   )
 }

--- a/frontend/src/CodexChat.tsx
+++ b/frontend/src/CodexChat.tsx
@@ -1,203 +1,26 @@
-// Codex 对话面板 —— 读 codex rollout(JSONL) 渲染成对话，输入框经 ttmux send 注入。
-// 相比 Claude 面板，这里对 codex 工具做了「特殊渲染」：
-//   shell/exec_command → 终端命令卡片（$ cmd + 折叠输出）
-//   apply_patch        → 彩色 diff 补丁
-//   reasoning          → 折叠「推理」
-import { useEffect, useRef, useState } from 'react'
-import { Button, Input } from 'antd'
-import { api } from './api'
-import FileBrowser from './FileBrowser'
-import Markdown from './Markdown'
-import { PromptPanel } from './prompt'
-
-interface Block { kind: string; text?: string; name?: string; input?: string; isError?: boolean }
-interface Msg { role: string; blocks: Block[]; ts?: string }
-
-const ACCENT = '#10a37f' // OpenAI 绿
-const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace'
-
-// 从 function_call 入参里提取 shell 命令（cmd / command）
-function extractCmd(input?: string): string | null {
-  if (!input) return null
-  try {
-    const o = JSON.parse(input)
-    return o.cmd || o.command || (Array.isArray(o.argv) ? o.argv.join(' ') : null)
-  } catch { return null }
-}
-
-// 入参精简成一行摘要
-function argSummary(input?: string): string {
-  if (!input) return ''
-  try {
-    const o = JSON.parse(input)
-    const key = ['path', 'file_path', 'pattern', 'query', 'cmd', 'command'].find((k) => o[k])
-    const v = key ? String(o[key]) : JSON.stringify(o)
-    return v.length > 140 ? v.slice(0, 140) + '…' : v
-  } catch { return input.slice(0, 140) }
-}
-
-function Collapsible({ label, text, color, open: dflt = false }: { label: string; text?: string; color: string; open?: boolean }) {
-  const [open, setOpen] = useState(dflt)
-  if (!text) return null
-  return (
-    <div style={{ fontSize: 12 }}>
-      <a onClick={() => setOpen((o) => !o)} style={{ color }}>{open ? '▾' : '▸'} {label}</a>
-      {open && <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '4px 0 0', maxHeight: 320, overflow: 'auto', background: '#0d1117', padding: 8, borderRadius: 6, fontFamily: mono, color: '#c9d1d9' }}>{text}</pre>}
-    </div>
-  )
-}
-
-// 彩色 diff（apply_patch 的 input 即补丁文本）
-function Patch({ text }: { text: string }) {
-  return (
-    <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 360, overflow: 'auto', fontFamily: mono, fontSize: 12, lineHeight: 1.45 }}>
-      {text.split('\n').map((l, i) => {
-        let color = '#8b949e'
-        if (l.startsWith('+') && !l.startsWith('+++')) color = '#3fb950'
-        else if (l.startsWith('-') && !l.startsWith('---')) color = '#f85149'
-        else if (l.startsWith('@@') || l.startsWith('***')) color = '#d2a8ff'
-        else color = '#c9d1d9'
-        return <div key={i} style={{ color }}>{l || ' '}</div>
-      })}
-    </pre>
-  )
-}
-
-function ToolCard({ b }: { b: Block }) {
-  // apply_patch：直接展示补丁 diff
-  if (b.name === 'apply_patch') {
-    return (
-      <div style={{ border: '1px solid #30363d', borderRadius: 8, background: '#0d1117', padding: '8px 10px' }}>
-        <div style={{ color: ACCENT, fontWeight: 600, fontSize: 12.5, marginBottom: 6 }}>✎ apply_patch</div>
-        {b.input && <Patch text={b.input} />}
-      </div>
-    )
-  }
-  // shell / exec_command：终端命令卡片
-  const cmd = extractCmd(b.input)
-  if (cmd) {
-    return (
-      <div style={{ border: '1px solid #30363d', borderRadius: 8, background: '#0d1117', padding: '6px 10px', fontFamily: mono, fontSize: 12.5 }}>
-        <span style={{ color: ACCENT }}>❯</span>{' '}
-        <span style={{ color: '#c9d1d9', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{cmd}</span>
-      </div>
-    )
-  }
-  // 其他工具：名称 + 一行摘要
-  return (
-    <div style={{ border: '1px solid #30363d', borderRadius: 8, background: '#0d1117', padding: '6px 10px', fontSize: 12.5 }}>
-      <span style={{ color: ACCENT, fontWeight: 600 }}>⚙ {b.name}</span>
-      {argSummary(b.input) && <span style={{ color: '#8b949e', marginLeft: 8, fontFamily: mono }}>{argSummary(b.input)}</span>}
-    </div>
-  )
-}
-
-function Bubble({ m }: { m: Msg }) {
-  const isUser = m.role === 'user'
-  const isTool = m.role === 'tool'
-  const align = isUser ? 'flex-end' : 'flex-start'
-  const bg = isUser ? ACCENT : isTool ? 'transparent' : '#161b22'
-  const border = isUser ? 'none' : '1px solid #30363d'
-  return (
-    <div style={{ display: 'flex', justifyContent: align, margin: '6px 0' }}>
-      <div style={{ maxWidth: isTool ? '100%' : '86%', width: isTool ? '100%' : 'auto', background: bg, border, borderRadius: 12, padding: isTool ? 0 : '8px 12px', color: isUser ? '#fff' : '#e6edf3', display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {m.blocks.map((b, i) => {
-          if (b.kind === 'text') return <Markdown key={i} accent={isUser ? '#d6fff0' : ACCENT}>{b.text || ''}</Markdown>
-          if (b.kind === 'thinking') return <Collapsible key={i} label="推理" text={b.text} color="#8b949e" />
-          if (b.kind === 'tool_use') return <ToolCard key={i} b={b} />
-          if (b.kind === 'tool_result') return <Collapsible key={i} label={b.isError ? '⚠ 输出（出错）' : '输出'} text={b.text} color={b.isError ? '#f85149' : '#8b949e'} />
-          return null
-        })}
-      </div>
-    </div>
-  )
-}
+// Codex 对话面板（容器）：拉 codex rollout 转录 → 交给 ChatShell 渲染。
+// 渲染/工具卡片在 chat/CodexMessage，外壳在 chat/ChatShell，共用件在 chat/blocks。
+import { useMemo } from 'react'
+import { ChatShell } from './chat/ChatShell'
+import { Typing } from './chat/blocks'
+import { CodexBubble, CODEX_ACCENT } from './chat/CodexMessage'
+import { useTranscript, isPending, pairToolResults } from './chat/useTranscript'
 
 export default function CodexChat({ name, file, dir, onBack }: { name: string; file?: string; dir?: string; onBack: () => void }) {
-  const [msgs, setMsgs] = useState<Msg[]>([])
-  const [input, setInput] = useState('')
-  const [sending, setSending] = useState(false)
-  const [err, setErr] = useState('')
-  const [showFiles, setShowFiles] = useState(false)
-  const offsetRef = useRef(0)
-  const fileRef = useRef<string | undefined>(file)
-  const boxRef = useRef<HTMLDivElement>(null)
-  const atBottom = useRef(true)
-
-  useEffect(() => {
-    let stop = false
-    offsetRef.current = 0
-    fileRef.current = file
-    setMsgs([])
-    const poll = async () => {
-      try {
-        const q = new URLSearchParams({ offset: String(offsetRef.current) })
-        if (fileRef.current) q.set('file', fileRef.current)
-        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/codex-transcript?${q.toString()}`)
-        const d = r.data
-        if (stop) return
-        if (d.file) fileRef.current = d.file
-        if (d.messages?.length) { setMsgs((m) => [...m, ...d.messages]); offsetRef.current = d.nextOffset }
-        else if (typeof d.nextOffset === 'number') offsetRef.current = d.nextOffset
-      } catch (e: any) { if (!stop) setErr(e.message) }
-    }
-    poll()
-    const t = setInterval(poll, 2000)
-    return () => { stop = true; clearInterval(t) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name])
-
-  useEffect(() => {
-    if (atBottom.current && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
-  }, [msgs])
-
-  const onScroll = () => {
-    const el = boxRef.current
-    if (el) atBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
-  }
-
-  const send = async () => {
-    const text = input.trim()
-    if (!text || sending) return
-    setSending(true); setErr('')
-    try { await api('POST', '/tasks/_/send', { sess: name, msg: text }); setInput(''); atBottom.current = true }
-    catch (e: any) { setErr(e.message) }
-    finally { setSending(false) }
-  }
+  const { msgs, err } = useTranscript(name, file, 'codex-transcript')
+  const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
+  const pending = isPending(view)
 
   return (
-    <div style={{ display: 'flex', height: '100%', background: '#06090d' }}>
-      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: '1px solid #30363d' }}>
-          <span style={{ color: ACCENT, fontWeight: 600 }}>✸ Codex</span>
-          <span style={{ color: '#8b949e', fontSize: 12 }}>{name}</span>
-          <span style={{ flex: 1 }} />
-          <Button size="small" type={showFiles ? 'primary' : 'default'}
-            style={showFiles ? { background: ACCENT, borderColor: ACCENT } : {}}
-            onClick={() => setShowFiles((s) => !s)}>📁 文件</Button>
-          <Button size="small" onClick={onBack}>切回终端 ▸</Button>
-        </div>
-        <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '8px 12px' }}>
-          {msgs.length === 0 && <div style={{ color: '#8b949e', textAlign: 'center', marginTop: 30 }}>加载对话记录…</div>}
-          {msgs.map((m, i) => <Bubble key={i} m={m} />)}
-        </div>
-        {/* 交互式选择框（审批/选项菜单）：检测到才显示，可点选 */}
-        <PromptPanel name={name} accent={ACCENT} />
-        {err && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{err}</div>}
-        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid #30363d' }}>
-          <Input.TextArea
-            value={input} onChange={(e) => setInput(e.target.value)}
-            autoSize={{ minRows: 1, maxRows: 5 }} placeholder="给 Codex 发消息（Enter 发送，Shift+Enter 换行）"
-            onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
-          />
-          <Button type="primary" loading={sending} onClick={send} style={{ background: ACCENT, borderColor: ACCENT }}>发送</Button>
-        </div>
-      </div>
-      {showFiles && (
-        <div style={{ flex: '0 0 clamp(200px, 32%, 300px)', minWidth: 0 }}>
-          <FileBrowser dir={dir} accent={ACCENT} onClose={() => setShowFiles(false)} />
-        </div>
-      )}
-    </div>
+    <ChatShell
+      name={name} dir={dir} accent={CODEX_ACCENT} error={err}
+      title={<span style={{ color: CODEX_ACCENT, fontWeight: 600 }}>✸ Codex</span>}
+      placeholder="给 Codex 发消息（Enter 发送，Shift+Enter 换行）"
+      onBack={onBack}
+      messages={view}
+      renderMessage={(m, i) => <CodexBubble key={m.id || i} m={m} results={results} />}
+      pending={pending ? <Typing color={CODEX_ACCENT} /> : undefined}
+      busy={pending}
+    />
   )
 }

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -1,8 +1,8 @@
 // 文件侧栏 —— 在 Claude / Codex 对话页右侧浏览工作目录、查看文件内容（类似 codex 右侧边栏）。
 // 单层可导航列表：目录在前可进入、↑ 回上级、点文件在弹层里查看正文。
-import { useEffect, useState } from 'react'
-import { Button, Modal, Spin } from 'antd'
-import { api } from './api'
+import { useEffect, useRef, useState } from 'react'
+import { Button, Modal, Spin, App as AntApp } from 'antd'
+import { api, upload } from './api'
 import Markdown from './Markdown'
 
 const IMG_EXT = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'avif', 'svg']
@@ -46,7 +46,7 @@ function Viewer({ path, accent, onClose }: { path: string; accent: string; onClo
 
   const name = path.split('/').pop()
   const codePre = (text: string) => (
-    <pre style={{ margin: 0, whiteSpace: 'pre', overflow: 'auto', maxHeight: '70vh', background: '#0d1117', padding: 12, borderRadius: 8, fontFamily: 'ui-monospace, monospace', fontSize: 12.5, lineHeight: 1.5, color: '#c9d1d9' }}>{text}</pre>
+    <pre style={{ margin: 0, whiteSpace: 'pre', overflow: 'auto', maxHeight: '70vh', background: 'var(--bg-base)', padding: 12, borderRadius: 8, fontFamily: 'ui-monospace, monospace', fontSize: 12.5, lineHeight: 1.5, color: '#c9d1d9' }}>{text}</pre>
   )
 
   return (
@@ -60,11 +60,11 @@ function Viewer({ path, accent, onClose }: { path: string; accent: string; onClo
           {isMd && data && !data.binary && (
             <Button size="small" onClick={() => setSource((s) => !s)}>{source ? '渲染' : '源码'}</Button>
           )}
-          <a href={rawUrl} target="_blank" rel="noreferrer" style={{ color: '#8b949e', fontSize: 12 }}>↗ 原始</a>
+          <a href={rawUrl} target="_blank" rel="noreferrer" style={{ color: 'var(--text-dim)', fontSize: 12 }}>↗ 原始</a>
         </div>
       }>
       {isImg ? (
-        <div style={{ textAlign: 'center', background: '#0d1117', borderRadius: 8, padding: 12 }}>
+        <div style={{ textAlign: 'center', background: 'var(--bg-base)', borderRadius: 8, padding: 12 }}>
           <img src={rawUrl} alt={name} style={{ maxWidth: '100%', maxHeight: '74vh', objectFit: 'contain' }} />
         </div>
       ) : (
@@ -72,7 +72,7 @@ function Viewer({ path, accent, onClose }: { path: string; accent: string; onClo
           {err && <div style={{ color: '#f85149' }}>{err}</div>}
           {!data && !err && <div style={{ textAlign: 'center', padding: 30 }}><Spin /></div>}
           {data && data.binary && (
-            <div style={{ color: '#8b949e' }}>二进制文件，无法预览（{fmtSize(data.size)}）。<a href={rawUrl} target="_blank" rel="noreferrer" style={{ color: accent }}>下载/打开原始文件</a></div>
+            <div style={{ color: 'var(--text-dim)' }}>二进制文件，无法预览（{fmtSize(data.size)}）。<a href={rawUrl} target="_blank" rel="noreferrer" style={{ color: accent }}>下载/打开原始文件</a></div>
           )}
           {data && !data.binary && (
             <>
@@ -88,11 +88,15 @@ function Viewer({ path, accent, onClose }: { path: string; accent: string; onClo
   )
 }
 
-export default function FileBrowser({ dir, accent = '#58a6ff', onClose }: { dir?: string; accent?: string; onClose?: () => void }) {
+export default function FileBrowser({ dir, accent = '#58a6ff', onClose, onInsertPath }: { dir?: string; accent?: string; onClose?: () => void; onInsertPath?: (p: string) => void }) {
   const [path, setPath] = useState(dir || '')
   const [data, setData] = useState<Dir | null>(null)
   const [err, setErr] = useState('')
   const [view, setView] = useState<string | null>(null)
+  const [tick, setTick] = useState(0) // 上传后强制重载当前目录
+  const [uploading, setUploading] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+  const { message } = AntApp.useApp()
 
   // 会话切换（dir 变化）→ 回到工作目录根
   useEffect(() => { setPath(dir || '') }, [dir])
@@ -103,36 +107,67 @@ export default function FileBrowser({ dir, accent = '#58a6ff', onClose }: { dir?
     const q = path ? `?path=${encodeURIComponent(path)}` : ''
     api('GET', `/files${q}`).then((r) => { if (!stop) setData(r.data) }).catch((e) => { if (!stop) setErr(e.message) })
     return () => { stop = true }
-  }, [path])
+  }, [path, tick])
 
   const cur = data?.path || path
+
+  const doUpload = async (files: FileList | File[]) => {
+    if (!files || !files.length || !cur || uploading) return
+    setUploading(true)
+    try {
+      const res = await upload(cur, files)
+      message.success(`已上传 ${res.saved.length} 个文件`)
+      setTick((t) => t + 1)
+    } catch (e: any) { message.error('上传失败：' + e.message) }
+    finally { setUploading(false) }
+  }
   // 根目录之上不再回退（防止越过工作目录乱逛；dir 为空时允许一直向上）
   const canUp = !!data && data.parent !== data.path && (!dir || cur !== dir)
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#0a0e13', borderLeft: '1px solid #21262d' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 10px', borderBottom: '1px solid #21262d' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#0a0e13', borderLeft: '1px solid var(--border-subtle)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 10px', borderBottom: '1px solid var(--border-subtle)' }}>
         <span style={{ color: accent }}><FolderIcon /></span>
-        <span style={{ color: '#e6edf3', fontWeight: 600, fontSize: 13 }}>文件</span>
+        <span style={{ color: 'var(--text-bright)', fontWeight: 600, fontSize: 13 }}>文件</span>
         <span style={{ flex: 1 }} />
-        {onClose && <a onClick={onClose} style={{ color: '#8b949e', fontSize: 12 }}>✕</a>}
+        <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
+          onChange={(e) => { if (e.target.files?.length) doUpload(e.target.files); e.target.value = '' }} />
+        <a onClick={() => fileRef.current?.click()} title="上传到当前目录" style={{ color: uploading ? accent : 'var(--text-dim)', fontSize: 13, marginRight: onClose ? 8 : 0 }}>⬆</a>
+        {onClose && <a onClick={onClose} style={{ color: 'var(--text-dim)', fontSize: 12 }}>✕</a>}
       </div>
-      <div title={cur} style={{ padding: '4px 10px', color: '#8b949e', fontSize: 11.5, fontFamily: 'ui-monospace, monospace', borderBottom: '1px solid #161b22', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', direction: 'rtl', textAlign: 'left' }}>{cur || '…'}</div>
+      <div title={cur} style={{ padding: '4px 10px', color: 'var(--text-dim)', fontSize: 11.5, fontFamily: 'ui-monospace, monospace', borderBottom: '1px solid var(--bg-container)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', direction: 'rtl', textAlign: 'left' }}>{cur || '…'}</div>
       <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '4px 0' }}>
         {err && <div style={{ color: '#f85149', fontSize: 12, padding: '6px 10px' }}>{err}</div>}
         {canUp && (
           <div onClick={() => setPath(data!.parent)} style={rowStyle()}>
-            <span style={{ color: '#8b949e' }}>↑</span><span style={{ color: '#8b949e' }}>上级目录</span>
+            <span style={{ color: 'var(--text-dim)' }}>↑</span><span style={{ color: 'var(--text-dim)' }}>上级目录</span>
           </div>
         )}
         {data?.entries.map((e) => (
-          <div key={e.name} onClick={() => (e.dir ? setPath((cur === '/' ? '' : cur) + '/' + e.name) : setView((cur === '/' ? '' : cur) + '/' + e.name))} style={rowStyle()}>
-            <span style={{ color: e.dir ? accent : '#6e7681', flex: '0 0 auto', display: 'inline-flex' }}>{e.dir ? <FolderIcon /> : <FileIcon />}</span>
-            <span style={{ color: e.dir ? '#e6edf3' : '#c9d1d9', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
-            {!e.dir && <span style={{ color: '#6e7681', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(e.size)}</span>}
+          <div key={e.name} className="cc-filerow"
+            draggable
+            onDragStart={(ev) => {
+              const full = (cur === '/' ? '' : cur) + '/' + e.name
+              ev.dataTransfer.setData('application/x-ttmux-path', full) // 给对话框识别用
+              ev.dataTransfer.setData('text/plain', full)
+              ev.dataTransfer.effectAllowed = 'copy'
+            }}
+            onClick={() => (e.dir ? setPath((cur === '/' ? '' : cur) + '/' + e.name) : setView((cur === '/' ? '' : cur) + '/' + e.name))} style={rowStyle()}>
+            <span style={{ color: e.dir ? accent : 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex' }}>{e.dir ? <FolderIcon /> : <FileIcon />}</span>
+            <span style={{ color: e.dir ? 'var(--text-bright)' : 'var(--text-bright)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
+            {!e.dir && <span style={{ color: 'var(--text-dimmer)', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(e.size)}</span>}
+            {onInsertPath && (
+              <a className="cc-dl" title="插入路径到输入框（@引用）"
+                onClick={(ev) => { ev.stopPropagation(); onInsertPath((cur === '/' ? '' : cur) + '/' + e.name) }}
+                style={{ color: accent, flex: '0 0 auto', fontSize: 13, fontWeight: 700 }}>@</a>
+            )}
+            {!e.dir && (
+              <a className="cc-dl" title="下载" href={`/api/file/raw?path=${encodeURIComponent((cur === '/' ? '' : cur) + '/' + e.name)}&dl=1`}
+                onClick={(ev) => ev.stopPropagation()} style={{ color: 'var(--text-dim)', flex: '0 0 auto', fontSize: 13 }}>↓</a>
+            )}
           </div>
         ))}
-        {data && data.entries.length === 0 && <div style={{ color: '#6e7681', fontSize: 12, padding: '6px 10px' }}>空目录</div>}
+        {data && data.entries.length === 0 && <div style={{ color: 'var(--text-dimmer)', fontSize: 12, padding: '6px 10px' }}>空目录</div>}
       </div>
       {view && <Viewer path={view} accent={accent} onClose={() => setView(null)} />}
     </div>

--- a/frontend/src/Markdown.tsx
+++ b/frontend/src/Markdown.tsx
@@ -2,16 +2,21 @@
 // 工具输出/命令仍按原样 <pre> 显示，不走这里。
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import rehypeHighlight from 'rehype-highlight'
 import type { CSSProperties } from 'react'
+import { CodeBox } from './chat/blocks'
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace'
 
-const preStyle: CSSProperties = {
-  margin: '6px 0', padding: 10, borderRadius: 6, background: '#0d1117', border: '1px solid #21262d',
-  overflow: 'auto', fontFamily: mono, fontSize: 12.5, lineHeight: 1.45,
+// 从 hast 节点递归取纯文本（供复制按钮用原始代码而非高亮后的 DOM）
+function nodeText(node: any): string {
+  if (!node) return ''
+  if (node.type === 'text') return node.value || ''
+  return Array.isArray(node.children) ? node.children.map(nodeText).join('') : ''
 }
+
 const inlineCode: CSSProperties = {
-  fontFamily: mono, fontSize: '0.88em', background: 'rgba(110,118,129,.28)',
+  fontFamily: mono, fontSize: '0.88em', background: 'var(--border-subtle)',
   padding: '1px 5px', borderRadius: 4,
 }
 
@@ -20,6 +25,7 @@ export default function Markdown({ children, accent = '#58a6ff' }: { children: s
     <div style={{ fontSize: 13.5, lineHeight: 1.55, wordBreak: 'break-word' }}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[[rehypeHighlight, { detect: true, ignoreMissing: true }]]}
         components={{
           // 段落/列表/标题 收紧默认大边距
           p: ({ children }) => <p style={{ margin: '4px 0' }}>{children}</p>,
@@ -31,19 +37,23 @@ export default function Markdown({ children, accent = '#58a6ff' }: { children: s
           h3: ({ children }) => <h3 style={{ fontSize: 14.5, margin: '6px 0 4px', fontWeight: 600 }}>{children}</h3>,
           h4: ({ children }) => <h4 style={{ fontSize: 13.5, margin: '6px 0 4px', fontWeight: 600 }}>{children}</h4>,
           a: ({ children, href }) => <a href={href} target="_blank" rel="noreferrer" style={{ color: accent, textDecoration: 'underline' }}>{children}</a>,
-          blockquote: ({ children }) => <blockquote style={{ margin: '6px 0', padding: '2px 10px', borderLeft: '3px solid #30363d', color: '#aab2bd' }}>{children}</blockquote>,
-          hr: () => <hr style={{ border: 0, borderTop: '1px solid #30363d', margin: '8px 0' }} />,
+          blockquote: ({ children }) => <blockquote style={{ margin: '6px 0', padding: '2px 10px', borderLeft: '3px solid var(--border)', color: 'var(--text-dim)' }}>{children}</blockquote>,
+          hr: () => <hr style={{ border: 0, borderTop: '1px solid var(--border)', margin: '8px 0' }} />,
           // pre 透传，由 code 统一加样式（块级 vs 行内）
           pre: ({ children }) => <>{children}</>,
-          code: ({ className, children }) => {
-            const text = String(children)
-            const block = (className && className.startsWith('language-')) || text.includes('\n')
-            if (block) return <pre style={preStyle}><code style={{ fontFamily: mono }}>{children}</code></pre>
+          code: ({ className, children, node }: any) => {
+            const cls = className || ''
+            const block = /hljs|language-/.test(cls) || nodeText(node).includes('\n')
+            // 块级代码复用对话里的 CodeBox（hover 复制 + 主题色 + 语法高亮）
+            if (block) {
+              const raw = (node ? nodeText(node) : String(children)).replace(/\n$/, '')
+              return <CodeBox text={raw} max={420} className={`hljs ${cls}`}>{children}</CodeBox>
+            }
             return <code style={inlineCode}>{children}</code>
           },
           table: ({ children }) => <table style={{ borderCollapse: 'collapse', margin: '6px 0', fontSize: 12.5 }}>{children}</table>,
-          th: ({ children }) => <th style={{ border: '1px solid #30363d', padding: '3px 8px', textAlign: 'left', background: '#161b22' }}>{children}</th>,
-          td: ({ children }) => <td style={{ border: '1px solid #30363d', padding: '3px 8px' }}>{children}</td>,
+          th: ({ children }) => <th style={{ border: '1px solid var(--border)', padding: '3px 8px', textAlign: 'left', background: 'var(--bg-container)' }}>{children}</th>,
+          td: ({ children }) => <td style={{ border: '1px solid var(--border)', padding: '3px 8px' }}>{children}</td>,
           img: ({ src, alt }) => <img src={src} alt={alt} style={{ maxWidth: '100%', borderRadius: 6 }} />,
         }}
       >

--- a/frontend/src/Swarm.tsx
+++ b/frontend/src/Swarm.tsx
@@ -13,8 +13,8 @@ import Markdown from './Markdown'
 
 // ── 配色（与 App.tsx 一致） ──
 const C = {
-  bg: '#0d1117', bg2: '#161b22', bg3: '#06090d', line: '#21262d', line2: '#30363d',
-  fg: '#e6edf3', fg2: '#8b949e', fg3: '#6e7681',
+  bg: 'var(--bg-base)', bg2: 'var(--bg-container)', bg3: 'var(--bg-term)', line: 'var(--border-subtle)', line2: 'var(--border)',
+  fg: 'var(--text-bright)', fg2: 'var(--text-dim)', fg3: 'var(--text-dimmer)',
   blue: '#58a6ff', green: '#3fb950', amber: '#d29922', red: '#f85149', magenta: '#d2a8ff', cyan: '#39c5cf',
 }
 const COLS = ['backlog', 'assigned', 'doing', 'review', 'done', 'blocked'] as const
@@ -54,24 +54,51 @@ export default function Swarm({ openTerm, initialSwarm, onNav }: { openTerm: (n:
 }
 
 // ── 列表页 ──
+const SWARM_STATUSES = ['running', 'planning', 'integrating', 'done', 'archived'] as const
+const SWARM_STATUS_LABEL: Record<string, string> = {
+  running: '运行中', planning: '规划', integrating: '集成中', done: '完成', archived: '归档',
+}
+
 function SwarmList({ list, onOpen, reload }: { list: SwarmRow[]; onOpen: (n: string) => void; reload: () => void }) {
   const [creating, setCreating] = useState(false)
+  // 默认只看「活跃」（非归档）；归档的蜂群需点「归档」筛选才显示
+  const [status, setStatus] = useState<string>('active')
+  const norm = (st: string) => st || 'planning'
+  const isArchived = (s: SwarmRow) => norm(s.status) === 'archived'
+  const count = (f: string) => f === 'active'
+    ? list.filter((s) => !isArchived(s)).length
+    : list.filter((s) => norm(s.status) === f).length
+  // 活跃在前 + 实际存在的非归档子状态；归档单列最后（默认不展示）
+  const options = [
+    { label: `活跃 ${count('active')}`, value: 'active' },
+    ...SWARM_STATUSES.filter((st) => st !== 'archived' && count(st) > 0).map((st) => ({ label: `${SWARM_STATUS_LABEL[st]} ${count(st)}`, value: st })),
+    ...(count('archived') > 0 ? [{ label: `${SWARM_STATUS_LABEL.archived} ${count('archived')}`, value: 'archived' }] : []),
+  ]
+  const shown = status === 'active' ? list.filter((s) => !isArchived(s)) : list.filter((s) => norm(s.status) === status)
   return (
     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
         <span style={{ fontSize: 18, fontWeight: 700, color: C.fg }}>蜂群</span>
         <span style={{ color: C.fg3, fontSize: 12 }}>一个 master cc 带一群 member cc 协作</span>
         <Button type="primary" style={{ marginLeft: 'auto' }} onClick={() => setCreating(true)}>+ 新建蜂群</Button>
       </div>
+      {/* 按状态过滤 */}
+      {list.length > 0 && options.length > 1 && (
+        <Segmented value={status} onChange={(v) => setStatus(v as string)} options={options} />
+      )}
       {list.length === 0 ? (
         <Card style={{ textAlign: 'center', padding: '32px 0' }}>
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={<span style={{ color: C.fg2 }}>还没有蜂群</span>}>
             <Button type="primary" onClick={() => setCreating(true)}>+ 新建第一个蜂群</Button>
           </Empty>
         </Card>
+      ) : shown.length === 0 ? (
+        <Card style={{ textAlign: 'center', padding: '24px 0' }}>
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={<span style={{ color: C.fg2 }}>没有「{status === 'active' ? '活跃' : (SWARM_STATUS_LABEL[status] || status)}」的蜂群</span>} />
+        </Card>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(300px,1fr))', gap: 14 }}>
-          {list.map((s) => <SwarmCard key={s.id || s.name} s={s} onOpen={onOpen} />)}
+          {shown.map((s) => <SwarmCard key={s.id || s.name} s={s} onOpen={onOpen} />)}
         </div>
       )}
       <NewSwarmModal open={creating} onClose={() => setCreating(false)} onDone={reload} />

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -14,6 +14,14 @@ export interface TermHandle {
   toBottom: () => void
 }
 
+// xterm 不认 CSS var()，需具体色值：读 <html> 上的同名变量，随黑/白主题切换。
+function xtermTheme() {
+  const cs = getComputedStyle(document.documentElement)
+  const bg = cs.getPropertyValue('--xterm-bg').trim() || '#06090d'
+  const fg = cs.getPropertyValue('--xterm-fg').trim() || '#e6edf3'
+  return { background: bg, foreground: fg, cursor: '#58a6ff' }
+}
+
 // 跨 http（局域网非安全上下文）也能用的复制
 function copyText(s: string) {
   if (navigator.clipboard && window.isSecureContext) {
@@ -101,7 +109,7 @@ const Term = forwardRef<TermHandle, {
       cursorBlink: true,
       scrollback: 5000,
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-      theme: { background: '#06090d', foreground: '#e6edf3', cursor: '#58a6ff' },
+      theme: xtermTheme(),
     })
     const fit = new FitAddon()
     term.loadAddon(fit)
@@ -109,6 +117,10 @@ const Term = forwardRef<TermHandle, {
     termRef.current = term
     fitRef.current = fit
     setTimeout(() => { try { fit.fit() } catch {} }, 0)
+
+    // 跟随全局黑/白主题：监听 <html data-theme> 变化，热更新终端配色
+    const themeObs = new MutationObserver(() => { try { term.options.theme = xtermTheme() } catch {} })
+    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
 
     const dataDisp = term.onData((d) => { const ws = wsRef.current; if (ws && ws.readyState === 1) ws.send(d) })
     const ro = new ResizeObserver(() => sendResize())
@@ -146,6 +158,7 @@ const Term = forwardRef<TermHandle, {
       unmounted.current = true
       clearTimeout(retry.current)
       ro.disconnect()
+      themeObs.disconnect()
       window.removeEventListener('resize', sendResize)
       el.removeEventListener('touchstart', onTS, { capture: true } as any)
       el.removeEventListener('touchmove', onTM, { capture: true } as any)

--- a/frontend/src/UpdateBanner.tsx
+++ b/frontend/src/UpdateBanner.tsx
@@ -1,0 +1,43 @@
+// 检测到前端有新构建（index-<hash>.js 变了）就提示刷新，省得每次手动硬刷新。
+// index.html 由后端以 no-cache 提供，所以轮询它拿到的就是最新 hash。
+import { useEffect, useState } from 'react'
+
+const RE = /assets\/index-([A-Za-z0-9_-]+)\.js/
+
+function currentHash(): string {
+  for (const s of Array.from(document.scripts)) {
+    const m = s.src && s.src.match(RE)
+    if (m) return m[1]
+  }
+  return ''
+}
+
+export default function UpdateBanner() {
+  const [stale, setStale] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const cur = currentHash()
+    if (!cur) return
+    let stop = false
+    const check = async () => {
+      try {
+        const r = await fetch('/', { cache: 'no-store' })
+        const html = await r.text()
+        const m = html.match(RE)
+        if (!stop && m && m[1] !== cur) setStale(true)
+      } catch {}
+    }
+    const t = setInterval(check, 60000)
+    return () => { stop = true; clearInterval(t) }
+  }, [])
+
+  if (!stale || dismissed) return null
+  return (
+    <div style={{ position: 'fixed', left: '50%', bottom: 18, transform: 'translateX(-50%)', zIndex: 2000, display: 'flex', alignItems: 'center', gap: 12, background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 10, padding: '8px 14px', boxShadow: 'var(--elevated-shadow)', color: 'var(--text-bright)', fontSize: 13 }}>
+      <span>🔄 有新版本</span>
+      <a onClick={() => location.reload()} style={{ color: '#58a6ff', fontWeight: 600 }}>刷新</a>
+      <a onClick={() => setDismissed(true)} style={{ color: 'var(--text-dim)' }}>稍后</a>
+    </div>
+  )
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -23,3 +23,15 @@ export async function api(method: string, path: string, body?: any): Promise<any
   }
   return data
 }
+
+// 上传文件到指定目录（multipart）。返回 { dir, saved: 绝对路径[] }。
+export async function upload(dir: string, files: FileList | File[]): Promise<{ dir: string; saved: string[] }> {
+  const form = new FormData()
+  form.append('dir', dir)
+  Array.from(files).forEach((f) => form.append('files', f))
+  const r = await fetch('/api/upload', { method: 'POST', body: form })
+  if (r.status === 401) { onUnauth(); throw new Error('未登录') }
+  const data = await r.json().catch(() => null)
+  if (!r.ok) throw new Error(data?.error?.message || data?.error?.code || 'HTTP ' + r.status)
+  return data.data
+}

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -1,0 +1,208 @@
+// 对话页外壳：头部 / 滚动区 / 交互选择框 / 输入发送 / 文件侧栏。
+// Claude、Codex 共用，差异只在 title、accent、占位文案与消息渲染(renderMessage)。
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { Button, Input, App as AntApp } from 'antd'
+import { api, upload } from '../api'
+import FileBrowser from '../FileBrowser'
+import { PromptPanel, detectPrompt } from '../prompt'
+import type { Msg } from './types'
+
+export function ChatShell({ name, dir, accent, title, placeholder, onBack, messages, renderMessage, pending, busy, error }: {
+  name: string
+  dir?: string
+  accent: string
+  title: ReactNode
+  placeholder: string
+  onBack: () => void
+  messages: Msg[]
+  renderMessage: (m: Msg, i: number) => ReactNode
+  pending?: ReactNode
+  busy?: boolean
+  error?: string
+}) {
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [sendErr, setSendErr] = useState('')
+  const [showFiles, setShowFiles] = useState(false)
+  const [showJump, setShowJump] = useState(false)
+  const [limit, setLimit] = useState(200) // 只渲染最近 N 条，超长转录不卡
+  const [dragOver, setDragOver] = useState(false)
+  const [dropMode, setDropMode] = useState<'upload' | 'path'>('upload')
+  const [uploading, setUploading] = useState(false)
+  const boxRef = useRef<HTMLDivElement>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
+  const atBottom = useRef(true)
+  const { message } = AntApp.useApp()
+
+  // 把路径插进输入框（文件侧栏「@」按钮 / 拖拽 / 上传后共用）
+  const insertPath = (p: string) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + p + ' ')
+
+  // 上传文件到会话工作目录，并把文件名插进输入框，方便直接让模型处理
+  const doUpload = async (files: FileList | File[]) => {
+    if (!files || !files.length || uploading) return
+    setUploading(true)
+    try {
+      const cwd = await api('GET', `/sessions/${encodeURIComponent(name)}/cwd`)
+      const dir = cwd?.data?.dir
+      if (!dir) { message.error('无法定位工作目录'); return }
+      const res = await upload(dir, files)
+      const names = res.saved.map((p) => p.split('/').pop() || p)
+      setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + names.join(' ') + ' ')
+      message.success(`已上传 ${names.length} 个文件到 ${dir}`)
+    } catch (e: any) { message.error('上传失败：' + e.message) }
+    finally { setUploading(false) }
+  }
+
+  const hidden = Math.max(0, messages.length - limit)
+  const visible = hidden > 0 ? messages.slice(-limit) : messages
+
+  // 贴底时自动跟随新消息；用户上滚后不打扰
+  useEffect(() => {
+    if (atBottom.current && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
+  }, [messages, pending])
+
+  const onScroll = () => {
+    const el = boxRef.current
+    if (!el) return
+    atBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    setShowJump(!atBottom.current)
+  }
+
+  const jump = () => {
+    atBottom.current = true; setShowJump(false)
+    if (boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
+  }
+
+  const send = async () => {
+    const text = input.trim()
+    if (!text || sending) return
+    setSending(true); setSendErr('')
+    try { await api('POST', '/tasks/_/send', { sess: name, msg: text }); setInput(''); atBottom.current = true }
+    catch (e: any) { setSendErr(e.message) }
+    finally { setSending(false) }
+  }
+
+  // 中断生成：向会话注入 Escape（Claude / Codex 都按 Esc 打断当前回合）
+  const stop = () => { api('POST', `/sessions/${encodeURIComponent(name)}/keys`, { keys: ['Escape'] }).catch(() => {}) }
+
+  const errMsg = sendErr || error
+
+  return (
+    <div style={{ display: 'flex', height: '100%', background: 'var(--bg-term)' }}>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', position: 'relative' }}
+        onDragEnter={(e) => { e.preventDefault() }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          const isPath = Array.from(e.dataTransfer.types || []).includes('application/x-ttmux-path')
+          e.dataTransfer.dropEffect = 'copy'
+          setDropMode(isPath ? 'path' : 'upload')
+          if (!dragOver) setDragOver(true)
+        }}
+        onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOver(false) }}
+        onDrop={(e) => {
+          e.preventDefault(); setDragOver(false)
+          const p = e.dataTransfer.getData('application/x-ttmux-path') || e.dataTransfer.getData('text/plain')
+          if (p && !e.dataTransfer.files?.length) { insertPath(p); return } // 从文件侧栏拖来的：插入路径
+          if (e.dataTransfer?.files?.length) doUpload(e.dataTransfer.files) // 从系统拖来的：上传
+        }}>
+        {dragOver && (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 30, pointerEvents: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.45)', border: `2px dashed ${accent}`, borderRadius: 12, color: accent, fontSize: 15, fontWeight: 600 }}>
+            {dropMode === 'path' ? '📄 松开插入文件路径' : '📎 松开上传到工作目录'}
+          </div>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: '1px solid var(--border)' }}>
+          {title}
+          <span style={{ color: 'var(--text-dim)', fontSize: 12 }}>{name}</span>
+          <span style={{ flex: 1 }} />
+          <Button size="small" type={showFiles ? 'primary' : 'default'} style={showFiles ? { background: accent, borderColor: accent } : {}} onClick={() => setShowFiles((s) => !s)}>📁 文件</Button>
+          <Button size="small" onClick={onBack}>切回终端 ▸</Button>
+        </div>
+        <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex' }}>
+          <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '8px 12px' }}>
+            {messages.length === 0 && !pending && <div style={{ color: 'var(--text-dim)', textAlign: 'center', marginTop: 30 }}>加载对话记录…</div>}
+            {hidden > 0 && (
+              <div style={{ textAlign: 'center', margin: '2px 0 8px' }}>
+                <a onClick={() => setLimit((l) => l + 200)} style={{ color: 'var(--text-dim)', fontSize: 12 }}>⤒ 加载更早 {hidden} 条</a>
+              </div>
+            )}
+            {visible.map(renderMessage)}
+            {pending}
+            {busy && <LiveTail name={name} />}
+          </div>
+          {showJump && (
+            <button onClick={jump} title="回到底部"
+              style={{ position: 'absolute', right: 14, bottom: 12, width: 34, height: 34, borderRadius: '50%', border: '1px solid var(--border)', background: 'var(--bg-container)', color: accent, fontSize: 16, cursor: 'pointer', boxShadow: 'var(--card-hover-shadow)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              ↓
+            </button>
+          )}
+        </div>
+        {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
+        <PromptPanel name={name} accent={accent} />
+        {errMsg && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{errMsg}</div>}
+        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end' }}>
+          <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
+            onChange={(e) => { if (e.target.files?.length) doUpload(e.target.files); e.target.value = '' }} />
+          <Button title="上传文件到工作目录" loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>
+          <Input.TextArea
+            value={input} onChange={(e) => setInput(e.target.value)}
+            autoSize={{ minRows: 1, maxRows: 5 }} placeholder={placeholder}
+            onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
+          />
+          {busy && <Button danger title="发送 Esc 打断当前生成" onClick={stop}>■ 停止</Button>}
+          <Button type="primary" loading={sending} onClick={send} style={{ background: accent, borderColor: accent }}>发送</Button>
+        </div>
+      </div>
+      {showFiles && (
+        <div style={{ flex: '0 0 clamp(200px, 32%, 300px)', minWidth: 0 }}>
+          <FileBrowser dir={dir} accent={accent} onClose={() => setShowFiles(false)} onInsertPath={insertPath} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// 把终端实况(capture)清洗成「干净的实时回复」：去掉方框线、底部输入框/提示、spinner 行，
+// 只留正在生成的正文尾部。启发式、随 TUI 版本可能要微调，但作为实时预览足够。
+const LEAD_BOX = /^[\s│┃|╎┆┊╭╰├╞┝─━═>❯]+/u
+const TAIL_BOX = /[\s│┃|╎┆┊╮╯┤╡┥─━═]+$/u
+const BOX_ONLY = /^[\s─━═│┃╭╮╰╯├┤┬┴┼╞╡╪.·]*$/u
+const NOISE = /(esc to interrupt|esc to cancel|enter to select|tab\/arrow|to navigate|\? for shortcuts|ctrl\+|shift\+tab|bypass permissions|↑↓|tokens?\b|⧉|auto-?accept|for newline)/i
+const SPINNER = /^[\s]*[●○◯⏺✶✳✻∗*•·✢✦✧✺✷+✽][\s]*$/u
+
+function cleanTail(raw: string): string {
+  const out: string[] = []
+  for (let l of String(raw).replace(/\r/g, '').split('\n')) {
+    l = l.replace(LEAD_BOX, '').replace(TAIL_BOX, '').replace(/^[●○◯⏺✶✳✻∗•·]\s?/u, '')
+    if (!l.trim() || BOX_ONLY.test(l) || SPINNER.test(l) || NOISE.test(l)) continue
+    out.push(l)
+  }
+  return out.slice(-10).join('\n')
+}
+
+function LiveTail({ name }: { name: string }) {
+  const [text, setText] = useState('')
+  useEffect(() => {
+    let stop = false
+    const poll = async () => {
+      try {
+        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/capture?lines=40`)
+        const raw = r.data || ''
+        // 交互式选择框交给 PromptPanel 专门渲染，这里不再重复显示（避免被截断/错乱）
+        if (!stop) setText(detectPrompt(raw) ? '' : cleanTail(raw))
+      } catch {}
+    }
+    poll()
+    const t = setInterval(poll, 800)
+    return () => { stop = true; clearInterval(t) }
+  }, [name])
+  if (!text) return null
+  return (
+    <div style={{ margin: '4px 0', border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-base)', overflow: 'hidden' }}>
+      <div style={{ fontSize: 11, color: 'var(--text-dim)', padding: '4px 8px', display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span className="cc-pulse" style={{ width: 6, height: 6, borderRadius: '50%', background: '#3fb950', display: 'inline-block' }} />
+        实时输出（终端）
+      </div>
+      <pre style={{ margin: 0, padding: '0 8px 8px', maxHeight: 160, overflow: 'auto', fontFamily: 'ui-monospace, monospace', fontSize: 11.5, lineHeight: 1.45, color: 'var(--text-dim)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{text}</pre>
+    </div>
+  )
+}

--- a/frontend/src/chat/ClaudeMessage.tsx
+++ b/frontend/src/chat/ClaudeMessage.tsx
@@ -1,0 +1,106 @@
+// Claude 工具调用 + 气泡渲染。工具按类型富展示（命令/写入/diff/待办…），
+// 工具结果按 tool_use_id 折叠在对应调用之下。
+import { memo, useState } from 'react'
+import Markdown from '../Markdown'
+import { CodeBox, Collapsible, Diff, MONO, fmtTs, ToolResult } from './blocks'
+import type { Block, Msg } from './types'
+
+function parseInput(input?: string): any {
+  if (!input) return null
+  try { return JSON.parse(input) } catch { return null }
+}
+
+// 工具名 → 图标 + 单行标题（取最有信息量的字段）
+function toolHead(name?: string, o?: any): { icon: string; title: string } {
+  const n = name || '工具'
+  const s = (v: any) => (v == null ? '' : String(v))
+  const clip = (v: string) => (v.length > 140 ? v.slice(0, 140) + '…' : v)
+  switch (n) {
+    case 'Bash': return { icon: '$', title: clip(s(o?.command)) }
+    case 'Read': return { icon: '📖', title: clip(s(o?.file_path)) }
+    case 'Write': return { icon: '✏️', title: clip(s(o?.file_path)) }
+    case 'Edit': case 'MultiEdit': return { icon: '✏️', title: clip(s(o?.file_path)) }
+    case 'NotebookEdit': return { icon: '📓', title: clip(s(o?.notebook_path)) }
+    case 'Glob': return { icon: '🔍', title: clip(s(o?.pattern) + (o?.path ? `  @ ${o.path}` : '')) }
+    case 'Grep': return { icon: '🔍', title: clip(s(o?.pattern) + (o?.path ? `  @ ${o.path}` : '')) }
+    case 'Task': return { icon: '🤖', title: clip(s(o?.description || o?.subagent_type)) }
+    case 'TodoWrite': return { icon: '☑', title: `${(o?.todos || []).length} 项待办` }
+    case 'WebFetch': return { icon: '🌐', title: clip(s(o?.url)) }
+    case 'WebSearch': return { icon: '🌐', title: clip(s(o?.query)) }
+    default: {
+      const key = o && ['command', 'file_path', 'path', 'pattern', 'query', 'prompt', 'description'].find((k) => o[k])
+      return { icon: '⚙', title: clip(key ? s(o[key]) : (o ? JSON.stringify(o) : '')) }
+    }
+  }
+}
+
+// 工具调用的「详情体」：按工具类型展开有用信息
+function ToolBody({ name, o, raw }: { name?: string; o: any; raw?: string }) {
+  if (name === 'Bash') return <CodeBox text={o?.command || ''} />
+  if (name === 'Write') return <CodeBox text={o?.content || ''} max={420} />
+  if (name === 'Edit') {
+    const minus = (o?.old_string || '').split('\n').map((l: string) => '- ' + l).join('\n')
+    const plus = (o?.new_string || '').split('\n').map((l: string) => '+ ' + l).join('\n')
+    return <div style={{ marginTop: 6 }}><Diff text={minus + (plus ? '\n' + plus : '')} /></div>
+  }
+  if (name === 'MultiEdit' && Array.isArray(o?.edits)) {
+    return <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 6 }}>{o.edits.map((e: any, i: number) => <ToolBody key={i} name="Edit" o={e} />)}</div>
+  }
+  if (name === 'TodoWrite' && Array.isArray(o?.todos)) {
+    const mark: Record<string, string> = { completed: '✅', in_progress: '🔄', pending: '⬜' }
+    return (
+      <div style={{ marginTop: 6, fontSize: 12.5, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {o.todos.map((t: any, i: number) => (
+          <div key={i} style={{ color: t.status === 'completed' ? 'var(--text-dim)' : 'var(--text-bright)', textDecoration: t.status === 'completed' ? 'line-through' : 'none' }}>
+            {mark[t.status] || '⬜'} {t.content}
+          </div>
+        ))}
+      </div>
+    )
+  }
+  if (name === 'Task') return <CodeBox text={o?.prompt || ''} max={260} />
+  if (name === 'WebFetch') return <CodeBox text={o?.prompt || o?.url || ''} max={160} />
+  const pretty = o ? JSON.stringify(o, null, 2) : (raw || '')
+  return pretty ? <CodeBox text={pretty} /> : null
+}
+
+function ToolUse({ b, result }: { b: Block; result?: Block }) {
+  const o = parseInput(b.input)
+  const { icon, title } = toolHead(b.name, o)
+  const [open, setOpen] = useState(false)
+  const hasBody = !!(o || b.input)
+  return (
+    <div style={{ border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-base)', padding: '6px 10px', fontSize: 12.5 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, cursor: hasBody ? 'pointer' : 'default' }} onClick={() => hasBody && setOpen((v) => !v)}>
+        <span style={{ color: '#d2a8ff', fontWeight: 600, flex: '0 0 auto' }}>{icon} {b.name}</span>
+        {title && <span style={{ color: 'var(--text-dim)', fontFamily: MONO, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{title}</span>}
+        {hasBody && <span style={{ marginLeft: 'auto', color: 'var(--text-dimmer)', flex: '0 0 auto' }}>{open ? '▾' : '▸'}</span>}
+      </div>
+      {open && <ToolBody name={b.name} o={o} raw={b.input} />}
+      {result && <ToolResult result={result} />}
+    </div>
+  )
+}
+
+export const ClaudeBubble = memo(function ClaudeBubble({ m, results }: { m: Msg; results: Record<string, Block> }) {
+  const isUser = m.role === 'user'
+  const isTool = m.role === 'tool'
+  const align = isUser ? 'flex-end' : 'flex-start'
+  const bg = isUser ? '#1f6feb' : isTool ? 'transparent' : 'var(--bg-container)'
+  const border = isUser || isTool ? 'none' : '1px solid var(--border)'
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: align, margin: '6px 0', gap: 2 }}>
+      <div style={{ maxWidth: isUser ? '86%' : '100%', width: isUser ? 'auto' : '100%', background: bg, border, borderRadius: 12, padding: isTool ? 0 : '8px 12px', color: isUser ? '#fff' : 'var(--text-bright)', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {m.blocks.map((b, i) => {
+          if (b.kind === 'text') return <Markdown key={i} accent={isUser ? '#cfe1ff' : '#58a6ff'}>{b.text || ''}</Markdown>
+          if (b.kind === 'thinking') return <Collapsible key={i} label="思考过程" text={b.text} color="var(--text-dim)" />
+          if (b.kind === 'tool_use') return <ToolUse key={i} b={b} result={b.id ? results[b.id] : undefined} />
+          if (b.kind === 'tool_result') return <Collapsible key={i} label={b.isError ? '⚠ 工具输出（错误）' : '工具输出'} text={b.text} color={b.isError ? '#f85149' : 'var(--text-dim)'} />
+          if (b.text) return <Markdown key={i} accent="#58a6ff">{b.text}</Markdown>
+          return null
+        })}
+      </div>
+      {m.ts && !isTool && <span style={{ fontSize: 10, color: 'var(--text-dimmer)', padding: '0 4px' }}>{fmtTs(m.ts)}</span>}
+    </div>
+  )
+})

--- a/frontend/src/chat/CodexMessage.tsx
+++ b/frontend/src/chat/CodexMessage.tsx
@@ -1,0 +1,74 @@
+// Codex 工具调用 + 气泡渲染：
+//   shell/exec_command → 终端命令卡片；apply_patch → 彩色 diff；reasoning → 折叠「推理」。
+import { memo } from 'react'
+import Markdown from '../Markdown'
+import { Collapsible, Diff, MONO, fmtTs, ToolResult } from './blocks'
+import type { Block, Msg } from './types'
+
+export const CODEX_ACCENT = '#10a37f' // OpenAI 绿
+
+function extractCmd(input?: string): string | null {
+  if (!input) return null
+  try {
+    const o = JSON.parse(input)
+    return o.cmd || o.command || (Array.isArray(o.argv) ? o.argv.join(' ') : null)
+  } catch { return null }
+}
+
+function argSummary(input?: string): string {
+  if (!input) return ''
+  try {
+    const o = JSON.parse(input)
+    const key = ['path', 'file_path', 'pattern', 'query', 'cmd', 'command'].find((k) => o[k])
+    const v = key ? String(o[key]) : JSON.stringify(o)
+    return v.length > 140 ? v.slice(0, 140) + '…' : v
+  } catch { return input.slice(0, 140) }
+}
+
+function ToolCard({ b, result }: { b: Block; result?: Block }) {
+  const cmd = b.name === 'apply_patch' ? null : extractCmd(b.input)
+  return (
+    <div style={{ border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-base)', padding: cmd ? '6px 10px' : '8px 10px', fontSize: 12.5 }}>
+      {b.name === 'apply_patch' ? (
+        <>
+          <div style={{ color: CODEX_ACCENT, fontWeight: 600, fontSize: 12.5, marginBottom: 6 }}>✎ apply_patch</div>
+          {b.input && <Diff text={b.input} />}
+        </>
+      ) : cmd ? (
+        <div style={{ fontFamily: MONO }}>
+          <span style={{ color: CODEX_ACCENT }}>❯</span>{' '}
+          <span style={{ color: 'var(--text-bright)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{cmd}</span>
+        </div>
+      ) : (
+        <div>
+          <span style={{ color: CODEX_ACCENT, fontWeight: 600 }}>⚙ {b.name}</span>
+          {argSummary(b.input) && <span style={{ color: 'var(--text-dim)', marginLeft: 8, fontFamily: MONO }}>{argSummary(b.input)}</span>}
+        </div>
+      )}
+      {result && <ToolResult result={result} />}
+    </div>
+  )
+}
+
+export const CodexBubble = memo(function CodexBubble({ m, results }: { m: Msg; results: Record<string, Block> }) {
+  const isUser = m.role === 'user'
+  const isTool = m.role === 'tool'
+  const align = isUser ? 'flex-end' : 'flex-start'
+  const bg = isUser ? CODEX_ACCENT : isTool ? 'transparent' : 'var(--bg-container)'
+  const border = isUser || isTool ? 'none' : '1px solid var(--border)'
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: align, margin: '6px 0', gap: 2 }}>
+      <div style={{ maxWidth: isUser ? '86%' : '100%', width: isUser ? 'auto' : '100%', background: bg, border, borderRadius: 12, padding: isTool ? 0 : '8px 12px', color: isUser ? '#fff' : 'var(--text-bright)', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {m.blocks.map((b, i) => {
+          if (b.kind === 'text') return <Markdown key={i} accent={isUser ? '#d6fff0' : CODEX_ACCENT}>{b.text || ''}</Markdown>
+          if (b.kind === 'thinking') return <Collapsible key={i} label="推理" text={b.text} color="var(--text-dim)" />
+          if (b.kind === 'tool_use') return <ToolCard key={i} b={b} result={b.id ? results[b.id] : undefined} />
+          if (b.kind === 'tool_result') return <Collapsible key={i} label={b.isError ? '⚠ 输出（出错）' : '输出'} text={b.text} color={b.isError ? '#f85149' : 'var(--text-dim)'} />
+          if (b.text) return <Markdown key={i} accent={CODEX_ACCENT}>{b.text}</Markdown>
+          return null
+        })}
+      </div>
+      {m.ts && !isTool && <span style={{ fontSize: 10, color: 'var(--text-dimmer)', padding: '0 4px' }}>{fmtTs(m.ts)}</span>}
+    </div>
+  )
+})

--- a/frontend/src/chat/blocks.tsx
+++ b/frontend/src/chat/blocks.tsx
@@ -1,0 +1,90 @@
+// 对话渲染共用的小组件：代码框 / 折叠块 / 彩色 diff / 「正在生成」省略号。
+import { useState, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react'
+import type { Block } from './types'
+
+export const MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+
+// 时间戳 → HH:MM（解析失败返回空）
+export function fmtTs(ts?: string): string {
+  if (!ts) return ''
+  const d = new Date(ts)
+  if (isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+// 跨 http（局域网非安全上下文）也能用的复制
+function copyText(s: string) {
+  if (navigator.clipboard && window.isSecureContext) { navigator.clipboard.writeText(s).catch(() => {}); return }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = s; ta.style.position = 'fixed'; ta.style.opacity = '0'
+    document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta)
+  } catch {}
+}
+
+// text 始终用于复制；children(可选)是已高亮的节点，传入时渲染它而非纯文本。
+export function CodeBox({ text, max = 320, className, children }: { text: string; max?: number; className?: string; children?: ReactNode }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = (e: ReactMouseEvent) => { e.stopPropagation(); copyText(text); setCopied(true); setTimeout(() => setCopied(false), 1200) }
+  return (
+    <div style={{ position: 'relative' }} className="cc-codebox">
+      <button onClick={onCopy} title="复制" className="cc-copy"
+        style={{ position: 'absolute', top: 6, right: 6, zIndex: 1, border: '1px solid var(--border)', background: 'var(--bg-container)', color: copied ? '#3fb950' : 'var(--text-dim)', borderRadius: 6, fontSize: 11, lineHeight: 1, padding: '3px 7px', cursor: 'pointer' }}>
+        {copied ? '✓ 已复制' : '复制'}
+      </button>
+      <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '6px 0 0', maxHeight: max, overflow: 'auto', background: 'var(--bg-base)', padding: 8, borderRadius: 6, fontFamily: MONO, fontSize: 12, lineHeight: 1.5, color: 'var(--text-bright)' }}>
+        <code className={className}>{children ?? text}</code>
+      </pre>
+    </div>
+  )
+}
+
+// 工具调用的输出（折叠；出错默认展开）。Claude / Codex 共用。
+export function ToolResult({ result }: { result: Block }) {
+  const [open, setOpen] = useState(!!result.isError)
+  return (
+    <div style={{ marginTop: 6, borderTop: '1px dashed var(--border)', paddingTop: 4 }}>
+      <a onClick={() => setOpen((v) => !v)} style={{ color: result.isError ? '#f85149' : 'var(--text-dim)', fontSize: 12 }}>
+        {open ? '▾' : '▸'} {result.isError ? '⚠ 输出（错误）' : '输出'}
+      </a>
+      {open && <CodeBox text={result.text || '(空)'} />}
+    </div>
+  )
+}
+
+export function Collapsible({ label, text, color, open: dflt = false }: { label: string; text?: string; color: string; open?: boolean }) {
+  const [open, setOpen] = useState(dflt)
+  if (!text) return null
+  return (
+    <div style={{ fontSize: 12 }}>
+      <a onClick={() => setOpen((o) => !o)} style={{ color }}>{open ? '▾' : '▸'} {label}</a>
+      {open && <CodeBox text={text} />}
+    </div>
+  )
+}
+
+// 彩色 diff：+ 绿 / - 红 / @@,*** 紫。既能渲染补丁文本，也能渲染手动拼的 +/- 行。
+export function Diff({ text, max = 360 }: { text: string; max?: number }) {
+  return (
+    <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: max, overflow: 'auto', fontFamily: MONO, fontSize: 12, lineHeight: 1.45 }}>
+      {text.split('\n').map((l, i) => {
+        let color = 'var(--text-bright)'
+        if (l.startsWith('+') && !l.startsWith('+++')) color = '#3fb950'
+        else if (l.startsWith('-') && !l.startsWith('---')) color = '#f85149'
+        else if (l.startsWith('@@') || l.startsWith('***')) color = '#d2a8ff'
+        return <div key={i} style={{ color }}>{l || ' '}</div>
+      })}
+    </pre>
+  )
+}
+
+export function Typing({ color = '#d2a8ff' }: { color?: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start', margin: '6px 0' }}>
+      <div style={{ background: 'var(--bg-container)', border: '1px solid var(--border)', borderRadius: 12, padding: '8px 14px', color: 'var(--text-dim)', fontSize: 13, display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+        <span>正在生成</span>
+        <span className="cc-dots" style={{ ['--cc-dot' as any]: color }}><i /><i /><i /></span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/chat/types.ts
+++ b/frontend/src/chat/types.ts
@@ -1,0 +1,11 @@
+// 对话内容块 —— 遵循 Anthropic 标准块类型；Codex 转录也归一到同一形状。
+export interface Block {
+  kind: string          // text | thinking | tool_use | tool_result
+  text?: string
+  name?: string         // tool_use 工具名
+  input?: string        // tool_use 入参(JSON 字符串)
+  id?: string           // tool_use 的 id
+  toolUseId?: string    // tool_result 对应的 tool_use id
+  isError?: boolean
+}
+export interface Msg { role: string; blocks: Block[]; ts?: string; id?: string }

--- a/frontend/src/chat/useTranscript.ts
+++ b/frontend/src/chat/useTranscript.ts
@@ -1,0 +1,57 @@
+// 轮询会话转录(JSONL)，按物理行 offset 增量拉取，自动归一为 Msg[]。
+// Claude 与 Codex 共用，只是 path 不同(transcript / codex-transcript)。
+import { useEffect, useState } from 'react'
+import { api } from '../api'
+import type { Block, Msg } from './types'
+
+export function useTranscript(name: string, file: string | undefined, path: string, interval = 1500) {
+  const [msgs, setMsgs] = useState<Msg[]>([])
+  const [err, setErr] = useState('')
+  useEffect(() => {
+    let stop = false
+    let offset = 0
+    let f = file
+    setMsgs([]); setErr('')
+    const poll = async () => {
+      try {
+        const q = new URLSearchParams({ offset: String(offset) })
+        if (f) q.set('file', f)
+        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/${path}?${q.toString()}`)
+        const d = r.data
+        if (stop) return
+        if (d.file) f = d.file
+        if (d.messages?.length) { setMsgs((m) => [...m, ...d.messages]); offset = d.nextOffset }
+        else if (typeof d.nextOffset === 'number') offset = d.nextOffset
+      } catch (e: any) { if (!stop) setErr(e.message) }
+    }
+    poll()
+    const t = setInterval(poll, interval)
+    return () => { stop = true; clearInterval(t) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [name])
+  return { msgs, err }
+}
+
+// 把 tool_result 按 tool_use_id 挂回对应 tool_use，并从消息流里隐去已收纳的独立结果气泡。
+// Claude、Codex 共用（两端后端都已透出 id / toolUseId）。
+export function pairToolResults(msgs: Msg[]): { results: Record<string, Block>; view: Msg[] } {
+  const results: Record<string, Block> = {}
+  for (const m of msgs) for (const b of m.blocks) if (b.kind === 'tool_result' && b.toolUseId) results[b.toolUseId] = b
+  const consumed = new Set<string>()
+  for (const m of msgs) for (const b of m.blocks) if (b.kind === 'tool_use' && b.id && results[b.id]) consumed.add(b.id)
+  const view = msgs.map((m) => {
+    if (m.role !== 'tool') return m
+    const blocks = m.blocks.filter((b) => !(b.kind === 'tool_result' && b.toolUseId && consumed.has(b.toolUseId)))
+    return { ...m, blocks }
+  }).filter((m) => m.blocks.length > 0)
+  return { results, view }
+}
+
+// 「正在生成」判定：最后一轮还没轮到 assistant 收尾(用户刚发 / 工具刚返回 / 正调用工具)。
+export function isPending(view: Msg[]): boolean {
+  const last = view[view.length - 1]
+  if (!last) return false
+  if (last.role === 'user' || last.role === 'tool') return true
+  if (last.role === 'assistant') return last.blocks[last.blocks.length - 1]?.kind === 'tool_use'
+  return false
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,29 +1,90 @@
 /* 全局基调 · 精致克制
    目标：细边框、舒展留白、克制的交互反馈、精修排版（近 Linear/Vercel 的高级感）。
-   只调"基调"，不逐页堆样式；页面组件继承这里的观感即可。 */
+   只调"基调"，不逐页堆样式；页面组件继承这里的观感即可。
+   黑/白主题：所有结构色走 CSS 变量，<html data-theme="light"> 时整体翻白。
+   终端画布的颜色由 Terminal.tsx 读取同名变量并随主题切换。 */
 
-:root { color-scheme: dark; }
+/* ── 深色（默认）── */
+:root {
+  color-scheme: dark;
+  --bg-base: #0d1117;
+  --bg-container: #161b22;
+  --bg-elevated: #1b222b;
+  --bg-term: #06090d;
+  --border: #30363d;
+  --border-subtle: #21262d;
+  --text-bright: #e6edf3;
+  --text-dim: #8b949e;
+  --text-dimmer: #6e7681;
+  --brand-grad: linear-gradient(180deg, #f5f7fa 0%, #c3c9d1 46%, #9aa1ab 56%, #e7ebef 100%);
+  --list-hover: rgba(255, 255, 255, .025);
+  --scroll-thumb: #2a313a;
+  --scroll-thumb-hover: #3d444d;
+  --card-hover-shadow: 0 8px 24px rgba(1, 4, 9, .5);
+  --elevated-shadow: 0 16px 48px rgba(1, 4, 9, .55);
+  --xterm-bg: #06090d;
+  --xterm-fg: #e6edf3;
+  /* highlight.js token 配色（深色，GitHub-ish） */
+  --hl-comment: #8b949e;
+  --hl-keyword: #ff7b72;
+  --hl-string: #a5d6ff;
+  --hl-number: #79c0ff;
+  --hl-title: #d2a8ff;
+  --hl-attr: #7ee787;
+  --hl-built: #ffa657;
+}
+
+/* ── 浅色 ── */
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg-base: #f6f8fa;
+  --bg-container: #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-term: #ffffff;
+  --border: #d0d7de;
+  --border-subtle: #e6e9ec;
+  --text-bright: #1f2328;
+  --text-dim: #57606a;
+  --text-dimmer: #8c959f;
+  --brand-grad: linear-gradient(180deg, #2c333b 0%, #1f2328 100%);
+  --list-hover: rgba(27, 31, 36, .04);
+  --scroll-thumb: #c9d1d9;
+  --scroll-thumb-hover: #aab1b9;
+  --card-hover-shadow: 0 8px 24px rgba(140, 149, 159, .18);
+  --elevated-shadow: 0 16px 48px rgba(140, 149, 159, .22);
+  --xterm-bg: #ffffff;
+  --xterm-fg: #1f2328;
+  /* highlight.js token 配色（浅色） */
+  --hl-comment: #6e7781;
+  --hl-keyword: #cf222e;
+  --hl-string: #0a3069;
+  --hl-number: #0550ae;
+  --hl-title: #8250df;
+  --hl-attr: #116329;
+  --hl-built: #953800;
+}
 
 html, body, #root { height: 100%; margin: 0; }
 body {
-  background: #0d1117;
+  background: var(--bg-base);
   /* 精修字体栈：优先界面无衬线 + 中文黑体；数字等宽对齐更整齐 */
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
     'Hiragino Sans GB', 'Microsoft YaHei', Roboto, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  transition: background-color .2s ease;
 }
 
-/* ── 细滚动条：更窄、更暗，hover 才稍亮（覆盖 index.html 的基础版） ── */
-* { scrollbar-width: thin; scrollbar-color: #2a313a transparent; }
+/* ── 细滚动条：更窄，hover 才稍亮 ── */
+* { scrollbar-width: thin; scrollbar-color: var(--scroll-thumb) transparent; }
 *::-webkit-scrollbar { width: 9px; height: 9px; }
 *::-webkit-scrollbar-track { background: transparent; }
 *::-webkit-scrollbar-thumb {
-  background: #2a313a; border-radius: 8px;
+  background: var(--scroll-thumb); border-radius: 8px;
   border: 2px solid transparent; background-clip: content-box;
 }
-*::-webkit-scrollbar-thumb:hover { background: #3d444d; background-clip: content-box; }
+*::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); background-clip: content-box; }
 *::-webkit-scrollbar-corner { background: transparent; }
 
 /* 选区色：主色低透明，克制 */
@@ -37,20 +98,20 @@ body {
 }
 
 /* ── 卡片：细边框 + 克制悬浮（边框微亮 + 极轻阴影，不位移） ── */
-.ant-card { border-color: #21262d; }
-.ant-card-bordered { border-color: #21262d; }
+.ant-card { border-color: var(--border-subtle); }
+.ant-card-bordered { border-color: var(--border-subtle); }
 .ant-card-hoverable:hover {
-  border-color: #30363d;
-  box-shadow: 0 8px 24px rgba(1, 4, 9, .5);
+  border-color: var(--border);
+  box-shadow: var(--card-hover-shadow);
   transform: translateY(-1px);
 }
-.ant-card-head { border-block-end-color: #21262d; min-height: 46px; }
+.ant-card-head { border-block-end-color: var(--border-subtle); min-height: 46px; }
 .ant-card-head-title { font-weight: 600; letter-spacing: .2px; }
 
 /* ── 列表：行距舒展、分隔线更淡、hover 轻微提亮并圆角 ── */
-.ant-list-split .ant-list-item { border-block-end-color: #1c2128; }
+.ant-list-split .ant-list-item { border-block-end-color: var(--border-subtle); }
 .ant-list-item { border-radius: 8px; padding-inline: 8px; }
-.ant-list-item:hover { background: rgba(255, 255, 255, .025); }
+.ant-list-item:hover { background: var(--list-hover); }
 
 /* ── 输入框：聚焦细发光，克制 ── */
 .ant-input:focus, .ant-input-focused,
@@ -69,5 +130,39 @@ body {
 
 /* 弹层：与页面拉开一点层次（配合 colorBgElevated） */
 .ant-modal-content, .ant-dropdown-menu, .ant-popover-inner, .ant-select-dropdown {
-  box-shadow: 0 16px 48px rgba(1, 4, 9, .55) !important;
+  box-shadow: var(--elevated-shadow) !important;
 }
+
+/* ── Claude 对话「正在生成」省略号 ── */
+.cc-dots { display: inline-flex; gap: 3px; }
+.cc-dots i {
+  width: 5px; height: 5px; border-radius: 50%; background: var(--cc-dot, #d2a8ff);
+  animation: cc-blink 1.2s infinite both;
+}
+.cc-dots i:nth-child(2) { animation-delay: .2s; }
+.cc-dots i:nth-child(3) { animation-delay: .4s; }
+@keyframes cc-blink { 0%, 80%, 100% { opacity: .25; } 40% { opacity: 1; } }
+.cc-pulse { animation: cc-blink 1.2s infinite both; }
+
+/* 文件行下载按钮：hover 行时浮现 */
+.cc-dl { opacity: 0; transition: opacity .15s ease; }
+.cc-filerow:hover .cc-dl, .cc-dl:focus { opacity: 1; }
+@media (pointer: coarse) { .cc-dl { opacity: .6; } }
+
+/* 代码框复制按钮：默认淡出，hover 代码框时浮现 */
+.cc-copy { opacity: 0; transition: opacity .15s ease; }
+.cc-codebox:hover .cc-copy, .cc-copy:focus { opacity: 1; }
+@media (pointer: coarse) { .cc-copy { opacity: .6; } }
+
+/* ── 语法高亮（highlight.js 类 → 主题变量；不引外部 CSS，随黑白主题切换） ── */
+.hljs { color: var(--text-bright); background: transparent; }
+.hljs-comment, .hljs-quote { color: var(--hl-comment); font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-section, .hljs-doctag { color: var(--hl-keyword); }
+.hljs-string, .hljs-template-string, .hljs-addition, .hljs-meta-string { color: var(--hl-string); }
+.hljs-number, .hljs-params, .hljs-type, .hljs-selector-attr, .hljs-selector-pseudo { color: var(--hl-number); }
+.hljs-title, .hljs-name, .hljs-selector-id, .hljs-selector-class { color: var(--hl-title); }
+.hljs-attr, .hljs-attribute, .hljs-variable, .hljs-template-variable { color: var(--hl-attr); }
+.hljs-built_in, .hljs-builtin-name, .hljs-symbol, .hljs-bullet, .hljs-link, .hljs-meta, .hljs-regexp { color: var(--hl-built); }
+.hljs-deletion { color: #f85149; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 600; }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,62 +1,17 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { ConfigProvider, theme, App as AntApp } from 'antd'
-import zhCN from 'antd/locale/zh_CN'
+import { App as AntApp } from 'antd'
 import App from './App'
+import { ThemeProvider } from './theme'
 import './index.css'
 
+// 主题(黑/白)统一收敛到 ThemeProvider：它内部按 mode 渲染 ConfigProvider + 写 data-theme。
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ConfigProvider
-      locale={zhCN}
-      theme={{
-        algorithm: theme.darkAlgorithm,
-        token: {
-          colorPrimary: '#58a6ff',
-          // 圆角分级：小控件收一点、卡片/弹层更柔
-          borderRadius: 8,
-          borderRadiusLG: 12,
-          borderRadiusSM: 6,
-          // 精修字体栈（与 index.css 一致）+ 略松行高，排版更透气
-          fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', Roboto, Helvetica, Arial, sans-serif",
-          fontSize: 14,
-          lineHeight: 1.6,
-          // 统一深黑主题
-          colorBgBase: '#0d1117',
-          colorBgContainer: '#161b22',
-          colorBgElevated: '#1b222b', // 弹层/模态略提亮，拉开层次
-          colorBgLayout: '#0d1117',
-          colorBorder: '#2a313a',     // 主边框收敛，少一分生硬
-          colorBorderSecondary: '#21262d',
-          boxShadowSecondary: '0 8px 24px rgba(1,4,9,0.5)',
-          wireframe: false,
-        },
-        components: {
-          Layout: { siderBg: '#0d1117', headerBg: '#161b22', bodyBg: '#0d1117' },
-          Menu: {
-            darkItemBg: 'transparent',
-            darkItemSelectedBg: 'rgba(88,166,255,0.16)',
-            darkItemSelectedColor: '#58a6ff',
-            darkItemHoverBg: 'rgba(255,255,255,0.04)',
-            itemBorderRadius: 8,
-            itemHeight: 42,
-            itemMarginInline: 8,
-          },
-          // 卡片：标题更稳、内距更舒展
-          Card: { borderRadiusLG: 12, paddingLG: 18, headerFontSize: 15 },
-          // 按钮：去掉默认投影更干净，字重略加
-          Button: { fontWeight: 500, primaryShadow: 'none', defaultShadow: 'none', dangerShadow: 'none' },
-          Modal: { borderRadiusLG: 14, contentBg: '#161b22', headerBg: 'transparent' },
-          // 分段控件选中态用主色，醒目克制
-          Segmented: { borderRadius: 8, itemSelectedBg: '#1f6feb', itemSelectedColor: '#fff' },
-          Tag: { borderRadiusSM: 6 },
-          Tooltip: { borderRadius: 8 },
-        },
-      }}
-    >
+    <ThemeProvider>
       <AntApp>
         <App />
       </AntApp>
-    </ConfigProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/prompt.tsx
+++ b/frontend/src/prompt.tsx
@@ -10,10 +10,10 @@ import { api } from './api'
 export interface Choice { num: number; label: string; selected: boolean }
 export interface Prompt { kind: 'select' | 'yesno'; question: string; choices: Choice[] }
 
-const CURSOR = /[❯➤▶►▸→›»☞◉●]/u                       // 选中游标常见字形
+const CURSOR = /[❯➤▶►▸→›»☞◉●>]/u                      // 选中游标常见字形（含 ASCII >）
 const LEAD = /^[\s│┃|╎┆┊╭╰├╞┝─━═]+/u                  // 行首方框线/竖线/空白
 const TAIL = /[\s│┃|╎┆┊╮╯┤╡┥─━═]+$/u                  // 行尾同上
-const OPT = /^(?:[❯➤▶►▸→›»☞◉●]\s*)?(\d+)[.)]\s+(\S.*)$/u // [游标?] N. 文本
+const OPT = /^(?:[❯➤▶►▸→›»☞◉●>]\s*)?(\d+)[.)]\s+(\S.*)$/u // [游标?] N. 文本
 const KW = /(proceed|allow|continue|overwrite|apply|approve|trust|run|是否|确认|继续|允许|要不要|执行)/i
 const clean = (s: string) => s.replace(LEAD, '').replace(TAIL, '')
 
@@ -90,20 +90,32 @@ export function PromptPanel({ name, accent }: { name: string; accent: string }) 
     setTimeout(async () => { setP(await fetchPrompt(name)) }, 350)
   }
 
+  // 点选某项：从当前游标用方向键移动到目标项再回车确认。
+  // 比直接发数字键更可靠——纯方向键菜单（无数字热键）也能点选。
+  const choose = (target: Choice) => {
+    const cur = Math.max(0, p!.choices.findIndex((c) => c.selected))
+    const tgt = p!.choices.findIndex((c) => c.num === target.num)
+    if (tgt < 0) return
+    const delta = tgt - cur
+    const keys = Array(Math.abs(delta)).fill(delta > 0 ? 'Down' : 'Up')
+    keys.push('Enter')
+    press(keys)
+  }
+
   return (
-    <div style={{ borderTop: `1px solid ${accent}55`, background: '#0d1117', padding: '10px 12px' }}>
+    <div style={{ borderTop: `1px solid ${accent}55`, background: 'var(--bg-base)', padding: '10px 12px' }}>
       <div style={{ color: accent, fontSize: 12, fontWeight: 600, marginBottom: 8 }}>● 需要你确认</div>
-      {p.question && <div style={{ color: '#e6edf3', fontSize: 13, marginBottom: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{p.question}</div>}
+      {p.question && <div style={{ color: 'var(--text-bright)', fontSize: 13, marginBottom: 8, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{p.question}</div>}
       {p.kind === 'select' ? (
         <Space direction="vertical" style={{ width: '100%' }} size={6}>
           {p.choices.map((ch) => (
-            <Button key={ch.num} block disabled={busy} onClick={() => press([String(ch.num)])}
+            <Button key={ch.num} block disabled={busy} onClick={() => choose(ch)}
               style={{
                 textAlign: 'left', height: 'auto', minHeight: 32, whiteSpace: 'normal', padding: '6px 10px',
-                borderColor: ch.selected ? accent : '#30363d', color: '#e6edf3',
+                borderColor: ch.selected ? accent : 'var(--border)', color: 'var(--text-bright)',
                 background: ch.selected ? accent + '22' : 'transparent',
               }}>
-              <b style={{ color: accent, marginRight: 6 }}>{ch.num}.</b>{ch.label}
+              <b style={{ color: accent, marginRight: 6 }}>{ch.selected ? '❯' : ''}{ch.num}.</b>{ch.label}
             </Button>
           ))}
         </Space>

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,0 +1,73 @@
+// 主题（黑/白）切换：单一 mode 状态，持久化到 localStorage，并把 data-theme 写到 <html>，
+// CSS 变量(index.css)与 Antd 算法(ConfigProvider)据此同步切换。
+// 自定义内联色用 CSS 变量(var(--bg-base) 等)；Antd 派生色需具体值，故这里按 mode 给具体 token。
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { ConfigProvider, theme as antdTheme } from 'antd'
+import zhCN from 'antd/locale/zh_CN'
+
+export type ThemeMode = 'dark' | 'light'
+const KEY = 'ttmux-theme'
+
+const ThemeCtx = createContext<{ mode: ThemeMode; toggle: () => void; setMode: (m: ThemeMode) => void }>({
+  mode: 'dark', toggle: () => {}, setMode: () => {},
+})
+export const useThemeMode = () => useContext(ThemeCtx)
+
+function buildTheme(mode: ThemeMode) {
+  const dark = mode === 'dark'
+  return {
+    algorithm: dark ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+    token: {
+      colorPrimary: '#58a6ff',
+      borderRadius: 8, borderRadiusLG: 12, borderRadiusSM: 6,
+      fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', Roboto, Helvetica, Arial, sans-serif",
+      fontSize: 14, lineHeight: 1.6,
+      colorBgBase: dark ? '#0d1117' : '#f6f8fa',
+      colorBgContainer: dark ? '#161b22' : '#ffffff',
+      colorBgElevated: dark ? '#1b222b' : '#ffffff',
+      colorBgLayout: dark ? '#0d1117' : '#f6f8fa',
+      colorBorder: dark ? '#2a313a' : '#d0d7de',
+      colorBorderSecondary: dark ? '#21262d' : '#e6e9ec',
+      boxShadowSecondary: dark ? '0 8px 24px rgba(1,4,9,0.5)' : '0 8px 24px rgba(140,149,159,0.18)',
+      wireframe: false,
+    },
+    components: {
+      Layout: dark
+        ? { siderBg: '#0d1117', headerBg: '#161b22', bodyBg: '#0d1117' }
+        : { siderBg: '#ffffff', headerBg: '#ffffff', bodyBg: '#f6f8fa' },
+      Menu: dark ? {
+        darkItemBg: 'transparent', darkItemSelectedBg: 'rgba(88,166,255,0.16)',
+        darkItemSelectedColor: '#58a6ff', darkItemHoverBg: 'rgba(255,255,255,0.04)',
+        itemBorderRadius: 8, itemHeight: 42, itemMarginInline: 8,
+      } : {
+        itemBg: 'transparent', itemSelectedBg: 'rgba(31,111,235,0.10)',
+        itemSelectedColor: '#1f6feb', itemHoverBg: 'rgba(31,111,235,0.06)',
+        itemBorderRadius: 8, itemHeight: 42, itemMarginInline: 8,
+      },
+      Card: { borderRadiusLG: 12, paddingLG: 18, headerFontSize: 15 },
+      Button: { fontWeight: 500, primaryShadow: 'none', defaultShadow: 'none', dangerShadow: 'none' },
+      Modal: { borderRadiusLG: 14, contentBg: dark ? '#161b22' : '#ffffff', headerBg: 'transparent' },
+      Segmented: { borderRadius: 8, itemSelectedBg: '#1f6feb', itemSelectedColor: '#fff' },
+      Tag: { borderRadiusSM: 6 },
+      Tooltip: { borderRadius: 8 },
+    },
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    try { const v = localStorage.getItem(KEY); if (v === 'light' || v === 'dark') return v } catch {}
+    return 'dark'
+  })
+  useEffect(() => {
+    try { localStorage.setItem(KEY, mode) } catch {}
+    document.documentElement.dataset.theme = mode
+    document.documentElement.style.colorScheme = mode
+  }, [mode])
+  const toggle = () => setMode((m) => (m === 'dark' ? 'light' : 'dark'))
+  return (
+    <ThemeCtx.Provider value={{ mode, toggle, setMode }}>
+      <ConfigProvider locale={zhCN} theme={buildTheme(mode)}>{children}</ConfigProvider>
+    </ThemeCtx.Provider>
+  )
+}

--- a/start-all.sh
+++ b/start-all.sh
@@ -103,7 +103,8 @@ fi
 
 # ── 3. 编译后端（增量）──────────────────────────────────────────
 BIN=backend/ttmux-web
-if [ ! -f "$BIN" ] || [ "$(find backend -name '*.go' -newer "$BIN" 2>/dev/null | head -1)" ]; then
+# 检测 .go 与 go:embed 的资源(*.tmpl/*.html)变更，避免改模板却跳过编译
+if [ ! -f "$BIN" ] || [ "$(find backend \( -name '*.go' -o -name '*.tmpl' -o -name '*.html' \) -newer "$BIN" 2>/dev/null | head -1)" ]; then
   echo "==> 编译后端..."
   (cd backend && go build -o ttmux-web ./cmd)
 else


### PR DESCRIPTION
## 概述
Web 控制台对话页(Claude / Codex)的全面改造,外加黑白主题、文件上传/下载、多项交互修复。

## 对话页
- 抽出共享 `chat/` 模块(`useTranscript` / `ChatShell` / `blocks` / 消息组件),两个面板收成薄容器
- 工具调用富渲染:Bash / Write / Edit(diff) / TodoWrite 等;`tool_result` 按 `tool_use_id` 折叠回对应调用(双端,后端透出 id/call_id)
- Markdown 语法高亮(`rehype-highlight`,主题变量配色)+ 代码块复制按钮
- 生成中「实时输出」预览(清洗终端 capture)+ 打字指示 + Esc 停止
- 列表窗口化(最近 N 条 + 加载更早)、回到底部、消息时间戳、稳定 key(后端补 uuid/行号)

## 主题
- 新增 `theme.tsx`:黑/白主题切换(持久化),结构色走 CSS 变量,Antd 算法 + xterm 配色随主题切换;新版本自动提示刷新

## 文件能力
- 后端 `POST /upload`(multipart,重名避让)、`/file/raw?dl=1` 下载
- 对话框拖拽:系统文件 → 上传到 cwd;文件侧栏 → 插入路径(@ 引用)
- 文件侧栏:每文件 `@` 插入 / `↓` 下载,头部 `⬆` 上传

## 会话与交互
- 会话列表过滤/搜索、蜂群会话默认隐藏、点击直接进终端
- **发送修复**:改为「字面文本 + 独立回车」分两步注入,修复 Codex 把发送变成换行(已端到端验证)
- 交互选项点选改为方向键导航 + 回车(纯方向键菜单也可点)
- 新建会话目录候选(最近目录)+ DirPicker 快捷候选
- 手机端 主题/全屏/退出 收进「更多」

## 验证
- `go build ./...` 通过、`tsc --noEmit` 通过、`vite build` 通过
- 上传→下载 round-trip、发送提交、路由鉴权均已实测

🤖 Generated with [Claude Code](https://claude.com/claude-code)