### PR TITLE
fix: Codex 检测误报——排除 Claude 启动的 codex mcp-server 子进程

### DIFF
--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -21,10 +21,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// cmdlineHasCodex 判断进程命令行是否是 codex CLI。
+// cmdlineHasCodex 判断进程命令行是否是交互式 codex CLI。
+// 排除 codex-web（ttmux 自身）、mcp-server（Claude Code 会把 codex 当 MCP server 启动）、
+// app-server（Codex 桌面端/VS Code 插件的后台服务）。
 func cmdlineHasCodex(pid int) bool {
 	cl := processCmdline(pid)
-	return strings.Contains(cl, "codex") && !strings.Contains(cl, "codex-web")
+	return strings.Contains(cl, "codex") &&
+		!strings.Contains(cl, "codex-web") &&
+		!strings.Contains(cl, "mcp-server") &&
+		!strings.Contains(cl, "app-server")
 }
 
 func codexSessionsRoot() string {


### PR DESCRIPTION
## Summary
- **Bug**: 只启动了 Claude Code 的 tmux 会话，侧边栏同时显示 Claude 和 Codex 标签
- **Root cause**: `~/.claude.json` 配置了 Codex 作为 MCP server，Claude Code 启动时会 spawn `codex mcp-server` 子进程。旧的 `treeMatch` DFS 遍历整个进程树（深度 12），误命中这个孙进程
- **Fix**: `paneToolDir` 改为只检查 pane PID 及其直接子进程（用户启动的主进程），不递归更深层的内部子服务。移除不再使用的 `treeMatch`

## 进程树
```
zsh (pane PID)           ← depth 0: 检查 ✓
  └── claude             ← depth 1: 检查 ✓（直接子进程 = 用户启动的主进程）
        └── codex mcp-server  ← depth 2+: 不再检查（内部子服务）
```

## Test plan
- [ ] 配置了 Codex MCP server 的环境，只启动 Claude Code，确认侧边栏仅显示 Claude 标签
- [ ] 同时启动 Claude 和 Codex 交互式 CLI，确认两个标签都正常显示
- [ ] Codex review 通过，无阻塞性问题