### PR TITLE
feat(files): 文件工作区统一组件 FileWorkspace + VSCode 式双栏编辑

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,8 @@ import { api, upload, makeClipboardImageFile, setUnauthorizedHandler } from './a
 import Term, { TermHandle, TermStatus } from './Terminal'
 import ClaudeChat from './ClaudeChat'
 import CodexChat from './CodexChat'
-import FileBrowser, { Viewer, FileTypeIcon } from './FileBrowser'
+import FileBrowser from './FileBrowser'
+import FileWorkspace from './FileWorkspace'
 import FloatingFileDrawer from './FloatingFileDrawer'
 import GitPanel from './GitPanel'
 import BrowserView from './BrowserView'
@@ -188,8 +189,8 @@ function FilesPage({ openTerm }: { openTerm: (name: string) => void }) {
     }
   }
   return (
-    <div style={{ height: '100%', minHeight: 0 }}>
-      <FileBrowser accent="#58a6ff" layout="split" onOpenAgent={openAgent} />
+    <div style={{ height: '100%', minHeight: 0, display: 'flex' }}>
+      <FileWorkspace dir="" accent="#58a6ff" onOpenAgent={openAgent} />
     </div>
   )
 }
@@ -672,63 +673,8 @@ function TerminalPane(props: {
   }
 
   // 文件侧栏（终端视图下也可用）：定位到当前会话的工作目录。左侧停靠时默认展开。
+  // 编辑器多 tab / 打开的文件 / 拖拽调宽等都下沉到 <FileWorkspace>（左侧停靠时用），这里只保留 showFiles。
   const [showFiles, setShowFiles] = useState(fileDock === 'left')
-  // VSCode 式编辑器 tab（仅左侧停靠的独立全屏页）：第一个 tab 永远是当前会话，
-  // 点文件浏览器里的文件 → 在会话 tab 右边开/激活一个文件 tab。activeFile=null 表示会话 tab。
-  const [openFiles, setOpenFiles] = useState<string[]>([])
-  const [activeFile, setActiveFile] = useState<string | null>(null)
-  const [dirtyFiles, setDirtyFiles] = useState<Set<string>>(new Set()) // 有未保存改动的文件 tab
-  const setFileDirty = (p: string, dirty: boolean) => setDirtyFiles((prev) => {
-    if (prev.has(p) === dirty) return prev
-    const n = new Set(prev)
-    dirty ? n.add(p) : n.delete(p)
-    return n
-  })
-  const openFileTab = (p: string) => {
-    setOpenFiles((prev) => (prev.includes(p) ? prev : [...prev, p]))
-    setActiveFile(p)
-  }
-  const doCloseFileTab = (p: string) => {
-    const i = openFiles.indexOf(p)
-    const next = openFiles.filter((x) => x !== p)
-    setOpenFiles(next)
-    setFileDirty(p, false)
-    if (activeFile === p) setActiveFile(next[i - 1] ?? next[i] ?? null) // 关掉激活 tab → 落到左邻，否则会话 tab
-  }
-  const closeFileTab = (p: string) => {
-    if (dirtyFiles.has(p)) {
-      modal.confirm({
-        title: t('file.closeUnsavedTitle'),
-        content: pathBasename(p),
-        okText: t('file.closeWithoutSaving'),
-        cancelText: t('common.cancel'),
-        okButtonProps: { danger: true },
-        onOk: () => doCloseFileTab(p),
-      })
-    } else doCloseFileTab(p)
-  }
-  // 正在看文件 tab（左侧停靠全屏页）：底部会话输入/快捷键栏此时隐藏（#3）
-  const viewingFile = fileDock === 'left' && activeFile !== null
-  // 左侧文件停靠栏宽度：可拖拽调整，记 localStorage
-  const [dockW, setDockW] = useState(() => { const s = Number(localStorage.getItem('ttmux.fileDockW')); return s >= 160 && s <= 640 ? s : 280 })
-  const dockWRef = useRef(dockW)
-  dockWRef.current = dockW
-  const startDockResize = (e: React.PointerEvent) => {
-    e.preventDefault()
-    const startX = e.clientX, startW = dockW
-    document.body.style.userSelect = 'none'
-    document.body.style.cursor = 'col-resize'
-    const move = (ev: PointerEvent) => setDockW(Math.min(640, Math.max(160, startW + ev.clientX - startX)))
-    const up = () => {
-      window.removeEventListener('pointermove', move)
-      window.removeEventListener('pointerup', up)
-      document.body.style.userSelect = ''
-      document.body.style.cursor = ''
-      localStorage.setItem('ttmux.fileDockW', String(dockWRef.current))
-    }
-    window.addEventListener('pointermove', move)
-    window.addEventListener('pointerup', up)
-  }
   const [showGit, setShowGit] = useState(false)
   const [cwd, setCwd] = useState('')
   // 文件栏与 Git 面板共用右侧抽屉位，互斥显示。
@@ -754,6 +700,7 @@ function TerminalPane(props: {
   const onTermDrop = (e: React.DragEvent) => {
     if (!isPathDrag(e)) return
     e.preventDefault()
+    e.stopPropagation() // 别再冒泡到 FileWorkspace 的分栏 drop：拖到终端=注入@，不触发分栏
     setDragOver(false)
     const mention = toMention(readDropPath(e))
     if (!mention || !active) return
@@ -912,6 +859,159 @@ function TerminalPane(props: {
     )
   }
 
+  // ── 会话（终端）各部件抽成局部 JSX：左侧停靠走 <FileWorkspace> 的槽位，右侧抽屉走原地布局，二者共用同一份 ──
+  const sessionTab = (
+    <>
+      <i style={{ width: 7, height: 7, borderRadius: '50%', background: active && statusMap[active] === 'connected' ? '#3fb950' : '#d29922' }} />
+      {active}
+    </>
+  )
+  const tabStrip = (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid var(--border)', overflowX: 'auto' }}>
+      {onCollapse && <Button size="small" type="text" style={{ color: 'var(--text-dim)' }} onClick={onCollapse}>✕ {t('common.collapse')}</Button>}
+      {terms.map((termName) => (
+        <span key={termName} onClick={() => setActive(termName)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', borderRadius: 8, cursor: 'pointer', whiteSpace: 'nowrap',
+            background: termName === active ? '#1f6feb33' : 'transparent', border: termName === active ? '1px solid #1f6feb' : '1px solid var(--border)', color: 'var(--text-bright)',
+          }}>
+          <i style={{ width: 7, height: 7, borderRadius: '50%', background: termNeedsInput[termName] ? '#d29922' : (statusMap[termName] === 'connected' ? '#3fb950' : statusMap[termName] === 'connecting' ? '#d29922' : '#f85149') }} />
+          {termNeedsInput[termName] && <span title={t('prompt.confirmRequired')} style={{ color: '#d29922', fontSize: 12, fontWeight: 600 }}>{t('session.waiting')}</span>}
+          {claudeMap[termName]?.running && <span title={t('session.runningClaude')} style={{ color: '#58a6ff' }}>✳</span>}
+          {codexMap[termName]?.running && <span title={t('session.runningCodex')} style={{ color: '#10a37f' }}>✸</span>}
+          {termName}
+          <a onClick={(e) => { e.stopPropagation(); closeTerm(termName) }} style={{ color: 'var(--text-dim)' }}>×</a>
+        </span>
+      ))}
+    </div>
+  )
+  const sessionToolbar = (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)', flexWrap: 'wrap' }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-dim)', fontSize: 12 }}>
+        <i style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
+        {activeNeedsInput ? t('session.waiting') : st === 'connected' ? t('terminal.status.connected') : st === 'connecting' ? t('terminal.status.connecting') : t('terminal.status.disconnected')}
+      </span>
+      {active && claudeMap[active]?.running && (
+        <Tooltip title={t('chat.switchToClaude')}>
+          <Button size="small" type={claudeView[active] ? 'primary' : 'default'}
+            onClick={() => setClaudeView((v) => ({ ...v, [active!]: !v[active!] }))}>✳ Claude</Button>
+        </Tooltip>
+      )}
+      {active && codexMap[active]?.running && (
+        <Tooltip title={t('chat.switchToCodex')}>
+          <Button size="small" type={codexView[active] ? 'primary' : 'default'}
+            style={codexView[active] ? { background: '#10a37f', borderColor: '#10a37f' } : {}}
+            onClick={() => setCodexView((v) => ({ ...v, [active!]: !v[active!] }))}>✸ Codex</Button>
+        </Tooltip>
+      )}
+      <Dropdown trigger={['click']} menu={{ items: tmuxMenu(t) as any, onClick: ({ key }) => sendKey(key) }} placement="bottomLeft">
+        <Button size="small" type="primary" ghost>tmux ▾</Button>
+      </Dropdown>
+      {active && (
+        <Tooltip title={t('terminal.openInNewTabTitle')}>
+          <Button size="small" onClick={() => window.open(`/#/term/${encodeURIComponent(active)}`, '_blank')}>↗ {t('terminal.newTab')}</Button>
+        </Tooltip>
+      )}
+      {active && <Button size="small" onClick={() => setRenameSession(active)}>{t('session.rename')}</Button>}
+      <Tooltip title={promptOff ? t('prompt.popupOff') : t('prompt.popupOn')}>
+        <Button size="small" type={promptOff ? 'default' : 'primary'} ghost={!promptOff} onClick={togglePromptOff}>{promptOff ? '🔕' : '🔔'} {t('prompt.popup')}</Button>
+      </Tooltip>
+      <Tooltip title={t('terminal.fileBrowserTitle')}>
+        <Button size="small" type={showFiles ? 'primary' : 'default'} onClick={toggleFiles}>📁 {t('chat.files')}</Button>
+      </Tooltip>
+      <Tooltip title={t('terminal.gitPanelTitle')}>
+        <Button size="small" type={showGit ? 'primary' : 'default'} onClick={toggleGit}
+          icon={<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ verticalAlign: '-2px' }}><circle cx="6" cy="6" r="2.3" /><circle cx="6" cy="18" r="2.3" /><circle cx="18" cy="8" r="2.3" /><path d="M6 8.3v7.4" /><path d="M18 10.3a6 6 0 0 1-6 6H8.3" /></svg>}>
+          {t('git.title')}
+        </Button>
+      </Tooltip>
+      <Tooltip title={showVoice ? t('voice.hideButton') : t('voice.showButton')}>
+        <Button size="small" type={showVoice ? 'primary' : 'default'} onClick={() => setShowVoice((v) => !v)}>🎤</Button>
+      </Tooltip>
+      <span style={{ flex: 1 }} />
+      <Tooltip title={t('terminal.scrollHistory')}><Button size="small" onClick={() => active && termRefs.current[active]?.scroll(-12)}>▲</Button></Tooltip>
+      <Tooltip title={t('terminal.toBottom')}><Button size="small" onClick={() => active && termRefs.current[active]?.toBottom()}>{t('terminal.bottomShort')}</Button></Tooltip>
+      <Tooltip title={t('terminal.decreaseFont')}><Button size="small" onClick={() => setFontSize(Math.max(10, fontSize - 1))}>A-</Button></Tooltip>
+      <Tooltip title={t('terminal.increaseFont')}><Button size="small" onClick={() => setFontSize(Math.min(22, fontSize + 1))}>A+</Button></Tooltip>
+      <Tooltip title={t('terminal.reconnect')}><Button size="small" onClick={() => active && termRefs.current[active]?.reconnect()}>{t('terminal.reconnectShort')}</Button></Tooltip>
+    </div>
+  )
+  const terminalArea = (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}
+      onDragOver={(e) => { if (isPathDrag(e)) { e.stopPropagation(); allowPathDrop(e); setDragOver(true) } }}
+      onDragLeave={(e) => { if (e.currentTarget === e.target) setDragOver(false) }}
+      onDrop={onTermDrop}>
+      {dragOver && (
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 5, pointerEvents: 'none',
+          border: '2px dashed #58a6ff', borderRadius: 8, background: 'rgba(88,166,255,.08)',
+          display: 'grid', placeItems: 'center', color: '#58a6ff', fontSize: 14, fontWeight: 600,
+        }}>{t('terminal.dropToMention')}</div>
+      )}
+      <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
+        {terms.map((termName) => (
+          <div key={termName} style={{ position: 'absolute', inset: 0, display: termName === active ? 'block' : 'none', padding: 6 }}>
+            <Term ref={(h) => { termRefs.current[termName] = h }} name={termName} fontSize={fontSize} active={termName === active} onStatus={(s) => setStatus(termName, s)}
+              onContextMenu={({ x, y, selection }) => { setActive(termName); setCtx({ x, y, session: termName, selection }) }}
+              onSelectionMenu={({ selection }) => { setActive(termName); setCtx(null); if (selection.trim()) { copyText(selection); message.success(t('common.copied')) } }}
+              onPaste={() => { setActive(termName); pasteClipboard(termName) }}
+              onImagePaste={(files) => { setActive(termName); pasteImage(termName, files) }} />
+            {claudeView[termName] && claudeMap[termName]?.running && (
+              <div style={{ position: 'absolute', inset: 0 }}>
+                <ClaudeChat name={termName} file={claudeMap[termName].file} dir={claudeMap[termName].dir} onBack={() => setClaudeView((v) => ({ ...v, [termName]: false }))} />
+              </div>
+            )}
+            {codexView[termName] && codexMap[termName]?.running && (
+              <div style={{ position: 'absolute', inset: 0 }}>
+                <CodexChat name={termName} file={codexMap[termName].file} dir={codexMap[termName].dir} onBack={() => setCodexView((v) => ({ ...v, [termName]: false }))} />
+              </div>
+            )}
+            {showVoice && !claudeView[termName] && !codexView[termName] && (
+              <VoiceInput accent="#58a6ff" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(termName)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+  const sessionBottom = (
+    <>
+      {isTouch && !inChat && (
+        <div style={{ display: 'flex', gap: 6, padding: '8px 8px 0' }} onDragOver={allowPathDrop} onDrop={onInputDrop}>
+          <Input ref={mobileInputRef} value={line} onFocus={exitCopyMode} onChange={(e) => setLine(e.target.value)}
+            onPressEnter={(e) => { if ((e.nativeEvent as any).isComposing) return; submitLine() }}
+            placeholder={t('terminal.mobileInputPlaceholder')} allowClear autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false} />
+          <Button type="primary" onMouseDown={noBlur} onClick={submitLine}>{t('common.send')}</Button>
+        </div>
+      )}
+      {!inChat && (
+        <div style={{ display: 'flex', gap: 6, padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
+          <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
+          {(prefsData.quickCommands || []).map((cmd) => (
+            <Button key={cmd} onMouseDown={noBlur} onClick={() => { if (isTouch) { setLine(cmd); requestAnimationFrame(() => mobileInputRef.current?.focus()) } else { sendRaw(cmd) } }} style={{ flex: '0 0 auto' }}>{cmd}</Button>
+          ))}
+          {KEYS.map(([label, seq]) => (
+            <Button key={label} onMouseDown={noBlur} onClick={() => tapKey(seq)} style={{ flex: '0 0 auto' }}>{label}</Button>
+          ))}
+          <Button onMouseDown={noBlur} style={{ flex: '0 0 auto', borderStyle: 'dashed' }} onClick={() => {
+            let val = ''
+            modal.confirm({
+              title: t('settings.quickCommands'),
+              content: <Input placeholder={t('settings.quickCommandPlaceholder')} onChange={(e) => (val = e.target.value)} autoFocus />,
+              okText: t('quickCmd.addOk'),
+              onOk: () => {
+                const v = val.trim()
+                if (!v) return
+                if ((prefsData.quickCommands || []).includes(v)) return
+                savePreferences({ quickCommands: [...(prefsData.quickCommands || []), v] })
+              },
+            })
+          }}>{t('quickCmd.add')}</Button>
+        </div>
+      )}
+    </>
+  )
+
   return (
     // paddingBottom=env(keyboard-inset-height)：软键盘悬浮覆盖时(见 main.tsx/index.html)，
     // 把整块内容抬到键盘之上，让底部输入条/快捷键栏不被遮住。桌面无虚拟键盘 → 0，无影响。
@@ -959,180 +1059,25 @@ function TerminalPane(props: {
           <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: 0.5, background: 'var(--brand-grad)', WebkitBackgroundClip: 'text', backgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>Roam</span>
         </div>
       )}
-      {/* 内容主体：左侧文件停靠（贯通上下） + 右侧会话列 */}
-      <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
-        {fileDock === 'left' && showFiles && (
-          <>
-            <div style={{ flex: `0 0 ${dockW}px`, minWidth: 0, minHeight: 0, display: 'flex' }}>
-              <FileBrowser dir={cwd} accent="#58a6ff" layout="dock" onClose={() => setShowFiles(false)} onOpenFile={openFileTab} selectedPath={activeFile} />
-            </div>
-            {/* 拖拽调宽的分隔条 */}
-            <div onPointerDown={startDockResize} title={t('file.dragResize')}
-              style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
-          </>
-        )}
-        <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-      {/* VSCode 式编辑器 tab 条（右列最上）：第一个永远是当前会话，其后是点开的文件 tab */}
-      {fileDock === 'left' && (
-        <div style={{ display: 'flex', alignItems: 'stretch', borderBottom: '1px solid var(--border)', overflowX: 'auto', background: 'var(--bg-container)' }}>
-          <div onClick={() => setActiveFile(null)} title={active || ''}
-            style={{
-              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 12px', cursor: 'pointer', whiteSpace: 'nowrap', fontSize: 12, borderRight: '1px solid var(--border)',
-              color: activeFile === null ? 'var(--text-bright)' : 'var(--text-dim)',
-              background: activeFile === null ? 'var(--bg-base)' : 'transparent',
-              borderTop: `2px solid ${activeFile === null ? '#58a6ff' : 'transparent'}`,
-            }}>
-            <i style={{ width: 7, height: 7, borderRadius: '50%', background: active && statusMap[active] === 'connected' ? '#3fb950' : '#d29922' }} />
-            {active}
+      {/* 内容主体：左侧走 <FileWorkspace>（文件树 + 编辑器多 tab）；右侧抽屉走原地布局。
+          会话（终端）各部件用上面抽出的 sessionTab/sessionToolbar/terminalArea/sessionBottom 复用。 */}
+      {fileDock === 'left' ? (
+        <FileWorkspace
+          dir={cwd} accent="#58a6ff"
+          explorerOpen={showFiles} onExplorerClose={() => setShowFiles(false)}
+          leadingTitle={active || ''} leadingTab={sessionTab}
+          leadingContent={terminalArea} chrome={sessionToolbar} footer={sessionBottom}
+        />
+      ) : (
+        <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+          <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+            {tabStrip}
+            {sessionToolbar}
+            {terminalArea}
+            {sessionBottom}
           </div>
-          {openFiles.map((f) => {
-            const isDirty = dirtyFiles.has(f)
-            return (
-              <div key={f} onClick={() => setActiveFile(f)} title={f}
-                className={`cc-filetab${isDirty ? ' dirty' : ''}`}
-                style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 3, padding: '5px 8px 5px 10px', cursor: 'pointer', whiteSpace: 'nowrap', fontSize: 12, borderRight: '1px solid var(--border)',
-                  color: activeFile === f ? 'var(--text-bright)' : 'var(--text-dim)',
-                  background: activeFile === f ? 'var(--bg-base)' : 'transparent',
-                  borderTop: `2px solid ${activeFile === f ? '#58a6ff' : 'transparent'}`,
-                }}>
-                <span style={{ display: 'inline-flex', transform: 'scale(0.72)' }}><FileTypeIcon name={f} /></span>
-                <span style={{ maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis' }}>{pathBasename(f)}</span>
-                {/* 关闭：脏文件平时显示橙点、hover tab 时变 ×（VSCode 行为）；干净文件常显 × */}
-                <a className="cc-tabx" onClick={(e) => { e.stopPropagation(); closeFileTab(f) }} title={isDirty ? t('file.unsaved') : t('file.closeTab')}>
-                  <span className="dot">●</span><span className="x">×</span>
-                </a>
-              </div>
-            )
-          })}
         </div>
       )}
-      {/* 标签栏（多会话）：单会话全屏页已用顶部标题栏代替，这里隐藏 */}
-      {fileDock !== 'left' && (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid var(--border)', overflowX: 'auto' }}>
-        {onCollapse && <Button size="small" type="text" style={{ color: 'var(--text-dim)' }} onClick={onCollapse}>✕ {t('common.collapse')}</Button>}
-        {terms.map((termName) => (
-          <span key={termName} onClick={() => setActive(termName)}
-            style={{
-              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 10px', borderRadius: 8, cursor: 'pointer', whiteSpace: 'nowrap',
-              background: termName === active ? '#1f6feb33' : 'transparent', border: termName === active ? '1px solid #1f6feb' : '1px solid var(--border)', color: 'var(--text-bright)',
-            }}>
-            <i style={{ width: 7, height: 7, borderRadius: '50%', background: termNeedsInput[termName] ? '#d29922' : (statusMap[termName] === 'connected' ? '#3fb950' : statusMap[termName] === 'connecting' ? '#d29922' : '#f85149') }} />
-            {termNeedsInput[termName] && <span title={t('prompt.confirmRequired')} style={{ color: '#d29922', fontSize: 12, fontWeight: 600 }}>{t('session.waiting')}</span>}
-            {claudeMap[termName]?.running && <span title={t('session.runningClaude')} style={{ color: '#58a6ff' }}>✳</span>}
-            {codexMap[termName]?.running && <span title={t('session.runningCodex')} style={{ color: '#10a37f' }}>✸</span>}
-            {termName}
-            <a onClick={(e) => { e.stopPropagation(); closeTerm(termName) }} style={{ color: 'var(--text-dim)' }}>×</a>
-          </span>
-        ))}
-      </div>
-      )}
-
-      {/* 工具栏：终端控制条，只属会话（第一个 tab）——看文件 tab 时隐藏 */}
-      {!viewingFile && (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)', flexWrap: 'wrap' }}>
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-dim)', fontSize: 12 }}>
-          <i style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
-          {activeNeedsInput ? t('session.waiting') : st === 'connected' ? t('terminal.status.connected') : st === 'connecting' ? t('terminal.status.connecting') : t('terminal.status.disconnected')}
-        </span>
-        {active && claudeMap[active]?.running && (
-          <Tooltip title={t('chat.switchToClaude')}>
-            <Button size="small" type={claudeView[active] ? 'primary' : 'default'}
-              onClick={() => setClaudeView((v) => ({ ...v, [active!]: !v[active!] }))}>✳ Claude</Button>
-          </Tooltip>
-        )}
-        {active && codexMap[active]?.running && (
-          <Tooltip title={t('chat.switchToCodex')}>
-            <Button size="small" type={codexView[active] ? 'primary' : 'default'}
-              style={codexView[active] ? { background: '#10a37f', borderColor: '#10a37f' } : {}}
-              onClick={() => setCodexView((v) => ({ ...v, [active!]: !v[active!] }))}>✸ Codex</Button>
-          </Tooltip>
-        )}
-        <Dropdown
-          trigger={['click']}
-          menu={{ items: tmuxMenu(t) as any, onClick: ({ key }) => sendKey(key) }}
-          placement="bottomLeft"
-        >
-          <Button size="small" type="primary" ghost>tmux ▾</Button>
-        </Dropdown>
-        {active && (
-          <Tooltip title={t('terminal.openInNewTabTitle')}>
-            <Button size="small" onClick={() => window.open(`/#/term/${encodeURIComponent(active)}`, '_blank')}>↗ {t('terminal.newTab')}</Button>
-          </Tooltip>
-        )}
-        {active && (
-          <Button size="small" onClick={() => setRenameSession(active)}>{t('session.rename')}</Button>
-        )}
-        <Tooltip title={promptOff ? t('prompt.popupOff') : t('prompt.popupOn')}>
-          <Button size="small" type={promptOff ? 'default' : 'primary'} ghost={!promptOff}
-            onClick={togglePromptOff}>{promptOff ? '🔕' : '🔔'} {t('prompt.popup')}</Button>
-        </Tooltip>
-        <Tooltip title={t('terminal.fileBrowserTitle')}>
-          <Button size="small" type={showFiles ? 'primary' : 'default'} onClick={toggleFiles}>📁 {t('chat.files')}</Button>
-        </Tooltip>
-        <Tooltip title={t('terminal.gitPanelTitle')}>
-          <Button size="small" type={showGit ? 'primary' : 'default'} onClick={toggleGit}
-            icon={<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ verticalAlign: '-2px' }}><circle cx="6" cy="6" r="2.3" /><circle cx="6" cy="18" r="2.3" /><circle cx="18" cy="8" r="2.3" /><path d="M6 8.3v7.4" /><path d="M18 10.3a6 6 0 0 1-6 6H8.3" /></svg>}>
-            {t('git.title')}
-          </Button>
-        </Tooltip>
-        <Tooltip title={showVoice ? t('voice.hideButton') : t('voice.showButton')}>
-          <Button size="small" type={showVoice ? 'primary' : 'default'} onClick={() => setShowVoice((v) => !v)}>🎤</Button>
-        </Tooltip>
-        <span style={{ flex: 1 }} />
-        <Tooltip title={t('terminal.scrollHistory')}><Button size="small" onClick={() => active && termRefs.current[active]?.scroll(-12)}>▲</Button></Tooltip>
-        <Tooltip title={t('terminal.toBottom')}><Button size="small" onClick={() => active && termRefs.current[active]?.toBottom()}>{t('terminal.bottomShort')}</Button></Tooltip>
-        <Tooltip title={t('terminal.decreaseFont')}><Button size="small" onClick={() => setFontSize(Math.max(10, fontSize - 1))}>A-</Button></Tooltip>
-        <Tooltip title={t('terminal.increaseFont')}><Button size="small" onClick={() => setFontSize(Math.min(22, fontSize + 1))}>A+</Button></Tooltip>
-        <Tooltip title={t('terminal.reconnect')}><Button size="small" onClick={() => active && termRefs.current[active]?.reconnect()}>{t('terminal.reconnectShort')}</Button></Tooltip>
-      </div>
-      )}
-
-      {/* 终端区（所有标签常驻，仅激活可见，保留滚动历史）。
-          支持从文件/Git 面板把文件拖进来 → 以 @相对路径 注入当前会话。 */}
-      <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}
-        onDragOver={(e) => { if (isPathDrag(e)) { allowPathDrop(e); setDragOver(true) } }}
-        onDragLeave={(e) => { if (e.currentTarget === e.target) setDragOver(false) }}
-        onDrop={onTermDrop}>
-        {dragOver && (
-          <div style={{
-            position: 'absolute', inset: 0, zIndex: 5, pointerEvents: 'none',
-            border: '2px dashed #58a6ff', borderRadius: 8, background: 'rgba(88,166,255,.08)',
-            display: 'grid', placeItems: 'center', color: '#58a6ff', fontSize: 14, fontWeight: 600,
-          }}>{t('terminal.dropToMention')}</div>
-        )}
-        <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
-          {terms.map((termName) => (
-            <div key={termName} style={{ position: 'absolute', inset: 0, display: termName === active ? 'block' : 'none', padding: 6 }}>
-              <Term ref={(h) => { termRefs.current[termName] = h }} name={termName} fontSize={fontSize} active={termName === active} onStatus={(s) => setStatus(termName, s)}
-                onContextMenu={({ x, y, selection }) => { setActive(termName); setCtx({ x, y, session: termName, selection }) }}
-                onSelectionMenu={({ selection }) => { setActive(termName); setCtx(null); if (selection.trim()) { copyText(selection); message.success(t('common.copied')) } }}
-                onPaste={() => { setActive(termName); pasteClipboard(termName) }}
-                onImagePaste={(files) => { setActive(termName); pasteImage(termName, files) }} />
-              {claudeView[termName] && claudeMap[termName]?.running && (
-                <div style={{ position: 'absolute', inset: 0 }}>
-                  <ClaudeChat name={termName} file={claudeMap[termName].file} dir={claudeMap[termName].dir} onBack={() => setClaudeView((v) => ({ ...v, [termName]: false }))} />
-                </div>
-              )}
-              {codexView[termName] && codexMap[termName]?.running && (
-                <div style={{ position: 'absolute', inset: 0 }}>
-                  <CodexChat name={termName} file={codexMap[termName].file} dir={codexMap[termName].dir} onBack={() => setCodexView((v) => ({ ...v, [termName]: false }))} />
-                </div>
-              )}
-              {/* 终端页右下角悬浮语音按钮：识别后字面量打进 pane，用户复查后自行回车（对话视图打开时由其自带按钮接管） */}
-              {showVoice && !claudeView[termName] && !codexView[termName] && (
-                <VoiceInput accent="#58a6ff" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(termName)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
-              )}
-            </div>
-          ))}
-          {/* 文件 tab：每个都常驻挂载（保留未保存编辑/滚动），仅激活的覆盖在终端上方 */}
-          {fileDock === 'left' && openFiles.map((f) => (
-            <div key={f} style={{ position: 'absolute', inset: 0, zIndex: 6, background: 'var(--bg-base)', display: activeFile === f ? 'block' : 'none' }}>
-              <Viewer path={f} accent="#58a6ff" inline tabbed active={activeFile === f} onClose={() => closeFileTab(f)} onOpenPath={openFileTab} onDirtyChange={setFileDirty} />
-            </div>
-          ))}
-        </div>
-      </div>
       {fileDock === 'right' && (
         <FloatingFileDrawer open={showFiles}>
           <FileBrowser dir={cwd} accent="#58a6ff" onClose={() => setShowFiles(false)} />
@@ -1141,53 +1086,6 @@ function TerminalPane(props: {
       <FloatingFileDrawer open={showGit}>
         <GitPanel dir={cwd} accent="#58a6ff" onClose={() => setShowGit(false)} />
       </FloatingFileDrawer>
-
-      {/* 移动端文字输入框：软键盘/输入法在 xterm 里会丢字，这里整行可靠发送到 PTY。
-          对话视图(Claude/Codex)有自己的输入框，这里隐藏避免双输入框。 */}
-      {isTouch && !inChat && !viewingFile && (
-        <div style={{ display: 'flex', gap: 6, padding: '8px 8px 0' }} onDragOver={allowPathDrop} onDrop={onInputDrop}>
-          <Input
-            ref={mobileInputRef}
-            value={line}
-            onFocus={exitCopyMode}
-            onChange={(e) => setLine(e.target.value)}
-            onPressEnter={(e) => { if ((e.nativeEvent as any).isComposing) return; submitLine() }}
-            placeholder={t('terminal.mobileInputPlaceholder')}
-            allowClear
-            autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false}
-          />
-          <Button type="primary" onMouseDown={noBlur} onClick={submitLine}>{t('common.send')}</Button>
-        </div>
-      )}
-
-      {/* 快捷键栏：对话视图/查看文件 tab 时隐藏（这条输入/快捷键栏只属会话，见 #3） */}
-      {!inChat && !viewingFile && (
-        <div style={{ display: 'flex', gap: 6, padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
-          <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
-          {(prefsData.quickCommands || []).map((cmd) => (
-            <Button key={cmd} onMouseDown={noBlur} onClick={() => { if (isTouch) { setLine(cmd); requestAnimationFrame(() => mobileInputRef.current?.focus()) } else { sendRaw(cmd) } }} style={{ flex: '0 0 auto' }}>{cmd}</Button>
-          ))}
-          {KEYS.map(([label, seq]) => (
-            <Button key={label} onMouseDown={noBlur} onClick={() => tapKey(seq)} style={{ flex: '0 0 auto' }}>{label}</Button>
-          ))}
-          <Button onMouseDown={noBlur} style={{ flex: '0 0 auto', borderStyle: 'dashed' }} onClick={() => {
-            let val = ''
-            modal.confirm({
-              title: t('settings.quickCommands'),
-              content: <Input placeholder={t('settings.quickCommandPlaceholder')} onChange={(e) => (val = e.target.value)} autoFocus />,
-              okText: t('quickCmd.addOk'),
-              onOk: () => {
-                const v = val.trim()
-                if (!v) return
-                if ((prefsData.quickCommands || []).includes(v)) return
-                savePreferences({ quickCommands: [...(prefsData.quickCommands || []), v] })
-              },
-            })
-          }}>{t('quickCmd.add')}</Button>
-        </div>
-      )}
-        </div>
-      </div>
     </div>
   )
 }

--- a/frontend/src/CodeEditor.tsx
+++ b/frontend/src/CodeEditor.tsx
@@ -31,12 +31,21 @@ export default function CodeEditor({
   onChange: (v: string) => void
   onSave: () => void
 }) {
+  // 让编辑器背景/装订线/缩略图跟应用统一（用 --bg-base，避免 Monaco 默认灰底跟四周不一致）。
+  const appBg = (typeof getComputedStyle !== 'undefined'
+    ? getComputedStyle(document.documentElement).getPropertyValue('--bg-base').trim()
+    : '') || (dark ? '#0d1117' : '#ffffff')
   return (
     <Editor
       height="100%"
       value={value}
       language={language}
-      theme={dark ? 'vs-dark' : 'vs'}
+      theme={dark ? 'roam-dark' : 'roam-light'}
+      beforeMount={(m) => {
+        const colors = { 'editor.background': appBg, 'editorGutter.background': appBg, 'minimap.background': appBg, 'editorStickyScroll.background': appBg }
+        m.editor.defineTheme('roam-dark', { base: 'vs-dark', inherit: true, rules: [], colors })
+        m.editor.defineTheme('roam-light', { base: 'vs', inherit: true, rules: [], colors })
+      }}
       onChange={(v) => onChange(v ?? '')}
       onMount={(editor, m) => {
         // Ctrl/Cmd+S 保存（onSave 读最新 draft，见 Viewer）
@@ -47,11 +56,11 @@ export default function CodeEditor({
         fontSize: 13,
         minimap: { enabled: true }, // 右侧代码缩略图：显示整段代码长度与当前所在位置（VSCode 同款）
         lineNumbers: 'on',
-        // 收紧行号与代码之间的缝隙：关掉字形边距/折叠栏、行号只留 2 位宽、去掉行装饰留白
+        // 行号装订线：关掉字形边距/折叠栏（那才是之前的大缝隙），保留 VSCode 同款行号↔代码间距
         glyphMargin: false,
         folding: false,
-        lineNumbersMinChars: 2,
-        lineDecorationsWidth: 2,
+        lineNumbersMinChars: 3,
+        lineDecorationsWidth: 10,
         scrollBeyondLastLine: false,
         automaticLayout: true,
         tabSize: 2,

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -408,7 +408,8 @@ export function Viewer({
 
   useEffect(() => {
     if (isImg || isPdf || isOffice) return // 图片/PDF/Office 直接走 raw 或专用面板
-    setData(null); setErr(''); setSource(false); setDraft('')
+    // tab 语境的 markdown 默认进编辑器（源码），点眼睛才切预览；非 tab（有头部）默认渲染。
+    setData(null); setErr(''); setSource(!!tabbed && MD_EXT.includes(extOf(path))); setDraft('')
     api('GET', `/file?path=${encodeURIComponent(path)}`).then((r) => { setData(r.data); setDraft(r.data?.content || '') }).catch((e) => setErr(e.message))
   }, [path, isImg, isPdf, isOffice])
 
@@ -528,8 +529,9 @@ export function Viewer({
                 : isMd && !source
                   ? <div style={{ height: previewHeight, overflow: 'auto' }}><Markdown accent={accent} resolveHref={resolvePreviewHref} onLinkClick={openPreviewLink}>{data.content}</Markdown></div>
                   : (
-                    // 文本/代码/JSON/Markdown(源码) → Monaco 编辑器（行号、语法高亮、可编辑；截断的大文件只读）
-                    <div style={{ height: previewHeight, border: '1px solid var(--border-subtle)', borderRadius: 8, overflow: 'hidden' }}>
+                    // 文本/代码/JSON/Markdown(源码) → Monaco 编辑器（行号、语法高亮、可编辑；截断的大文件只读）。
+                    // tab 语境下全屏无边框，背景由 CodeEditor 统一成应用底色。
+                    <div style={{ height: previewHeight, border: tabbed ? 'none' : '1px solid var(--border-subtle)', borderRadius: tabbed ? 0 : 8, overflow: 'hidden' }}>
                       <Suspense fallback={<div style={{ height: '100%', display: 'grid', placeItems: 'center' }}><Spin /></div>}>
                         <CodeEditor value={draft} language={monacoLangOf(path)} dark={mode === 'dark'} readOnly={!editable} onChange={setDraft} onSave={() => saveRef.current()} />
                       </Suspense>
@@ -557,8 +559,20 @@ export function Viewer({
   if (inline) {
     return (
       <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--bg-base)' }}>
-        <div style={{ padding: tabbed ? '4px 8px' : '9px 12px', borderBottom: '1px solid var(--border-subtle)' }}>{titleNode}</div>
-        <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', padding: tabbed ? '8px 8px 8px' : 12 }}>{bodyNode}</div>
+        {/* 编辑器 tab 语境(tabbed)：文件名/操作已由外层 tab 承担 → 去掉整条标题栏，编辑器全屏。保存用 Ctrl/Cmd+S。 */}
+        {!tabbed && <div style={{ padding: '9px 12px', borderBottom: '1px solid var(--border-subtle)' }}>{titleNode}</div>}
+        <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', padding: tabbed ? 0 : 12, position: 'relative' }}>
+          {bodyNode}
+          {/* tab 语境无头部：markdown 用右上角悬浮眼睛在「源码/预览」间切换 */}
+          {tabbed && isMd && data && !data.binary && (
+            <Tooltip title={source ? t('file.rendered') : t('file.source')} placement="left">
+              <button type="button" onClick={() => setSource((s) => !s)}
+                style={{ position: 'absolute', top: 8, right: 12, zIndex: 10, width: 30, height: 30, borderRadius: 6, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--border-subtle)', background: source ? 'var(--bg-container)' : accent, color: source ? 'var(--text-dim)' : '#fff' }}>
+                {source ? <EyeIcon /> : <CodeIcon />}
+              </button>
+            </Tooltip>
+          )}
+        </div>
       </div>
     )
   }
@@ -584,6 +598,40 @@ function formatJSON(text: string): string {
 
 function fence(lang: string, content: string): string {
   return '```' + lang + '\n' + content + '\n```'
+}
+
+// 统一：把文件绝对路径写进拖拽载荷（对话框识别 application/x-ttmux-path，其余认 text/plain）。
+function startPathDrag(ev: React.DragEvent, full: string) {
+  ev.dataTransfer.setData('application/x-ttmux-path', full)
+  ev.dataTransfer.setData('text/plain', full)
+  ev.dataTransfer.effectAllowed = 'copy'
+}
+
+// 统一：一行文件/目录的图标 + 名称 + 大小 + @插入 + 下载。平铺列表与树共用（外层容器各自处理缩进/展开）。
+function FileRowBody({ full, name, isDir, size, accent, onInsertPath }: {
+  full: string; name: string; isDir: boolean; size: number; accent: string; onInsertPath?: (p: string) => void
+}) {
+  const { t } = useI18n()
+  return (
+    <>
+      <span style={{ color: isDir ? accent : 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 22, justifyContent: 'center' }}>{isDir ? <FolderIcon /> : <FileTypeIcon name={name} />}</span>
+      <span style={{ color: 'var(--text-bright)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</span>
+      {!isDir && <span style={{ color: 'var(--text-dimmer)', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(size)}</span>}
+      {onInsertPath && (
+        <span data-file-action>
+          <IconButton title={t('file.insertPath')} onClick={() => onInsertPath(full)}>@</IconButton>
+        </span>
+      )}
+      {!isDir && (
+        <span data-file-action>
+          <Tooltip title={t('file.download')}>
+            <Button type="text" size="small" href={`/api/file/raw?path=${encodeURIComponent(full)}&dl=1`} download={name}
+              style={{ width: 24, height: 24, minWidth: 24, padding: 0, color: 'var(--text-dim)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><DownloadIcon /></Button>
+          </Tooltip>
+        </span>
+      )}
+    </>
+  )
 }
 
 // VSCode 风格可展开目录树：以 root 为根，子目录首次展开时懒加载（复用 GET /files?path=）。
@@ -636,36 +684,24 @@ function FileTree({
         <Fragment key={full}>
           <div className="cc-filerow"
             draggable
-            onDragStart={(ev) => {
-              ev.dataTransfer.setData('application/x-ttmux-path', full)
-              ev.dataTransfer.setData('text/plain', full)
-              ev.dataTransfer.effectAllowed = 'copy'
-            }}
+            onDragStart={(ev) => startPathDrag(ev, full)}
             onClick={(ev) => {
               if ((ev.target as HTMLElement).closest('[data-file-action]')) return
               e.dir ? toggleDir(full) : onOpenFile(full)
             }}
             onContextMenu={(ev) => { ev.preventDefault(); ev.stopPropagation(); onDeleteEntry(full, e.dir) }}
-            style={{ ...rowStyle(), gap: 4, paddingLeft: 8 + depth * 14, background: full === selected ? '#1f6feb22' : undefined }}>
-            <span style={{ flex: '0 0 auto', width: 14, display: 'inline-flex', justifyContent: 'center', color: 'var(--text-dim)' }}>
-              {e.dir ? <Chevron open={!!isOpen} /> : null}
-            </span>
-            <span style={{ color: e.dir ? accent : 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 22, justifyContent: 'center' }}>{e.dir ? <FolderIcon /> : <FileTypeIcon name={e.name} />}</span>
-            <span style={{ color: 'var(--text-bright)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
-            {!e.dir && <span style={{ color: 'var(--text-dimmer)', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(e.size)}</span>}
-            {onInsertPath && (
-              <span data-file-action>
-                <IconButton title={t('file.insertPath')} onClick={() => onInsertPath(full)}>@</IconButton>
+            style={{ ...rowStyle(), gap: 0, padding: 0, alignItems: 'stretch', minHeight: 26, background: full === selected ? '#1f6feb22' : undefined }}>
+            {/* VSCode 式层级缩进导引线：每深一层一条竖线，逐行拼成连续的层级线 */}
+            <span style={{ flex: '0 0 auto', width: 8 }} />
+            {Array.from({ length: depth }).map((_, i) => (
+              <span key={i} aria-hidden style={{ flex: '0 0 auto', width: 14, boxSizing: 'border-box', borderLeft: '1px solid var(--border-subtle)' }} />
+            ))}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0, padding: '4px 8px 4px 2px' }}>
+              <span style={{ flex: '0 0 auto', width: 14, display: 'inline-flex', justifyContent: 'center', color: 'var(--text-dim)' }}>
+                {e.dir ? <Chevron open={!!isOpen} /> : null}
               </span>
-            )}
-            {!e.dir && (
-              <span data-file-action>
-                <Tooltip title={t('file.download')}>
-                  <Button type="text" size="small" href={`/api/file/raw?path=${encodeURIComponent(full)}&dl=1`} download={e.name}
-                    style={{ width: 24, height: 24, minWidth: 24, padding: 0, color: 'var(--text-dim)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><DownloadIcon /></Button>
-                </Tooltip>
-              </span>
-            )}
+              <FileRowBody full={full} name={e.name} isDir={e.dir} size={e.size} accent={accent} onInsertPath={onInsertPath} />
+            </div>
           </div>
           {isOpen && (
             loading[full]
@@ -721,14 +757,13 @@ export default function FileBrowser({
   const [results, setResults] = useState<{ path: string; name: string; rel: string }[] | null>(null)
   const [searching, setSearching] = useState(false)
   const [searchTrunc, setSearchTrunc] = useState(false)
-  // 平铺列表 / VSCode 树 两种展示，仅会话内面板（sidebar/dock）可切；localStorage 记住选择。
-  // dock（新标签左侧）默认树模式，其余默认平铺；Files 页（split）始终平铺不带切换钮。
-  const canToggleView = layout !== 'split'
+  // 平铺列表 / VSCode 树 两种展示，所有文件面板都可切；localStorage 记住选择。
+  // dock（新标签左侧）与 split（独立 Files 页）默认树模式，会话右侧抽屉(sidebar)默认平铺。
+  const canToggleView = true
   const [browseMode, setBrowseMode] = useState<'flat' | 'tree'>(() => {
-    if (!canToggleView) return 'flat'
     const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('ttmux.fileBrowseMode') : null
     if (saved === 'tree' || saved === 'flat') return saved
-    return layout === 'dock' ? 'tree' : 'flat'
+    return layout === 'sidebar' ? 'flat' : 'tree'
   })
   useEffect(() => {
     if (canToggleView && typeof localStorage !== 'undefined') localStorage.setItem('ttmux.fileBrowseMode', browseMode)
@@ -908,7 +943,7 @@ export default function FileBrowser({
           <span style={{ flex: 1 }} />
           {onClose && <ClosePanelButton title={t('file.closePanel')} onClick={onClose} />}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'nowrap', overflowX: 'auto' }}>
           <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
             onChange={(e) => { if (e.target.files?.length) doUpload(e.target.files); e.target.value = '' }} />
           <IconButton title={t('file.back')} disabled={!canBack} onClick={goBack}><BackIcon /></IconButton>
@@ -996,7 +1031,7 @@ export default function FileBrowser({
               {searchTrunc && <div style={{ color: '#d29922', fontSize: 11, padding: '4px 10px' }}>{t('file.searchTruncated')}</div>}
               {(results || []).map((r) => (
                 <div key={r.path} className="cc-filerow" draggable title={r.rel}
-                  onDragStart={(ev) => { ev.dataTransfer.setData('application/x-ttmux-path', r.path); ev.dataTransfer.setData('text/plain', r.path); ev.dataTransfer.effectAllowed = 'copy' }}
+                  onDragStart={(ev) => startPathDrag(ev, r.path)}
                   onClick={() => openFile(r.path)}
                   style={{ ...rowStyle(), background: r.path === sel ? '#1f6feb22' : undefined }}>
                   <span style={{ color: 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 25, justifyContent: 'center' }}><FileTypeIcon name={r.name} /></span>
@@ -1019,45 +1054,22 @@ export default function FileBrowser({
         )}
         {browseMode === 'tree' ? (
           <FileTree root={cur} rootEntries={data?.entries || []} accent={accent} showHidden={showHidden} sortKey={sortKey} tick={tick} selected={sel} onOpenFile={openFile} onDeleteEntry={confirmDelete} onInsertPath={onInsertPath} />
-        ) : visibleEntries.map((e) => (
-          <div key={e.name} className="cc-filerow"
-            draggable
-            onDragStart={(ev) => {
-              const full = joinPath(cur, e.name)
-              ev.dataTransfer.setData('application/x-ttmux-path', full) // 给对话框识别用
-              ev.dataTransfer.setData('text/plain', full)
-              ev.dataTransfer.effectAllowed = 'copy'
-            }}
-            onClick={(ev) => {
-              if ((ev.target as HTMLElement).closest('[data-file-action]')) return
-              e.dir ? navigate(joinPath(cur, e.name)) : openFile(joinPath(cur, e.name))
-            }}
-            onContextMenu={(ev) => {
-              ev.preventDefault()
-              ev.stopPropagation()
-              confirmDelete(joinPath(cur, e.name), e.dir)
-            }}
-            style={{ ...rowStyle(), background: !e.dir && joinPath(cur, e.name) === sel ? '#1f6feb22' : undefined }}>
-            <span style={{ color: e.dir ? accent : 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 25, justifyContent: 'center' }}>{e.dir ? <FolderIcon /> : <FileTypeIcon name={e.name} />}</span>
-            <span style={{ color: e.dir ? 'var(--text-bright)' : 'var(--text-bright)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.name}</span>
-            {!e.dir && <span style={{ color: 'var(--text-dimmer)', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(e.size)}</span>}
-            {onInsertPath && (
-              <span data-file-action>
-                <IconButton title={t('file.insertPath')} onClick={() => onInsertPath(joinPath(cur, e.name))}>@</IconButton>
-              </span>
-            )}
-            {!e.dir && (
-              <>
-                <span data-file-action>
-                  <Tooltip title={t('file.download')}>
-                    <Button type="text" size="small" href={`/api/file/raw?path=${encodeURIComponent(joinPath(cur, e.name))}&dl=1`} download={e.name}
-                      style={{ width: 24, height: 24, minWidth: 24, padding: 0, color: 'var(--text-dim)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><DownloadIcon /></Button>
-                  </Tooltip>
-                </span>
-              </>
-            )}
-          </div>
-        ))}
+        ) : visibleEntries.map((e) => {
+          const full = joinPath(cur, e.name)
+          return (
+            <div key={e.name} className="cc-filerow"
+              draggable
+              onDragStart={(ev) => startPathDrag(ev, full)}
+              onClick={(ev) => {
+                if ((ev.target as HTMLElement).closest('[data-file-action]')) return
+                e.dir ? navigate(full) : openFile(full)
+              }}
+              onContextMenu={(ev) => { ev.preventDefault(); ev.stopPropagation(); confirmDelete(full, e.dir) }}
+              style={{ ...rowStyle(), background: !e.dir && full === sel ? '#1f6feb22' : undefined }}>
+              <FileRowBody full={full} name={e.name} isDir={e.dir} size={e.size} accent={accent} onInsertPath={onInsertPath} />
+            </div>
+          )
+        })}
         {data && data.entries.length === 0 && <div style={{ color: 'var(--text-dimmer)', fontSize: 12, padding: '6px 10px' }}>{t('file.emptyDirectory')}</div>}
         {browseMode !== 'tree' && data && data.entries.length > 0 && visibleEntries.length === 0 && (
           <div style={{ color: 'var(--text-dimmer)', fontSize: 12, padding: '6px 10px' }}>{t('file.allHidden', { count: hiddenCount })}</div>

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -1,0 +1,260 @@
+// 统一「文件工作区」：左侧文件浏览器(可拖拽调宽) + VSCode 式多文件编辑 tab + Monaco 编辑器。
+// 支持左右双栏(编辑组 A/B)：拖 tab 到另一栏、或从文件树拖文件到某栏；会话(终端)作为固定首 tab 常驻 A 栏。
+// 两处复用：独立 Files 页（纯文件）与新标签 SoloTerminal（会话经 leading* 槽传入）。
+import { type ReactNode, Fragment, useRef, useState } from 'react'
+import { App as AntApp } from 'antd'
+import FileBrowser, { Viewer, FileTypeIcon } from './FileBrowser'
+import { useI18n } from './i18n'
+
+type Group = 'A' | 'B'
+const TAB_MIME = 'application/x-ttmux-tab'
+const PATH_MIME = 'application/x-ttmux-path'
+const LEAD_MIME = 'application/x-ttmux-lead' // 拖会话(首)tab → 左右易位
+
+function baseName(p: string): string {
+  return p.split('/').pop() || p
+}
+
+export default function FileWorkspace({
+  dir,
+  accent = '#58a6ff',
+  onOpenAgent,
+  explorerOpen = true,
+  onExplorerClose,
+  leadingTab,
+  leadingTitle,
+  leadingContent,
+  chrome,
+  footer,
+  emptyText,
+}: {
+  dir: string
+  accent?: string
+  onOpenAgent?: (kind: 'claude' | 'codex', path: string) => void
+  explorerOpen?: boolean
+  onExplorerClose?: () => void
+  leadingTab?: ReactNode
+  leadingTitle?: string
+  leadingContent?: ReactNode
+  chrome?: ReactNode
+  footer?: ReactNode
+  emptyText?: string
+}) {
+  const { t } = useI18n()
+  const { modal } = AntApp.useApp()
+  const hasLeading = leadingTab != null
+
+  // 两个编辑组：A 主（含固定首 tab）、B 副（filesB 非空时出现，即分栏）
+  const [filesA, setFilesA] = useState<string[]>([])
+  const [filesB, setFilesB] = useState<string[]>([])
+  const [activeA, setActiveA] = useState<string | null>(null) // null = 固定首 tab(会话)
+  const [activeB, setActiveB] = useState<string | null>(null)
+  const [focus, setFocus] = useState<Group>('A')
+  const [dirtyFiles, setDirtyFiles] = useState<Set<string>>(new Set())
+  const [dropHint, setDropHint] = useState<Group | 'split' | null>(null) // 拖拽落点提示
+  const split = filesB.length > 0
+
+  const filesOf = (g: Group) => (g === 'A' ? filesA : filesB)
+  const setFilesOf = (g: Group, v: string[]) => (g === 'A' ? setFilesA(v) : setFilesB(v))
+  const activeOf = (g: Group) => (g === 'A' ? activeA : activeB)
+  const setActiveOf = (g: Group, v: string | null) => (g === 'A' ? setActiveA(v) : setActiveB(v))
+
+  const setFileDirty = (p: string, dirty: boolean) => setDirtyFiles((prev) => {
+    if (prev.has(p) === dirty) return prev
+    const n = new Set(prev); dirty ? n.add(p) : n.delete(p); return n
+  })
+
+  // 在某组打开文件；若已在另一组则跳到那一组，避免同一文件跨组重复
+  const openInGroup = (p: string, g: Group) => {
+    const other: Group = g === 'A' ? 'B' : 'A'
+    if (filesOf(other).includes(p)) { setActiveOf(other, p); setFocus(other); return }
+    if (!filesOf(g).includes(p)) setFilesOf(g, [...filesOf(g), p])
+    setActiveOf(g, p); setFocus(g)
+  }
+  const openFileTab = (p: string) => openInGroup(p, split ? focus : 'A')
+
+  const neighbor = (arr: string[], removedIdx: number, g: Group): string | null => {
+    const next = arr
+    return next[removedIdx - 1] ?? next[removedIdx] ?? (g === 'A' && hasLeading ? null : (next[0] ?? null))
+  }
+  const doClose = (p: string, g: Group) => {
+    const arr = filesOf(g)
+    const i = arr.indexOf(p)
+    if (i < 0) return
+    const next = arr.filter((x) => x !== p)
+    setFilesOf(g, next)
+    setFileDirty(p, false)
+    if (activeOf(g) === p) setActiveOf(g, neighbor(next, i, g))
+    if (g === 'B' && next.length === 0) setFocus('A')
+  }
+  const closeFileTab = (p: string, g: Group) => {
+    if (dirtyFiles.has(p)) {
+      modal.confirm({
+        title: t('file.closeUnsavedTitle'), content: baseName(p),
+        okText: t('file.closeWithoutSaving'), cancelText: t('common.cancel'),
+        okButtonProps: { danger: true }, onOk: () => doClose(p, g),
+      })
+    } else doClose(p, g)
+  }
+  // 把 tab 从 from 组移到 to 组（拖拽到另一栏）
+  const moveTab = (p: string, from: Group, to: Group) => {
+    if (from === to) { setActiveOf(to, p); setFocus(to); return }
+    const fromArr = filesOf(from)
+    const i = fromArr.indexOf(p)
+    const fromNext = fromArr.filter((x) => x !== p)
+    setFilesOf(from, fromNext)
+    if (activeOf(from) === p) setActiveOf(from, neighbor(fromNext, i, from))
+    if (!filesOf(to).includes(p)) setFilesOf(to, [...filesOf(to), p])
+    setActiveOf(to, p); setFocus(to)
+    if (from === 'B' && fromNext.length === 0) setFocus('A')
+  }
+
+  const leadingActive = hasLeading && activeA === null
+
+  // 两栏：宽度比(左栏占比，拖分隔条调整) + 左右易位
+  const panesRef = useRef<HTMLDivElement>(null)
+  const [splitFrac, setSplitFrac] = useState(0.5)
+  const [swapped, setSwapped] = useState(false)
+  const leftGroup: Group = swapped ? 'B' : 'A'
+  const startSplitResize = (e: React.PointerEvent) => {
+    e.preventDefault()
+    document.body.style.userSelect = 'none'; document.body.style.cursor = 'col-resize'
+    const move = (ev: PointerEvent) => {
+      const el = panesRef.current; if (!el) return
+      const r = el.getBoundingClientRect(); if (r.width <= 0) return
+      setSplitFrac(Math.min(0.85, Math.max(0.15, (ev.clientX - r.left) / r.width)))
+    }
+    const up = () => {
+      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up)
+      document.body.style.userSelect = ''; document.body.style.cursor = ''
+    }
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up)
+  }
+
+  // 左侧文件栏宽度：可拖拽调整，记 localStorage
+  const [dockW, setDockW] = useState(() => { const s = Number(localStorage.getItem('ttmux.fileDockW')); return s >= 160 && s <= 640 ? s : 280 })
+  const dockWRef = useRef(dockW)
+  dockWRef.current = dockW
+  const startResize = (e: React.PointerEvent) => {
+    e.preventDefault()
+    const startX = e.clientX, startW = dockW
+    document.body.style.userSelect = 'none'; document.body.style.cursor = 'col-resize'
+    const move = (ev: PointerEvent) => setDockW(Math.min(640, Math.max(160, startW + ev.clientX - startX)))
+    const up = () => {
+      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up)
+      document.body.style.userSelect = ''; document.body.style.cursor = ''
+      localStorage.setItem('ttmux.fileDockW', String(dockWRef.current))
+    }
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up)
+  }
+
+  const dragHasPayload = (e: React.DragEvent) => e.dataTransfer.types.includes(TAB_MIME) || e.dataTransfer.types.includes(PATH_MIME) || e.dataTransfer.types.includes(LEAD_MIME)
+  const applyDrop = (e: React.DragEvent, to: Group) => {
+    if (e.dataTransfer.types.includes(LEAD_MIME)) { setSwapped(to !== leftGroup); return } // 会话拖到某栏 → 会话那栏挪到该侧
+    const tab = e.dataTransfer.getData(TAB_MIME)
+    if (tab) { try { const { path, from } = JSON.parse(tab); moveTab(path, from, to) } catch {} ; return }
+    const p = e.dataTransfer.getData(PATH_MIME)
+    if (p) openInGroup(p, to)
+  }
+
+  const tabBase: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', whiteSpace: 'nowrap', fontSize: 12, cursor: 'pointer', borderRight: '1px solid var(--border)' }
+
+  const fileTab = (f: string, g: Group) => {
+    const isDirty = dirtyFiles.has(f)
+    const act = activeOf(g) === f
+    return (
+      <div key={g + f} title={f} draggable
+        onDragStart={(e) => { e.dataTransfer.setData(TAB_MIME, JSON.stringify({ path: f, from: g })); e.dataTransfer.effectAllowed = 'move' }}
+        onClick={() => { setActiveOf(g, f); setFocus(g) }}
+        className={`cc-filetab${isDirty ? ' dirty' : ''}`}
+        style={{ ...tabBase, gap: 3, padding: '5px 8px 5px 10px', color: act ? 'var(--text-bright)' : 'var(--text-dim)', background: act ? 'var(--bg-base)' : 'transparent', borderTop: `2px solid ${act ? '#58a6ff' : 'transparent'}` }}>
+        <span style={{ display: 'inline-flex', transform: 'scale(0.72)' }}><FileTypeIcon name={f} /></span>
+        <span style={{ maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis' }}>{baseName(f)}</span>
+        <a className="cc-tabx" onClick={(e) => { e.stopPropagation(); closeFileTab(f, g) }} title={isDirty ? t('file.unsaved') : t('file.closeTab')}>
+          <span className="dot">●</span><span className="x">×</span>
+        </a>
+      </div>
+    )
+  }
+
+  // 渲染一个编辑组（栏）：tab 条 + 内容（会话内容仅 A 栏；文件用 Monaco 覆盖）
+  const pane = (g: Group) => {
+    const primary = g === 'A'
+    const files = filesOf(g)
+    const active = activeOf(g)
+    const grow = !split ? 1 : (g === leftGroup ? splitFrac : 1 - splitFrac)
+    return (
+      <div style={{ flex: `${grow} 1 0`, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+        onClick={() => setFocus(g)}>
+        <div style={{ display: 'flex', alignItems: 'stretch', borderBottom: '1px solid var(--border)', background: 'var(--bg-container)' }}>
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'stretch', overflowX: 'auto' }}
+            onDragOver={(e) => { if (dragHasPayload(e)) { e.preventDefault(); setDropHint(g) } }}
+            onDragLeave={() => setDropHint((h) => (h === g ? null : h))}
+            onDrop={(e) => { if (dragHasPayload(e)) { e.preventDefault(); setDropHint(null); applyDrop(e, g) } }}>
+            {primary && hasLeading && (
+              <div onClick={() => setActiveOf('A', null)} title={leadingTitle}
+                draggable={split}
+                onDragStart={(e) => { e.dataTransfer.setData(LEAD_MIME, '1'); e.dataTransfer.effectAllowed = 'move' }}
+                style={{ ...tabBase, gap: 6, padding: '5px 12px', color: leadingActive ? 'var(--text-bright)' : 'var(--text-dim)', background: leadingActive ? 'var(--bg-base)' : 'transparent', borderTop: `2px solid ${leadingActive ? '#58a6ff' : 'transparent'}` }}>
+                {leadingTab}
+              </div>
+            )}
+            {files.map((f) => fileTab(f, g))}
+            {dropHint === g && <div style={{ flex: 1, minWidth: 24, background: 'rgba(88,166,255,.18)' }} />}
+          </div>
+        </div>
+        {/* 会话工具栏：只属会话，放在会话首 tab 的正下方、终端之上（跟着会话那栏走） */}
+        {primary && leadingActive && chrome}
+        <div style={{ flex: 1, minWidth: 0, minHeight: 0, position: 'relative', display: 'flex' }}
+          onDragOver={(e) => { if (dragHasPayload(e)) { e.preventDefault(); if (!split && primary) setDropHint('split'); else setDropHint(g) } }}
+          onDragLeave={(e) => { if (e.currentTarget === e.target) setDropHint(null) }}
+          onDrop={(e) => {
+            if (!dragHasPayload(e)) return
+            e.preventDefault()
+            const target: Group = (!split && primary && dropHint === 'split') ? 'B' : g
+            setDropHint(null); applyDrop(e, target)
+          }}>
+          {primary && leadingContent}
+          {files.map((f) => (
+            <div key={f} style={{ position: 'absolute', inset: 0, zIndex: 6, background: 'var(--bg-base)', display: active === f ? 'block' : 'none' }}>
+              <Viewer path={f} accent={accent} inline tabbed active={active === f} onClose={() => closeFileTab(f, g)} onOpenPath={(p) => openInGroup(p, g)} onDirtyChange={setFileDirty} onOpenAgent={onOpenAgent} />
+            </div>
+          ))}
+          {(!primary || !hasLeading) && active === null && files.length === 0 && (
+            <div style={{ flex: 1, display: 'grid', placeItems: 'center', color: 'var(--text-dimmer)', fontSize: 13 }}>{emptyText || t('file.selectPreview')}</div>
+          )}
+          {/* 单栏时拖到右半区 → 拆出第二栏 */}
+          {!split && primary && dropHint === 'split' && (
+            <div style={{ position: 'absolute', top: 0, right: 0, bottom: 0, width: '50%', zIndex: 20, pointerEvents: 'none', background: 'rgba(88,166,255,.12)', borderLeft: '2px dashed #58a6ff', display: 'grid', placeItems: 'center', color: '#58a6ff', fontSize: 13, fontWeight: 600 }}>{t('file.splitHere')}</div>
+          )}
+        </div>
+        {/* 会话底部输入/快捷键栏：只属会话，放在会话那栏终端下方 */}
+        {primary && leadingActive && footer}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+      {explorerOpen && (
+        <>
+          <div style={{ flex: `0 0 ${dockW}px`, minWidth: 0, minHeight: 0, display: 'flex' }}>
+            <FileBrowser dir={dir} accent={accent} layout="dock" onClose={onExplorerClose} onOpenFile={openFileTab} selectedPath={activeA} onOpenAgent={onOpenAgent} />
+          </div>
+          <div onPointerDown={startResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
+        </>
+      )}
+      <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        <div ref={panesRef} style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+          {(split ? (swapped ? ['B', 'A'] : ['A', 'B']) : ['A'] as Group[]).map((g, i) => (
+            // key 按组固定 → 易位/分栏时 React 不重挂终端(会话)，PTY/xterm 不断
+            <Fragment key={g}>
+              {i > 0 && <div onPointerDown={startSplitResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />}
+              {pane(g as Group)}
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -250,6 +250,8 @@ const enUS = {
   'file.closeUnsavedTitle': 'Close without saving?',
   'file.closeWithoutSaving': 'Close without saving',
   'file.dragResize': 'Drag to resize',
+  'file.splitHere': 'Drop here to split',
+  'file.swapPanes': 'Swap left/right',
   'file.searchFiles': 'Search files by name (recursive, regex/glob)',
   'file.searchPlaceholder': 'Filter files — text, glob or regex (e.g. a*.py)…',
   'file.noMatches': 'No matching files',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -250,6 +250,8 @@ const zhCN = {
   'file.closeUnsavedTitle': '关闭未保存的文件？',
   'file.closeWithoutSaving': '不保存并关闭',
   'file.dragResize': '拖拽调整宽度',
+  'file.splitHere': '拖到这里分栏',
+  'file.swapPanes': '左右易位',
   'file.searchFiles': '按文件名递归搜索（支持 glob/正则）',
   'file.searchPlaceholder': '搜索文件 —— 文字、通配或正则（如 a*.py）…',
   'file.noMatches': '没有匹配的文件',


### PR DESCRIPTION
## 概述
把「文件管理」抽成统一组件 **`FileWorkspace`**（左文件树 + 多文件编辑 tab + Monaco 编辑器），独立 Files 页与新标签 SoloTerminal 复用；并加入 VSCode 式**双栏编辑**。

## 主要改动
- **FileWorkspace 统一组件**：左侧文件树(可拖拽调宽) + 多文件编辑 tab + Monaco；Files 页因此也获得多 tab 编辑（无终端），SoloTerminal 把会话作为固定首 tab 经槽位传入。
- **双栏编辑**：
  - 拖文件 tab / 从文件树拖文件到内容区右半 → 拆出第二栏
  - 拖 tab 在两栏之间移动
  - 拖**会话 tab** 左右易位（可把对话放到右边）
  - 拖两栏中缝调整宽度比；关掉一栏最后一个 tab 自动收回单栏
  - 按组固定 React key → 易位/分栏时终端不重挂（PTY/xterm 不断）
- **会话工具栏/底部输入栏** 移到会话那一栏（首 tab 正下方、终端上下），跟随会话栏。
- **编辑器**：tab 语境全屏无标题栏（保存走 Ctrl/Cmd+S、脏点在 tab 上）；自定义主题把编辑器/装订线/minimap 背景统一成 `--bg-base`；装订线收紧 + 开 minimap；markdown 右上角**眼睛**在源码/预览间切换。
- **复用抽象**：`TerminalPane` 会话部件抽成 `sessionTab/tabStrip/sessionToolbar/terminalArea/sessionBottom`，左右两种布局共用；文件行渲染抽 `startPathDrag/FileRowBody`（平铺/树/搜索共用）。
- **内存**：仅激活的文件 tab 挂载 Monaco（其余占位保留 state），避免多实例 OOM。

## 说明
- 未包含浏览器镜像的临时诊断代码（`screencast.go` / `BrowserView.tsx`，标注「查完删」），故本 PR 不含。
- 已过本地质量门：i18n 审计、`tsc --noEmit`、go tests、`vite build`。交互（拖拽分栏/易位/调宽、md 眼睛、终端 @mention 不误分栏）建议再实跑确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)