### PR TITLE
修复文件拖拽到终端后覆盖层不消失的问题

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -683,6 +683,12 @@ function TerminalPane(props: {
 
   // 从文件/Git 面板把文件拖到终端 → 插入为 @绝对路径。
   const [dragOver, setDragOver] = useState(false)
+  useEffect(() => {
+    const clear = () => setDragOver(false)
+    document.addEventListener('dragend', clear)
+    document.addEventListener('drop', clear, true)
+    return () => { document.removeEventListener('dragend', clear); document.removeEventListener('drop', clear, true) }
+  }, [])
   // 拖拽载荷就是文件绝对路径，原样作为 @mention（不转相对路径）。
   const toMention = (raw: string) => {
     const p = raw.trim()

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -1,7 +1,7 @@
 // 统一「文件工作区」：左侧文件浏览器(可拖拽调宽) + VSCode 式多文件编辑 tab + Monaco 编辑器。
 // 支持左右双栏(编辑组 A/B)：拖 tab 到另一栏、或从文件树拖文件到某栏；会话(终端)作为固定首 tab 常驻 A 栏。
 // 两处复用：独立 Files 页（纯文件）与新标签 SoloTerminal（会话经 leading* 槽传入）。
-import { type ReactNode, Fragment, useRef, useState } from 'react'
+import { type ReactNode, Fragment, useEffect, useRef, useState } from 'react'
 import { App as AntApp } from 'antd'
 import FileBrowser, { Viewer, FileTypeIcon } from './FileBrowser'
 import { useI18n } from './i18n'
@@ -55,6 +55,12 @@ export default function FileWorkspace({
   const [focus, setFocus] = useState<Group>('A')
   const [dirtyFiles, setDirtyFiles] = useState<Set<string>>(new Set())
   const [dropHint, setDropHint] = useState<Group | 'split' | null>(null) // 拖拽落点提示
+  useEffect(() => {
+    const clear = () => setDropHint(null)
+    document.addEventListener('dragend', clear)
+    document.addEventListener('drop', clear, true)
+    return () => { document.removeEventListener('dragend', clear); document.removeEventListener('drop', clear, true) }
+  }, [])
   const split = filesB.length > 0
 
   const filesOf = (g: Group) => (g === 'A' ? filesA : filesB)


### PR DESCRIPTION
## Summary
- 拖拽文件经过编辑区到 Claude 终端后，拆分提示覆盖层（dropHint）不消失
- 原因：终端 onDrop 调用 stopPropagation 导致 FileWorkspace 的 drop 处理未触发，且 onDragLeave 的 `currentTarget===target` 判断在子元素（Monaco 编辑器等）上失效
- 修复：在 FileWorkspace 和 App 中添加全局 `dragend` + `drop`（capture phase）监听，确保拖拽操作结束后状态被清理

## Test plan
- [ ] 从文件浏览器拖文件到 Claude 终端，验证覆盖层消失
- [ ] 从文件浏览器拖文件到编辑区拆分，验证功能正常
- [ ] 拖拽后按 Esc 取消，验证覆盖层消失
- [ ] Tab 之间拖拽，验证功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)