### PR TITLE
ci: Policy Review 容忍 fork PR 无评论权限（403 不再 fail）

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,30 +33,36 @@ jobs:
             const marker = '<!-- ttmux-automated-review -->'
             const issue_number = context.issue.number
             const { owner, repo } = context.repo
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            })
-            const existing = comments.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes(marker)
-            )
             const nextBody = `${marker}\n${body}`
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body: nextBody,
-              })
-            } else {
-              await github.rest.issues.createComment({
+            // 来自 fork 的 PR 拿到的 GITHUB_TOKEN 是只读的，发评论会 403。
+            // 这种情况下别让整个 job 失败——审查正文已写进 step summary，降级为告警即可。
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number,
-                body: nextBody,
+                per_page: 100,
               })
+              const existing = comments.find(comment =>
+                comment.user.type === 'Bot' && comment.body.includes(marker)
+              )
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body: nextBody,
+                })
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: nextBody,
+                })
+              }
+            } catch (e) {
+              core.warning(`跳过发表审查评论（fork PR 的令牌通常只读，无法评论）：${e.message}`)
             }
 
       - name: Fail on blocking findings


### PR DESCRIPTION
## 问题
来自 fork 的 PR，其 `GITHUB_TOKEN` 只读，`Automated PR Review` 工作流用 `actions/github-script` 发/改 PR 评论会返回 `403 Resource not accessible by integration`，导致 **Policy Review** 整个 job 失败——即便审查本身没有阻断性发现（如 PR #18）。

## 修复
把发评论逻辑包进 `try/catch`，失败时降级为 `core.warning`，不再让 job 失败。审查正文已写入 step summary，fork PR 仍能在 Actions 摘要里看到结果；同仓库 PR 照常评论。

> 仅改 `.github/workflows/pr-review.yml`，无业务代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)