### PR TITLE
browser: CDP Chrome 全屏(宿主机)/headless 1920x1080

### DIFF
--- a/backend/browser/browser.go
+++ b/backend/browser/browser.go
@@ -84,7 +84,9 @@ func ensureChrome() error {
 		"--force-device-scale-factor=" + envOr("TTMUX_CHROME_SCALE", "2"),
 	}
 	if runtime.GOOS != "darwin" && os.Getenv("DISPLAY") == "" { // 无显示器（服务器）→ 无头，screencast 同样可用
-		args = append(args, "--headless=new", "--window-size=1280,800")
+		args = append(args, "--headless=new", "--window-size="+envOr("TTMUX_CHROME_WINDOW", "1920,1080"))
+	} else if envOr("TTMUX_CHROME_FULLSCREEN", "1") != "0" { // 宿主机有显示器：默认全屏启动，画面铺满宿主屏幕
+		args = append(args, "--start-fullscreen")
 	}
 	args = append(args, "about:blank")
 	cmd := exec.Command(chromeExecutable(), args...)


### PR DESCRIPTION
## 改动
`backend/browser/browser.go` 的 `ensureChrome()` 启动参数：

- **宿主机有显示器(headful)**：默认加 `--start-fullscreen`，Chrome 窗口铺满宿主屏幕。可用 `TTMUX_CHROME_FULLSCREEN=0` 关闭。
- **无显示器(headless)**：初始窗口尺寸 `1280x800` → `1920x1080`。可用 `TTMUX_CHROME_WINDOW` 覆盖（如 `2560,1440`）。

## 说明
- 该尺寸只是 Chrome 的**初始/兜底**窗口尺寸；前端接管后会发 `emulate` 按观看区原生尺寸覆盖视口，所以日常浏览仍自适应。
- 仅对**后端亲手拉起**的 Chrome 生效；若 9222 上已有外部 Chrome，`ensureChrome` 直接附着不重起，需先关掉旧实例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)