### PR TITLE
修复 macOS TCC 保护目录导致 /api/files 无限阻塞

### DIFF
--- a/backend/api/files.go
+++ b/backend/api/files.go
@@ -73,8 +73,8 @@ func (a *API) Files(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": p, "parent": filepath.Dir(p), "entries": list}})
 	case <-time.After(3 * time.Second):
 		c.JSON(http.StatusGatewayTimeout, gin.H{"error": gin.H{
-			"code":    "DIR_ACCESS_TIMEOUT",
-			"message": fmt.Sprintf("读取目录超时（可能是 macOS 隐私权限未授权）。请在「系统设置 → 隐私与安全性 → 完全磁盘访问权限」中授权 ttmux-web，或将其移到终端(Terminal)的授权下运行。路径: %s", p),
+			"code": "DIR_ACCESS_TIMEOUT",
+			"path": p,
 		}})
 	}
 }

--- a/backend/api/files.go
+++ b/backend/api/files.go
@@ -30,6 +30,7 @@ type fileEntry struct {
 }
 
 // Files GET /files?path=<dir> —— 列出目录内容（目录在前，按名排序）。
+// macOS TCC 保护目录（~/Downloads 等）在无权限时 ReadDir 会无限阻塞，因此加超时兜底。
 func (a *API) Files(c *gin.Context) {
 	p := c.Query("path")
 	if p == "" {
@@ -37,28 +38,45 @@ func (a *API) Files(c *gin.Context) {
 		p = home
 	}
 	p = filepath.Clean(p)
-	entries, err := os.ReadDir(p)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "FS_ERROR", "message": err.Error()}})
-		return
+
+	type readResult struct {
+		entries []os.DirEntry
+		err     error
 	}
-	list := []fileEntry{}
-	for _, e := range entries {
-		var size, mtime, ctime int64
-		if info, err := e.Info(); err == nil {
-			size = info.Size()
-			mtime = info.ModTime().Unix()
-			ctime = fileCtime(info)
+	ch := make(chan readResult, 1)
+	go func() {
+		entries, err := os.ReadDir(p)
+		ch <- readResult{entries, err}
+	}()
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "FS_ERROR", "message": res.err.Error()}})
+			return
 		}
-		list = append(list, fileEntry{Name: e.Name(), Dir: e.IsDir(), Size: size, Mtime: mtime, Ctime: ctime})
+		list := []fileEntry{}
+		for _, e := range res.entries {
+			var size, mtime, ctime int64
+			if info, err := e.Info(); err == nil {
+				size = info.Size()
+				mtime = info.ModTime().Unix()
+				ctime = fileCtime(info)
+			}
+			list = append(list, fileEntry{Name: e.Name(), Dir: e.IsDir(), Size: size, Mtime: mtime, Ctime: ctime})
+		}
+		sort.Slice(list, func(i, j int) bool {
+			if list[i].Dir != list[j].Dir {
+				return list[i].Dir
+			}
+			return list[i].Name < list[j].Name
+		})
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": p, "parent": filepath.Dir(p), "entries": list}})
+	case <-time.After(3 * time.Second):
+		c.JSON(http.StatusGatewayTimeout, gin.H{"error": gin.H{
+			"code":    "DIR_ACCESS_TIMEOUT",
+			"message": fmt.Sprintf("读取目录超时（可能是 macOS 隐私权限未授权）。请在「系统设置 → 隐私与安全性 → 完全磁盘访问权限」中授权 ttmux-web，或将其移到终端(Terminal)的授权下运行。路径: %s", p),
+		}})
 	}
