### PR TITLE
runtime: 删除已废弃的 bash 桥死代码

### DIFF
--- a/cli/ttmux-cli-go/internal/runtime/runtime.go
+++ b/cli/ttmux-cli-go/internal/runtime/runtime.go
@@ -18,26 +18,21 @@ type Runtime struct {
 	MetaDir    string
 	EnvFile    string
 	TmuxBin    string
-	ShellPath  string
-	Repository string
 	Now        func() time.Time
 }
 
 func New() Runtime {
 	home, _ := os.UserHomeDir()
 	dataDir := envOr("TTMUX_DATA", filepath.Join(home, ".local", "share", "ttmux"))
-	root := discoverRepo()
 	return Runtime{
-		HomeDir:    envOr("TTMUX_HOME", filepath.Join(home, ".ttmux")),
-		DataDir:    dataDir,
-		LogsDir:    filepath.Join(dataDir, "logs"),
-		GroupsDir:  filepath.Join(dataDir, "groups"),
-		MetaDir:    filepath.Join(dataDir, "meta"),
-		EnvFile:    filepath.Join(dataDir, "env"),
-		TmuxBin:    envOrLookup("TMUX_BIN", "tmux"),
-		ShellPath:  envOr("TTMUX_SHELL", filepath.Join(root, "ttmux")),
-		Repository: root,
-		Now:        time.Now,
+		HomeDir:   envOr("TTMUX_HOME", filepath.Join(home, ".ttmux")),
+		DataDir:   dataDir,
+		LogsDir:   filepath.Join(dataDir, "logs"),
+		GroupsDir: filepath.Join(dataDir, "groups"),
+		MetaDir:   filepath.Join(dataDir, "meta"),
+		EnvFile:   filepath.Join(dataDir, "env"),
+		TmuxBin:   envOrLookup("TMUX_BIN", "tmux"),
+		Now:       time.Now,
 	}
 }
 
@@ -51,15 +46,6 @@ func (r Runtime) EnsureDirs() error {
 		}
 	}
 	return nil
-}
-
-func (r Runtime) Shell(args ...string) error {
-	cmd := exec.Command(r.ShellPath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
-	return cmd.Run()
 }
 
 func (r Runtime) Tmux(args ...string) error {
@@ -287,17 +273,4 @@ func envOrLookup(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-func discoverRepo() string {
-	wd, err := os.Getwd()
-	if err != nil {
-		return "."
-	}
-	for dir := wd; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
-		if _, err := os.Stat(filepath.Join(dir, "ttmux")); err == nil {
-			return dir
-		}
-	}
-	return wd
 }


### PR DESCRIPTION
## 背景
项目根的 `./ttmux` 已删除，运行时一律用安装好的 `~/.local/bin/ttmux`（Go）。`Runtime.Shell()`（早期「Go 调旧 bash」的桥）已无任何调用方。

## 改动
删除 `cli/ttmux-cli-go/internal/runtime/runtime.go` 中的死代码：
- `Runtime` 结构体的 `ShellPath`、`Repository` 字段
- `Shell()` 方法
- `discoverRepo()` 函数（向上找 repo 根 `ttmux`）及 `New()` 中对应赋值

行为不变；`go build` + `go vet` 通过，全模块再无相关引用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)