### PR TITLE
fix(web): 文件树刷新时保留展开层级，不再折叠

### DIFF
--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -765,9 +765,6 @@ function FileTree({
   const [loading, setLoading] = useState<Record<string, boolean>>({})
   const { t } = useI18n()
 
-  // 换根目录或刷新（tick）→ 清空展开态与缓存，避免展示上一目录的子树
-  useEffect(() => { setExpanded(new Set()); setChildMap({}); setLoading({}) }, [root, tick])
-
   const loadDir = (dirPath: string) => {
     setLoading((m) => ({ ...m, [dirPath]: true }))
     api('GET', `/files?path=${encodeURIComponent(dirPath)}`)
@@ -775,6 +772,26 @@ function FileTree({
       .catch(() => setChildMap((m) => ({ ...m, [dirPath]: [] })))
       .finally(() => setLoading((m) => ({ ...m, [dirPath]: false })))
   }
+  // 静默重拉子项：不置 loading（保留旧子项直到新数据到），刷新时展开的目录不闪 spinner
+  const reloadDir = (dirPath: string) => {
+    api('GET', `/files?path=${encodeURIComponent(dirPath)}`)
+      .then((r) => setChildMap((m) => ({ ...m, [dirPath]: r.data?.entries || [] })))
+      .catch(() => {})
+  }
+
+  const prevRoot = useRef(root)
+  // 换根目录 → 清空展开态与缓存（旧展开对新目录无意义）。
+  // 刷新(tick 变、root 不变) → 保留展开层级，静默重拉各已展开目录的子项，
+  // 让新增/删除的文件显示出来而不折叠（顶层 rootEntries 由父组件随 tick 重拉）。
+  useEffect(() => {
+    if (prevRoot.current !== root) {
+      prevRoot.current = root
+      setExpanded(new Set()); setChildMap({}); setLoading({})
+      return
+    }
+    expanded.forEach((dirPath) => reloadDir(dirPath))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [root, tick])
   const toggleDir = (dirPath: string) => {
     setExpanded((s) => {
       const n = new Set(s)


### PR DESCRIPTION
## 问题
树形文件浏览器里点「刷新目录」，原本展开的所有子目录会**折叠回去**，展开层级丢失。

## 根因
`FileTree` 对「换根目录(`root`)」和「刷新(`tick`)」**共用同一套清空展开态的逻辑**：
```js
useEffect(() => { setExpanded(new Set()); setChildMap({}); setLoading({}) }, [root, tick])
```
所以一刷新就把 `expanded` 清空了。

## 修复
用 `prevRoot` ref 区分两种触发：
- **换根目录** → 照旧清空展开态（旧展开对新目录无意义）；
- **刷新(tick 变、root 不变)** → 保留 `expanded` 展开集，只对每个已展开目录**静默重拉子项**（新增 `reloadDir`，不置 loading → 不闪 spinner），既能显示磁盘上增删的文件、又不折叠。顶层 `rootEntries` 本就由父组件随 tick 重拉。

## 验证
- `tsc --noEmit` 通过；pre-commit 质量门通过。
- 真实浏览器(CDP)实测：展开目录 → 磁盘新增文件 → 点刷新 → **新文件出现且目录保持展开**；换目录仍正常清空展开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)