### PR TITLE
fix: IP 地址创建会话失败 + 终端面板展开收缩后显示不完整

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -77,11 +77,16 @@ func (a *API) FS(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": p, "parent": filepath.Dir(p), "dirs": dirs}})
 }
 
-// sanitizeSessionName 把 tmux 不允许出现在会话名中的字符替换掉。
+// SanitizeSessionName 把 tmux 不允许出现在会话名中的字符替换掉。
 // tmux 自身会把 '.' 和 ':' 替换为 '_'，这里提前做同样的事，
 // 避免后续 -t 引用时 '.' 被解析为 session.window.pane 分隔符而报错。
-func sanitizeSessionName(name string) string {
+func SanitizeSessionName(name string) string {
 	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
+}
+
+// sessionParam 读取路由 :name 参数并净化（点号/冒号 → 下划线）。
+func sessionParam(c *gin.Context) string {
+	return SanitizeSessionName(c.Param("name"))
 }
 
 // Sessions
@@ -95,7 +100,7 @@ func (a *API) NewSession(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
-	b.Name = sanitizeSessionName(b.Name)
+	b.Name = SanitizeSessionName(b.Name)
 	// 创建 detached 会话（转发给 tmux），可指定工作目录 -c
 	args := []string{"new-session", "-d", "-s", b.Name}
 	if strings.TrimSpace(b.Dir) != "" {
@@ -113,12 +118,12 @@ func (a *API) RenameSession(c *gin.Context) {
 	var b struct {
 		Name string `json:"name"`
 	}
-	oldName := strings.TrimSpace(c.Param("name"))
+	oldName := sessionParam(c)
 	if err := c.ShouldBindJSON(&b); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
-	newName := sanitizeSessionName(strings.TrimSpace(b.Name))
+	newName := SanitizeSessionName(strings.TrimSpace(b.Name))
 	if oldName == "" || newName == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
@@ -136,9 +141,9 @@ func (a *API) RenameSession(c *gin.Context) {
 }
 
 // 用 tmux kill-session（转发），避开 ttmux kill 的交互式 y/N 确认（后端无 tty）
-func (a *API) KillSession(c *gin.Context) { a.text(c, "kill-session", "-t", c.Param("name")) }
+func (a *API) KillSession(c *gin.Context) { a.text(c, "kill-session", "-t", sessionParam(c)) }
 func (a *API) Capture(c *gin.Context) {
-	a.text(c, "capture", c.Param("name"), "--lines", c.DefaultQuery("lines", "200"))
+	a.text(c, "capture", sessionParam(c), "--lines", c.DefaultQuery("lines", "200"))
 }
 
 // 允许注入的具名按键（其余只允许单个字母/数字）。用于在专业渲染模式下响应 TUI 选择框。
@@ -152,7 +157,7 @@ var allowedKeys = map[string]bool{
 // 之所以单列一个端点：/tasks/_/send 只能发「文本+回车」，无法发方向键/裸数字/Esc，
 // 而 Claude/Codex 的权限确认/选项菜单需要这些键来选择。
 func (a *API) Keys(c *gin.Context) {
-	name := c.Param("name")
+	name := sessionParam(c)
 	var b struct {
 		Keys []string `json:"keys"`
 	}
@@ -182,7 +187,7 @@ func (a *API) Keys(c *gin.Context) {
 
 // SessionCwd GET /sessions/:name/cwd —— 返回会话活动 pane 的工作目录（供文件侧栏定位根）。
 func (a *API) SessionCwd(c *gin.Context) {
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", c.Param("name"), "#{pane_current_path}").Output()
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", sessionParam(c), "#{pane_current_path}").Output()
 	dir := ""
 	if err == nil {
 		dir = strings.TrimSpace(string(out))
@@ -193,7 +198,7 @@ func (a *API) SessionCwd(c *gin.Context) {
 // SessionType POST /sessions/:name/type —— 把文本字面量打进当前 pane（不追加回车）。
 // 供终端页语音识别后回填用：内容停在输入行，用户复查/编辑后自行按 Enter 发送。
 func (a *API) SessionType(c *gin.Context) {
-	name := c.Param("name")
+	name := sessionParam(c)
 	var b struct {
 		Text string `json:"text"`
 	}
@@ -219,6 +224,7 @@ func (a *API) Send(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
+	b.Sess = SanitizeSessionName(b.Sess)
 	// 分两步注入：先字面文本(-l，不解释按键名)，停顿一下，再单独回车。
 	// 否则像 Codex 这类 TUI 会把「文本+回车」当成一次粘贴，把回车并进去变成换行而非提交。
 	if _, err := a.TT.Run("send-keys", "-t", b.Sess, "-l", b.Msg); err != nil {

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -77,6 +77,13 @@ func (a *API) FS(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": p, "parent": filepath.Dir(p), "dirs": dirs}})
 }
 
+// sanitizeSessionName 把 tmux 不允许出现在会话名中的字符替换掉。
+// tmux 自身会把 '.' 和 ':' 替换为 '_'，这里提前做同样的事，
+// 避免后续 -t 引用时 '.' 被解析为 session.window.pane 分隔符而报错。
+func sanitizeSessionName(name string) string {
+	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
+}
+
 // Sessions
 func (a *API) Sessions(c *gin.Context) { a.json(c, "ls", "--json") }
 func (a *API) NewSession(c *gin.Context) {
@@ -88,12 +95,18 @@ func (a *API) NewSession(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
+	b.Name = sanitizeSessionName(b.Name)
 	// 创建 detached 会话（转发给 tmux），可指定工作目录 -c
 	args := []string{"new-session", "-d", "-s", b.Name}
 	if strings.TrimSpace(b.Dir) != "" {
 		args = append(args, "-c", b.Dir)
 	}
-	a.text(c, args...)
+	out, err := a.TT.Run(args...)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": ttmux.StripANSI(out), "name": b.Name})
 }
 
 func (a *API) RenameSession(c *gin.Context) {
@@ -105,7 +118,7 @@ func (a *API) RenameSession(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
-	newName := strings.TrimSpace(b.Name)
+	newName := sanitizeSessionName(strings.TrimSpace(b.Name))
 	if oldName == "" || newName == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
@@ -114,7 +127,12 @@ func (a *API) RenameSession(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"data": gin.H{"name": newName}})
 		return
 	}
-	a.text(c, "rename-session", "-t", oldName, newName)
+	out, err := a.TT.Run("rename-session", "-t", oldName, newName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"name": newName}})
 }
 
 // 用 tmux kill-session（转发），避开 ttmux kill 的交互式 y/N 确认（后端无 tty）

--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -163,7 +163,7 @@ func newestJSONL(dir string) string {
 
 // ClaudeStatus GET /sessions/:name/claude —— 检测会话是否在跑 claude，并定位其 JSONL。
 func (a *API) ClaudeStatus(c *gin.Context) {
-	name := c.Param("name")
+	name := sessionParam(c)
 	dir := paneClaudeDir(name)
 	if dir == "" {
 		c.JSON(http.StatusOK, gin.H{"data": gin.H{"running": false}})
@@ -308,7 +308,7 @@ func parseLine(line string) *cMsg {
 func (a *API) ClaudeTranscript(c *gin.Context) {
 	file := c.Query("file")
 	if file == "" { // 未传则按会话现场定位
-		if dir := paneClaudeDir(c.Param("name")); dir != "" {
+		if dir := paneClaudeDir(sessionParam(c)); dir != "" {
 			home, _ := os.UserHomeDir()
 			file = newestJSONL(filepath.Join(home, ".claude", "projects", encodeProject(dir)))
 		}

--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -102,7 +102,7 @@ func newestCodexRollout(cwd string) string {
 
 // CodexStatus GET /sessions/:name/codex —— 检测会话是否在跑 codex，并定位其 rollout。
 func (a *API) CodexStatus(c *gin.Context) {
-	dir := paneToolDir(c.Param("name"), cmdlineHasCodex)
+	dir := paneToolDir(sessionParam(c), cmdlineHasCodex)
 	if dir == "" {
 		c.JSON(http.StatusOK, gin.H{"data": gin.H{"running": false}})
 		return
@@ -249,7 +249,7 @@ func parseCodexLine(line string) *cMsg {
 func (a *API) CodexTranscript(c *gin.Context) {
 	file := c.Query("file")
 	if file == "" {
-		if dir := paneToolDir(c.Param("name"), cmdlineHasCodex); dir != "" {
+		if dir := paneToolDir(sessionParam(c), cmdlineHasCodex); dir != "" {
 			file = newestCodexRollout(dir)
 		}
 	}

--- a/backend/pty/pty.go
+++ b/backend/pty/pty.go
@@ -43,6 +43,11 @@ func utf8Env(env []string) []string {
 	return append(env, "LC_ALL=C.UTF-8")
 }
 
+// SanitizeSessionName 替换 tmux 会话名中的 '.' 和 ':'，避免 -t 解析出错。
+func SanitizeSessionName(name string) string {
+	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
+}
+
 // tmuxScroll 通过 tmux copy-mode 滚动会话的真实历史（attach 用全屏，xterm 本地缓冲为空）。
 func tmuxScroll(name, dir string, lines int) {
 	if lines <= 0 {
@@ -79,7 +84,7 @@ var upgrader = websocket.Upgrader{
 
 // Handler 处理 /api/term/:name 的 WebSocket 升级与 PTY 桥接。
 func Handler(c *gin.Context) {
-	name := c.Param("name")
+	name := SanitizeSessionName(c.Param("name"))
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		return

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -224,7 +224,10 @@ export default function App() {
   const soloName = tab === 'term' && route.includes('/') ? decodeURIComponent(route.slice(route.indexOf('/') + 1)) : ''
   if (soloName) return <SoloTerminal name={soloName} />
 
-  const openTerm = (name: string) => {
+  const openTerm = (rawName: string) => {
+    // tmux 自身会把 '.' ':' 替换为 '_'，前端也同步净化，
+    // 确保标签名/WebSocket URL 与 tmux 实际 session 名一致。
+    const name = rawName.replace(/[.:]/g, '_')
     setTerms((ts) => (ts.includes(name) ? ts : [...ts, name]))
     setActive(name)
     if (hasSider) { setDockOpen(true); setDockMax(false) } // 桌面：拉出右侧停靠栏（压缩页面到左）

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,10 +133,11 @@ function FilesPage({ openTerm }: { openTerm: (name: string) => void }) {
     const prompt = `请打开并查看这个文件：${file}`
     const cmd = `${kind === 'claude' ? 'claude' : 'codex'} ${shellQuote(prompt)}`
     try {
-      await api('POST', '/sessions', { name, dir })
-      await api('POST', '/tasks/_/send', { sess: name, msg: cmd })
+      const res = await api('POST', '/sessions', { name, dir })
+      const actual = res.name || name
+      await api('POST', '/tasks/_/send', { sess: actual, msg: cmd })
       message.success(t('file.openedInAgent', { agent: kind === 'claude' ? 'Claude Code' : 'Codex' }))
-      openTerm(name)
+      openTerm(actual)
     } catch (e: any) {
       message.error(t('file.openFailed', { message: e.message }))
     }
@@ -277,6 +278,15 @@ export default function App() {
   const dockPageWidth = tab === 'sessions' || tab === 'overview' || tab === 'swarm' || tab === 'settings' ? 420 : 300
   const setStatus = (name: string, s: TermStatus) => setStatusMap((m) => ({ ...m, [name]: s }))
   const sendKey = (seq: string) => active && termRefs.current[active]?.send(seq)
+
+  // ponytail: dock 展开/收缩/最大化后，等 CSS transition 结束再 fit 活动终端，
+  // 否则 xterm 在动画中途拿到的尺寸不准，终端显示不完整（Issue #11）。
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (active) termRefs.current[active]?.fit()
+    }, 250) // 略长于 transition: .2s
+    return () => clearTimeout(timer)
+  }, [dockOpen, dockMax])
 
   // 全屏切换（标准 API + webkit 兜底）。不支持的浏览器（如 iOS Safari）隐藏按钮，改走「添加到主屏幕」
   const docEl: any = document.documentElement
@@ -1156,9 +1166,10 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
   const ok = async () => {
     if (!name.trim()) return message.error(t('session.nameRequired'))
     try {
-      await api('POST', '/sessions', { name: name.trim(), dir: dir.trim() })
-      if (agent !== 'none') await api('POST', '/tasks/_/send', { sess: name.trim(), msg: agent })
-      pushRecentDir(dir); message.success(t('session.created')); onClose(); onDone(name.trim())
+      const res = await api('POST', '/sessions', { name: name.trim(), dir: dir.trim() })
+      const actual = res.name || name.trim()
+      if (agent !== 'none') await api('POST', '/tasks/_/send', { sess: actual, msg: agent })
+      pushRecentDir(dir); message.success(t('session.created')); onClose(); onDone(actual)
     }
     catch (e: any) { message.error(e.message) }
   }
@@ -1196,10 +1207,11 @@ function RenameSessionModal({ session, onClose, onDone }: { session: string | nu
     const next = name.trim()
     if (!next) return message.error(t('session.nameRequired'))
     try {
-      await api('PATCH', `/sessions/${encodeURIComponent(session)}`, { name: next })
+      const res = await api('PATCH', `/sessions/${encodeURIComponent(session)}`, { name: next })
+      const actual = res.data?.name || next
       message.success(t('session.renamed'))
       onClose()
-      onDone(session, next)
+      onDone(session, actual)
     } catch (e: any) {
       message.error(e.message)
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -282,14 +282,6 @@ export default function App() {
   const setStatus = (name: string, s: TermStatus) => setStatusMap((m) => ({ ...m, [name]: s }))
   const sendKey = (seq: string) => active && termRefs.current[active]?.send(seq)
 
-  // ponytail: dock 展开/收缩/最大化后，等 CSS transition 结束再 fit 活动终端，
-  // 否则 xterm 在动画中途拿到的尺寸不准，终端显示不完整（Issue #11）。
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (active) termRefs.current[active]?.fit()
-    }, 250) // 略长于 transition: .2s
-    return () => clearTimeout(timer)
-  }, [dockOpen, dockMax])
 
   // 全屏切换（标准 API + webkit 兜底）。不支持的浏览器（如 iOS Safari）隐藏按钮，改走「添加到主屏幕」
   const docEl: any = document.documentElement
@@ -438,7 +430,9 @@ export default function App() {
 
           {/* 右侧终端停靠栏（桌面）：常驻挂载以保留连接，收起时宽度归零 */}
           {hasSider && terms.length > 0 && (
-            <div style={{
+            <div
+              onTransitionEnd={() => window.dispatchEvent(new Event('resize'))}
+              style={{
               flex: dockOpen ? 1 : '0 0 0px', minWidth: dockOpen ? 480 : 0,
               width: dockOpen ? 'auto' : 0, overflow: 'hidden', transition: 'flex-basis .2s, min-width .2s',
               display: 'flex', flexDirection: 'column', background: 'var(--bg-term)',


### PR DESCRIPTION
## Summary
- **Fixes #10**: 会话名中的 `.` 和 `:` 在创建时替换为 `_`（与 tmux 自身行为一致），避免后续 `-t` 引用时被解析为 session.window.pane 分隔符
- **Fixes #11**: dock 展开/收缩后延迟 250ms 重新 fit 活动终端，等 CSS transition 结束后再获取准确尺寸
- 后端 `NewSession` / `RenameSession` 返回净化后的实际名字，前端同步使用

## Test plan
- [ ] 用 IP 地址（如 `192.168.1.1`）创建会话，确认不再报错且会话名显示为 `192_168_1_1`
- [ ] 创建会话后能正常连接终端、发送命令
- [ ] 重命名会话为含点号的名字，确认自动净化
- [ ] 桌面端反复点击终端面板的「扩展/收起」把手，确认终端内容每次都能完整铺满
- [ ] 从文件页用 Agent 打开文件，确认会话名正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)