-	sort.Slice(list, func(i, j int) bool {
-		if list[i].Dir != list[j].Dir {
-			return list[i].Dir // 目录排前
-		}
-		return list[i].Name < list[j].Name
-	})
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": p, "parent": filepath.Dir(p), "entries": list}})
 }
 
 const fileReadCap = 512 * 1024 // 单文件正文上限，超出截断

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -853,7 +853,7 @@ export default function FileBrowser({
     const q = path ? `?path=${encodeURIComponent(path)}` : ''
     api('GET', `/files${q}`)
       .then((r) => { if (!stop) setData(r.data) })
-      .catch((e) => { if (!stop) setErr(e.message) })
+      .catch((e: any) => { if (!stop) setErr(e.apiError?.code === 'DIR_ACCESS_TIMEOUT' ? t('file.dirAccessTimeout', { path: e.apiError.path || path }) : e.message) })
       .finally(() => { if (!stop) setLoading(false) })
     return () => { stop = true }
   }, [path, tick])

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -18,8 +18,11 @@ export async function api(method: string, path: string, body?: any): Promise<any
   const ct = r.headers.get('content-type') || ''
   const data = ct.includes('json') ? await r.json() : await r.text()
   if (!r.ok) {
-    const msg = data?.error?.message || data?.error?.code || 'HTTP ' + r.status
-    throw new Error(msg)
+    const errObj = data?.error || {}
+    const msg = errObj.message || errObj.code || 'HTTP ' + r.status
+    const err = new Error(msg) as Error & { apiError?: Record<string, any> }
+    err.apiError = errObj
+    throw err
   }
   return data
 }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -208,6 +208,7 @@ const enUS = {
   'file.officePreview': 'Office to PDF preview',
   'file.officePreviewHelp': 'Preview depends on local LibreOffice/soffice conversion.',
   'file.binaryCannotPreview': 'Binary file cannot be previewed ({size}). ',
+  'file.dirAccessTimeout': 'Directory read timed out (likely macOS privacy permission not granted). Please grant Full Disk Access to ttmux-web in System Settings → Privacy & Security. Path: {path}',
   'file.downloadOrOpenRaw': 'Download/open raw file',
   'file.jsonPreview': 'JSON structure preview',
   'file.codePreview': '{lang} code preview',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -208,6 +208,7 @@ const zhCN = {
   'file.officePreview': 'Office 转 PDF 预览',
   'file.officePreviewHelp': '预览依赖本机 LibreOffice/soffice 转换。',
   'file.binaryCannotPreview': '二进制文件，无法预览（{size}）。',
+  'file.dirAccessTimeout': '读取目录超时（可能是 macOS 隐私权限未授权）。请在「系统设置 → 隐私与安全性 → 完全磁盘访问权限」中授权 ttmux-web。路径: {path}',
   'file.downloadOrOpenRaw': '下载/打开原始文件',
   'file.jsonPreview': 'JSON 结构预览',
   'file.codePreview': '{lang} 代码预览',


### PR DESCRIPTION
## Summary
- macOS TCC 隐私权限机制会阻止未授权进程访问 `~/Downloads`、`~/Documents`、`~/Desktop` 等受保护目录
- 当 `ttmux-web` 以守护进程方式运行且未获得「完全磁盘访问权限」时，`os.ReadDir` 会无限阻塞（等待永远不会出现的授权弹窗），导致 `/api/files` 请求挂死
- 修复：将 `ReadDir` 放入 goroutine 并加 3 秒超时，超时后返回 504 + 明确错误提示，引导用户到系统设置授权

## 复现
1. 在 macOS 上以 `nohup`/`launchd` 方式启动 `ttmux-web`（不通过 Terminal.app 启动）
2. 在文件浏览器中导航到 `~/Downloads`
3. 请求会无限挂起，永远不返回

## Test plan
- [ ] macOS 上未授权 FDA 时，访问 ~/Downloads 3 秒后返回超时错误提示
- [ ] 已授权 FDA 或非受保护目录（如 ~/GitHub）正常列出文件
- [ ] Linux 上行为不变（无 TCC 机制，ReadDir 不会阻塞）

🤖 Generated with [Claude Code](https://claude.com/claude-code)