### PR TITLE
fix: start.sh 中文全角括号导致 set -u 变量展开失败

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -153,7 +153,7 @@ elif [ ! -x "$BIN" ]; then
 fi
 
 # ── 启动 ─────────────────────────────────────────────────────────
-echo "==> 启动 ttmux-web  $SCHEME://$BIND  （口令: $TTMUX_WEB_PASSWORD）"
+echo "==> 启动 ttmux-web  $SCHEME://$BIND  （口令: ${TTMUX_WEB_PASSWORD}）"
 [ -n "$LAN" ] && echo "==> 手机/平板（同 WiFi）: $SCHEME://$LAN:$PORT"
 [ "$SCHEME" = https ] && echo "    （自签证书：手机首次访问点「高级 → 继续前往」即可，之后语音/剪贴板可用；如需 http 设 TTMUX_WEB_TLS=0）"
 
@@ -168,5 +168,5 @@ daemon_start "$BIN" -web "$(pwd)/frontend/dist" -addr "$BIND" "$@"
 sleep 1
 pids="$(port_pids)"
 [ -n "${pids// /}" ] && echo "$pids" | tr ' ' '\n' | head -1 > "$PIDFILE"
-echo "==> 已后台守护运行（日志: $LOG）"
+echo "==> 已后台守护运行（日志: ${LOG}）"
 echo "    停止: bash start.sh stop   状态: bash start.sh status   日志: bash start.sh logs"


### PR DESCRIPTION
## 问题

`start.sh` 在 `set -euo pipefail` 下运行时，第 156 行和第 171 行会报 `unbound variable` 错误：

```
start.sh: line 156: TTMUX_WEB_PASSWORD？: unbound variable
start.sh: line 171: LOG？: unbound variable
```

原因是 `$TTMUX_WEB_PASSWORD）` 和 `$LOG）` 中的全角右括号 `）`（U+FF09，3 字节 `ef bc 89`）紧跟在变量名后面，bash 将其视为变量名的一部分，而 `set -u` 要求所有变量必须定义，因此报错。

## 修复

用 `${VAR}` 花括号语法明确界定变量名边界：

```diff
- echo "==> 启动 ttmux-web  $SCHEME://$BIND  （口令: $TTMUX_WEB_PASSWORD）"
+ echo "==> 启动 ttmux-web  $SCHEME://$BIND  （口令: ${TTMUX_WEB_PASSWORD}）"

- echo "==> 已后台守护运行（日志: $LOG）"
+ echo "==> 已后台守护运行（日志: ${LOG}）"
```

## 测试

修复后在 macOS (arm64) 上 `bash start.sh` 正常启动，不再报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)