### PR TITLE
fix(phone): 修复安装安卓依赖时卡住（孤儿进程持锁）

### DIFF
--- a/backend/phone/handlers.go
+++ b/backend/phone/handlers.go
@@ -9,10 +9,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+// installMu 串行化平台依赖安装：避免前端多次点/多标签并发触发多个 brew install，
+// 互相撞下载锁导致全部失败、UI 卡住。第二个请求直接快速返回“安装进行中”。
+var installMu sync.Mutex
 
 func inPath(name string) bool { _, err := exec.LookPath(name); return err == nil }
 
@@ -65,6 +70,16 @@ func Install(c *gin.Context) {
 	script := findScript("phone/install-phone.sh")
 	if script == "" {
 		c.JSON(http.StatusOK, gin.H{"error": "找不到 scripts/phone/install-phone.sh,请手动安装依赖（Android: adb；iOS: idb）"})
+		return
+	}
+	if !installMu.TryLock() {
+		c.JSON(http.StatusOK, gin.H{"error": "已有依赖安装在进行中，请稍候（勿重复点击）"})
+		return
+	}
+	defer installMu.Unlock()
+	// 上锁后二次确认：可能刚好被上一个安装装好了，避免多余的一趟 brew。
+	if platformInstalled(body.Platform) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"installed": true, "log": "依赖已就绪"}})
 		return
 	}
 	out, _ := runCmd(180*time.Second, "bash", script, body.Platform)

--- a/backend/phone/ios.go
+++ b/backend/phone/ios.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -38,8 +39,12 @@ func (d *iosDevice) target() string {
 func haveIDB() bool { _, err := exec.LookPath("idb"); return err == nil }
 
 // runCmd 跑任意命令并带超时，返回 stdout（出错带 stderr 摘要）。
+// 用独立进程组启动：超时时 kill 整个进程组，连带杀掉命令 spawn 的子进程
+// （如 bash→brew→curl）。否则只杀父进程会留下孤儿——brew 下载孤儿仍持有下载锁，
+// 导致下次安装撞锁失败（“已被另一个 brew install 进程锁定”）。
 func runCmd(timeout time.Duration, name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // 自成进程组，pgid = pid
 	var out, errb bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
@@ -59,6 +64,10 @@ func runCmd(timeout time.Duration, name string, args ...string) ([]byte, error) 
 		}
 		return out.Bytes(), nil
 	case <-time.After(timeout):
+		// 负 pid = 向整个进程组发信号；先 TERM 给子进程善后机会，再兜底 KILL。
+		pgid := cmd.Process.Pid
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		go func() { time.Sleep(2 * time.Second); _ = syscall.Kill(-pgid, syscall.SIGKILL) }()
 		_ = cmd.Process.Kill()
 		return nil, fmt.Errorf("%s 超时", name)
 	}

--- a/scripts/phone/install-phone.sh
+++ b/scripts/phone/install-phone.sh
@@ -14,11 +14,28 @@ OS="$(uname -s 2>/dev/null || echo unknown)"
 say()  { echo "$*"; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# brew_install <cask|formula...>：跑 brew install 并透传真实退出码/输出。
+# 撞下载锁（上次安装的孤儿进程残留）时，清掉陈旧的 .incomplete 半成品后重试一次，
+# 避免反复报“已被另一个 brew install 进程锁定”而永远装不上。
+brew_install() {
+    local out rc
+    out="$(brew install "$@" 2>&1)"; rc=$?
+    echo "$out"
+    if [ $rc -ne 0 ] && echo "$out" | grep -q "has already locked"; then
+        say "↳ 撞到陈旧下载锁，清理半成品后重试…"
+        find "$(brew --cache 2>/dev/null || echo "$HOME/Library/Caches/Homebrew")/downloads" \
+            -name '*.incomplete' -mmin +1 -delete 2>/dev/null || true
+        out="$(brew install "$@" 2>&1)"; rc=$?
+        echo "$out"
+    fi
+    return $rc
+}
+
 install_adb() {
     have adb && { say "✔ adb 已就绪（$(adb version 2>/dev/null | head -1)）"; return 0; }
     case "$OS" in
         Darwin)
-            if have brew; then say "brew install android-platform-tools…"; brew install android-platform-tools 2>&1 || true
+            if have brew; then say "brew install android-platform-tools…"; brew_install android-platform-tools || true
             else say "需先装 Homebrew(https://brew.sh)再 brew install android-platform-tools"; fi ;;
         Linux)
             if have apt-get; then say "apt 安装 adb…"; sudo -n apt-get install -y adb 2>&1 || say "↳ 需 sudo:sudo apt-get install -y adb"
@@ -34,7 +51,7 @@ install_idb() {
     [ "$OS" = Darwin ] || { say "✘ idb 仅 macOS(iOS 模拟器);当前 $OS"; return 1; }
     have xcrun || say "⚠ 需 Xcode 命令行工具:xcode-select --install"
     have idb && { say "✔ idb 已就绪"; return 0; }
-    if have brew; then say "brew install idb-companion…"; brew install idb-companion 2>&1 || true
+    if have brew; then say "brew install idb-companion…"; brew_install idb-companion || true
     else say "需先装 Homebrew(https://brew.sh)"; fi
     if have pip3; then say "pip3 install fb-idb…"; pip3 install --user fb-idb 2>&1 || true
     else say "需 pip3 再 pip3 install fb-idb"; fi


### PR DESCRIPTION
## 问题

设置页打开「Android」平台开关触发安装依赖时会**卡住**，日志反复报 `✘ adb 仍未就绪`，并伴随：

```
Error: A `brew install android-platform-tools` process has already locked
/Users/.../platform-tools_r37.0.0-darwin.zip.incomplete.
```

## 根因

`runCmd` 超时后只 `Process.Kill()` 杀了 bash 父进程，`brew`/`curl` 子进程变成**孤儿继续运行并持有 Homebrew 下载锁**。用户再次点击安装时，新的 brew 撞到这个锁立即失败 → 反复"未就绪"、UI 卡死。

## 修复

- **孤儿进程（根因）** `backend/phone/ios.go`：`runCmd` 用独立进程组(`Setpgid`)启动，超时时 `Kill(-pgid)` 发信号给整个进程组（`SIGTERM`→兜底 `SIGKILL`），连带杀掉 `bash→brew→curl` 子进程链，不再留孤儿持锁。
- **撞锁自愈 + 错误透传** `scripts/phone/install-phone.sh`：新增 `brew_install` 包装，透传 brew 真实退出码/输出；检测到 `has already locked` 时清理陈旧 `.incomplete` 后自动重试一次。adb/idb 均改走它。
- **安装互斥** `backend/phone/handlers.go`：`installMu.TryLock()` 防止多次点击/多标签并发触发多个 brew 互撞下载锁；上锁后二次确认已装则直接返回。

## 验证

- 后端 `go build` + `go vet` 通过
- 脚本 `bash -n` 语法通过
- 单测验证进程组 `Kill(-pgid)` 能连带清除 bash spawn 的子孙进程，无孤儿残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)