### PR TITLE
fix(cli): tmux server 未启动时概览页会话数误报为 1

### DIFF
--- a/cli/ttmux-cli-go/e2e/e2e.sh
+++ b/cli/ttmux-cli-go/e2e/e2e.sh
@@ -31,10 +31,12 @@ mkdir -p "$TTMUX_DATA" "$TTMUX_HOME" "$HOME"
 export NO_COLOR=1
 unset TMUX_BIN TTMUX_AGENT TTMUX_QUIET 2>/dev/null || true
 
-# tmux wrapper bound to the private socket
+# tmux wrapper bound to the private socket（在改 PATH 前解析真实 tmux，
+# 避免硬编码 /usr/bin/tmux 在 macOS/Homebrew 环境下找不到）
+REAL_TMUX="$(command -v tmux)"
 cat > "$WBIN/tmux" <<EOF
 #!/usr/bin/env bash
-exec /usr/bin/tmux -L $SOCKET "\$@"
+exec "$REAL_TMUX" -L $SOCKET "\$@"
 EOF
 # fake claude/codex: stay alive so a resident "agent" session persists
 for stub in claude codex; do
@@ -77,6 +79,8 @@ sec "basics: version / help / info"
 eq "version" "ttmux v0.4.1-go" "$($GO -v)"
 has "help renders" "$($GO help)" "AI-native tmux wrapper"
 has "info --json sessions field" "$($GO info --json | jget 'list(d.keys())')" "sessions"
+eq "info --json sessions=0 (no server)" "0" "$($GO info --json | jget 'd["sessions"]')"
+eq "ls --json empty (no server)" "0" "$($GO ls --json | jget 'len(d)')"
 
 # ════════════════════════════════════════════
 sec "tasks: spawn / status / collect / group"

--- a/cli/ttmux-cli-go/internal/command/session/commands.go
+++ b/cli/ttmux-cli-go/internal/command/session/commands.go
@@ -16,7 +16,11 @@ import (
 // List renders the human-readable session table (mirrors _pretty_sessions),
 // hiding swarm-owned sessions via exclude.
 func List(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
-	out, _ := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}")
+	out, err := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}")
+	if err != nil {
+		// tmux server 未启动时输出的是 stderr 错误文本，不能当会话数据解析
+		out = ""
+	}
 	p := ui.P()
 	fmt.Fprintln(w)
 	count := 0

--- a/cli/ttmux-cli-go/internal/command/session/session.go
+++ b/cli/ttmux-cli-go/internal/command/session/session.go
@@ -30,7 +30,8 @@ type infoJSON struct {
 
 func ListJSON(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
 	out, err := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}\t#{session_activity}")
-	if err != nil && strings.TrimSpace(out) == "" {
+	if err != nil {
+		// tmux server 未启动时输出的是 stderr 错误文本（out 非空），只看 err
 		_, _ = io.WriteString(w, "[]\n")
 		return nil
 	}

--- a/cli/ttmux-cli-go/internal/command/session/session.go
+++ b/cli/ttmux-cli-go/internal/command/session/session.go
@@ -65,9 +65,8 @@ func ListJSON(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
 
 func InfoJSON(rt runtime.Runtime, version string, exclude map[string]bool, w io.Writer) error {
 	sessions := 0
-	out, _ := rt.TmuxOutput("list-sessions", "-F", "#{session_name}")
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if name := strings.TrimSpace(line); name != "" && !exclude[name] {
+	for _, name := range rt.Sessions() {
+		if !exclude[name] {
 			sessions++
 		}
 	}

--- a/cli/ttmux-cli-go/internal/runtime/runtime.go
+++ b/cli/ttmux-cli-go/internal/runtime/runtime.go
@@ -73,7 +73,12 @@ func (r Runtime) HasSession(name string) bool {
 
 // Sessions returns all tmux session names (unfiltered).
 func (r Runtime) Sessions() []string {
-	out, _ := r.TmuxOutput("list-sessions", "-F", "#{session_name}")
+	out, err := r.TmuxOutput("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		// tmux server 未启动时 list-sessions 非零退出，此时输出是 stderr 的
+		// 错误文本（如 "no server running ..."），不能按行当会话名解析
+		return nil
+	}
 	var names []string
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line = strings.TrimSpace(line); line != "" {


### PR DESCRIPTION
## 问题

全新安装 Roam 的机器上没有任何会话，但 Web 概览页的“会话”磁贴显示 **1**（下方的会话列表却正确显示为空）。

## 根因

概览磁贴的数据链路：前端 `GET /info` → 后端透传 CLI `info --json` → `InfoJSON` 执行 `tmux list-sessions -F '#{session_name}'` 按非空行计数。

在 tmux server 尚未启动的机器上，`list-sessions` 非零退出并向 stderr 输出一行错误：

```
no server running on /tmp/tmux-1000/default
```

而 `Runtime.TmuxOutput` 把 stderr 合并进了 stdout，`InfoJSON` 又用 `_` 丢弃了错误，于是这行错误文本被当成了一个“会话名”，计数变成 1。`/sessions`（`ListJSON`）因为用制表符多字段格式解析、有 `len(parts) < 4` 校验才侥幸正确，所以出现磁贴为 1、列表为空的分裂现象。

`Runtime.Sessions()` 有同样的问题，交互式界面（`interactive.go`）头部的会话计数也会因此误报。

## 修复

- `Runtime.Sessions()`：`list-sessions` 出错时直接返回空，不再把 stderr 文本按行当会话名。
- `InfoJSON`：改为复用 `rt.Sessions()` 并做 exclude 过滤，删除重复的解析逻辑。

## 验证

用假 tmux 脚本模拟两种场景，构建后运行 `ttmux info --json`：

- 模拟 `no server running`（exit 1 + stderr）：修复前 `"sessions":1`，修复后 `"sessions":0` ✅
- 模拟两个会话（stdout 输出 `work`/`demo`）：`"sessions":2`，计数不受影响 ✅

`go build ./...` 与 `go test ./...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)