### PR TITLE
fix(web): API 响应禁缓存，修复移动端文件实时重载失效

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -85,6 +85,10 @@ func New(cfg Config) *gin.Engine {
 
 	// 受保护端点
 	g := r.Group("/api", a.Middleware())
+	// API 返回的都是动态数据（会话状态、文件内容/元信息…）。移动端(Safari/WebView)与反代会对
+	// 无 Cache-Control 的 GET 做启发式缓存，导致文件实时重载轮询的 /file/stat 一直拿到旧 mtime
+	// → 不刷新。统一禁缓存，兜底前端的 cache:no-store。
+	g.Use(func(c *gin.Context) { c.Header("Cache-Control", "no-store") })
 	{
 		g.GET("/me", h.Me)
 		g.GET("/info", h.Info)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,6 +10,9 @@ export async function api(method: string, path: string, body?: any): Promise<any
     method,
     headers: body ? { 'Content-Type': 'application/json' } : undefined,
     body: body ? JSON.stringify(body) : undefined,
+    // 移动端(Safari/WebView)会对无 Cache-Control 的 GET 做启发式缓存，导致文件实时重载
+    // 轮询的 /file/stat 一直拿到旧 mtime → 不刷新。强制不走缓存，每次真打网络。
+    cache: 'no-store',
   })
   if (r.status === 401) {
     onUnauth()


### PR DESCRIPTION
## 问题
在**手机**上打开文件后，Claude Code / Codex 改动文件，网页**不自动刷新**（文件实时重载失效）。桌面 Chrome 正常。

## 根因
移动端 Safari / WebView 会对**无 `Cache-Control` 的 GET fetch 做启发式缓存**。文件实时重载靠每 ~2s 轮询 `/api/file/stat` 比对 `mtime`，但手机把响应缓存住了 → 每次拿到的都是**同一个旧 mtime** → 永远判定"没变" → 不重载。后端与前端逻辑本身都对，是被移动端缓存卡死。

桌面 Chrome 不做这种启发式缓存，所以桌面一直正常、问题只在移动端复现（已用真实浏览器 CDP 验证：桌面每次拿到新 mtime、实时重载生效）。

## 修复
- **前端** `api()`：所有 `/api` fetch 加 `cache: 'no-store'`，强制每次真打网络，移动端也绕过缓存。
- **后端** `/api` 路由组：统一加 `Cache-Control: no-store` 响应头，兜底移动端与反向代理 / frp。

API 返回的都是动态数据（会话状态、文件内容/元信息…），本就不该被缓存。

## 验证
- 桌面 Chrome (CDP 真实浏览器)：打开文件显示旧内容 → 改磁盘 → ~2s 后自动刷新为新内容，无回归。
- `curl` 确认 `/api/file`、`/api/file/stat` 现返回 `cache-control: no-store`。
- pre-commit 质量门（tsc / 密钥扫描 / 文件策略）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)