### PR TITLE
fix: 移动端输入框缩放 + 横向布局溢出修复

### DIFF
--- a/backend/home/index.html
+++ b/backend/home/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
 <title>导航</title>
 <style>
   :root { --accent:#1f6feb; }

--- a/backend/server/fallback.html
+++ b/backend/server/fallback.html
@@ -2,7 +2,7 @@
 <html lang="zh">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
 <meta name="theme-color" content="#0d1117">
 <title>ttmux 控制台</title>
 <style>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="zh">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#0d1117" />
   <!-- 添加到主屏幕后全屏运行（iOS/Android 平板等价 F11，无浏览器栏） -->
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -737,7 +737,7 @@ function TerminalPane(props: {
       </div>
 
       {/* 工具栏 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)', flexWrap: 'wrap' }}>
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-dim)', fontSize: 12 }}>
           <i style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
           {activeNeedsInput ? t('session.waiting') : st === 'connected' ? t('terminal.status.connected') : st === 'connecting' ? t('terminal.status.connecting') : t('terminal.status.disconnected')}
@@ -998,7 +998,7 @@ function Overview({ go, openTerm }: { go: (k: string) => void; openTerm: (n: str
                 {swarms.slice(0, 5).map((s: any) => (
                   <div key={s.id || s.name} onClick={() => go('swarm')}
                     style={{ cursor: 'pointer', padding: '10px 12px', borderRadius: 10, background: 'var(--bg-base)', border: '1px solid var(--border-subtle)' }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flexWrap: 'wrap' }}>
                       <span style={{ fontWeight: 600, color: 'var(--text-bright)', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
                       <span style={{ flex: '0 0 auto' }}><SwarmStatusTag status={s.status} /></span>
                       {s.supervisor && <Text type="secondary" style={{ fontSize: 12, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>◆{s.supervisor}</Text>}
@@ -1335,7 +1335,7 @@ function Sessions({ openTerm, closeTerm }: { openTerm: (n: string) => void; clos
                 // 整行点击直接进入终端；右侧操作区 stopPropagation 不触发进入
                 <List.Item style={{ padding: '10px 8px', cursor: 'pointer' }} onClick={() => openTerm(s.name)}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 10, width: '100%', minWidth: 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, flex: 1 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0, flex: 1, flexWrap: 'wrap' }}>
                       <i title={waiting ? t('prompt.confirmRequired') : connected ? t('terminal.status.connected') : t('terminal.status.idle')} style={{ width: 8, height: 8, borderRadius: '50%', flex: '0 0 8px', background: waiting ? '#d29922' : connected ? '#3fb950' : 'var(--text-dimmer)' }} />
                       <span style={{ fontWeight: 600, color: 'var(--text-bright)', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.name}>{s.name}</span>
                       {sw && <Tag color="blue" style={{ margin: 0, flex: '0 0 auto' }}>{t('nav.swarm')}:{sw.swarm}{sw.role === 'leader' ? `·${t('swarm.master')}` : ''}</Tag>}

--- a/frontend/src/GitPanel.tsx
+++ b/frontend/src/GitPanel.tsx
@@ -320,7 +320,7 @@ export default function GitPanel({ dir, accent = '#58a6ff', onClose }: { dir?: s
             {status.commits.map((cm) => (
               <div key={cm.hash} style={{ padding: '4px 10px', fontSize: 12, lineHeight: 1.4 }}>
                 <div style={{ color: 'var(--text-bright)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={cm.subject}>{cm.subject}</div>
-                <div style={{ color: 'var(--text-dimmer)', fontSize: 11, display: 'flex', gap: 8 }}>
+                <div style={{ color: 'var(--text-dimmer)', fontSize: 11, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                   <span style={{ fontFamily: 'ui-monospace, monospace', color: accent }}>{cm.short}</span>
                   <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{cm.author}</span>
                   <span style={{ flex: '0 0 auto' }}>{cm.when}</span>

--- a/frontend/src/Swarm.tsx
+++ b/frontend/src/Swarm.tsx
@@ -131,22 +131,22 @@ function SwarmCard({ s, onOpen }: { s: SwarmRow; onOpen: (n: string) => void }) 
       <div style={{ color: s.goal ? C.fg2 : C.fg3, fontSize: 13, marginBottom: 12, minHeight: 19, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
         {s.goal || t('overview.noGoal')}
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ display: 'inline-flex', gap: 3, alignItems: 'center' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <span style={{ display: 'inline-flex', gap: 3, alignItems: 'center', flexWrap: 'wrap' }}>
           {s.supervisor && <i title={s.supervisor} style={{ width: 8, height: 8, borderRadius: '50%', background: C.magenta }} />}
           {Array.from({ length: Math.min(s.alive, 10) }).map((_, i) => <i key={'a' + i} style={{ width: 8, height: 8, borderRadius: '50%', background: C.green }} />)}
           {Array.from({ length: Math.min(s.pending, 10) }).map((_, i) => <i key={'p' + i} style={{ width: 8, height: 8, borderRadius: '50%', background: C.amber }} />)}
           {Array.from({ length: Math.min(exited, 10) }).map((_, i) => <i key={'e' + i} style={{ width: 8, height: 8, borderRadius: '50%', background: C.line2 }} />)}
           {s.total + s.pending === 0 && !s.supervisor && <span style={{ color: C.fg3, fontSize: 12 }}>{t('swarm.noMembers')}</span>}
         </span>
-        <span style={{ marginLeft: 'auto', display: 'flex', gap: 10, alignItems: 'center', fontSize: 12, color: C.fg2 }}>
+        <span style={{ marginLeft: 'auto', display: 'flex', gap: 10, alignItems: 'center', fontSize: 12, color: C.fg2, flexWrap: 'wrap' }}>
           {s.supervisor && <span style={{ color: C.magenta }}>◆ {t('swarm.master')}</span>}
           {(s.total + s.pending) > 0 && <span>{t('swarm.memberSummary', { total: s.total, alive: s.alive })}</span>}
           {(s.total + s.pending) === 0 && !s.supervisor && <span style={{ color: C.fg3 }}>{t('swarm.noMembers')}</span>}
           {s.pending > 0 && <span style={{ color: C.amber }}>+{s.pending} {t('swarm.pendingUnlock')}</span>}
         </span>
       </div>
-      <div style={{ marginTop: 10, paddingTop: 9, borderTop: `1px solid ${C.line}`, display: 'flex', alignItems: 'center', fontSize: 11.5, color: C.fg3 }}>
+      <div style={{ marginTop: 10, paddingTop: 9, borderTop: `1px solid ${C.line}`, display: 'flex', alignItems: 'center', fontSize: 11.5, color: C.fg3, flexWrap: 'wrap', gap: 4 }}>
         <span style={{ color: s.supervisor ? C.magenta : C.fg3 }}>{s.supervisor ? `◆ ${s.supervisor}` : t('swarm.noSupervisor')}</span>
         <span style={{ marginLeft: 'auto' }}>{(s.created || '').slice(5, 16)}</span>
       </div>

--- a/frontend/src/UpdateBanner.tsx
+++ b/frontend/src/UpdateBanner.tsx
@@ -36,7 +36,7 @@ export default function UpdateBanner() {
 
   if (!stale || dismissed) return null
   return (
-    <div style={{ position: 'fixed', left: '50%', bottom: 18, transform: 'translateX(-50%)', zIndex: 2000, display: 'flex', alignItems: 'center', gap: 12, background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 10, padding: '8px 14px', boxShadow: 'var(--elevated-shadow)', color: 'var(--text-bright)', fontSize: 13 }}>
+    <div style={{ position: 'fixed', left: '50%', bottom: 18, transform: 'translateX(-50%)', zIndex: 2000, display: 'flex', alignItems: 'center', gap: 12, background: 'var(--bg-elevated)', border: '1px solid var(--border)', borderRadius: 10, padding: '8px 14px', boxShadow: 'var(--elevated-shadow)', color: 'var(--text-bright)', fontSize: 13, flexWrap: 'wrap', maxWidth: '90vw' }}>
       <span>🔄 {t('update.newVersion')}</span>
       <a onClick={() => location.reload()} style={{ color: '#58a6ff', fontWeight: 600 }}>{t('common.refresh')}</a>
       <a onClick={() => setDismissed(true)} style={{ color: 'var(--text-dim)' }}>{t('update.later')}</a>

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -115,7 +115,7 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
             {dropMode === 'path' ? t('chat.dropInsertPath') : t('chat.dropUpload')}
           </div>
         )}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: '1px solid var(--border)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 10px', borderBottom: '1px solid var(--border)', flexWrap: 'wrap' }}>
           {title}
           <span style={{ color: 'var(--text-dim)', fontSize: 12 }}>{name}</span>
           <span style={{ flex: 1 }} />
@@ -145,7 +145,7 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
         {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
         <PromptPanel name={name} accent={accent} />
         {errMsg && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{errMsg}</div>}
-        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end' }}>
+        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end', flexWrap: 'wrap' }}>
           <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
             onChange={(e) => { if (e.target.files?.length) doUpload(e.target.files); e.target.value = '' }} />
           <Button title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -145,7 +145,7 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
         {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
         <PromptPanel name={name} accent={accent} />
         {errMsg && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{errMsg}</div>}
-        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end' }}>
           <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
             onChange={(e) => { if (e.target.files?.length) doUpload(e.target.files); e.target.value = '' }} />
           <Button title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>


### PR DESCRIPTION
## 概要
- 在所有产品页面的 viewport meta 标签中添加 `maximum-scale=1`，防止 iOS Safari 在输入框聚焦时自动放大页面
- 为多处横向 flex 布局添加 `flexWrap: wrap`，防止在手机窄屏下内容溢出不可见

## 修改文件
**viewport 修复：**
- `frontend/index.html`
- `backend/home/index.html`
- `backend/server/fallback.html`

**flex-wrap 修复：**
- `App.tsx` — 终端工具栏、会话列表标签行、概览页蜂群信息行
- `ChatShell.tsx` — 聊天头部按钮组
- `Swarm.tsx` — 蜂群卡片成员指示、统计信息、底部日期行
- `UpdateBanner.tsx` — 更新提示横幅
- `GitPanel.tsx` — 提交信息行

## 测试计划
- [ ] 在 iPhone Safari 中点击输入框，确认页面不再自动缩放
- [ ] 在手机窄屏下查看各页面，确认按钮/标签能自动换行而不溢出
- [ ] 确认桌面端浏览体验无影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)