### PR TITLE
feat(web): 新建会话支持 Git Worktree 模式

### DIFF
--- a/backend/api/git.go
+++ b/backend/api/git.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -313,6 +314,89 @@ func (a *API) GitCommit(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true, "output": strings.TrimSpace(result)}})
+}
+
+// GitWorktreeAdd POST /git/worktree {dir} —— 在 dir/.worktrees/ 下新建 git worktree，返回路径。
+func (a *API) GitWorktreeAdd(c *gin.Context) {
+	var req struct {
+		Dir string `json:"dir"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Dir == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
+		return
+	}
+	dir := filepath.Clean(req.Dir)
+	if !filepath.IsAbs(dir) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_PATH"}})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	root, err := runGit(ctx, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "NOT_GIT_REPO", "message": "not a git repository"}})
+		return
+	}
+	root = strings.TrimSpace(root)
+
+	if _, err := runGit(ctx, root, "rev-parse", "--verify", "HEAD"); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "EMPTY_REPO", "message": "repository has no commits yet"}})
+		return
+	}
+
+	now := time.Now()
+	name := "_" + now.Format("20060102150405") + fmt.Sprintf("%03d", now.Nanosecond()/1e6)
+	wtDir := filepath.Join(root, ".worktrees", name)
+
+	if err := os.MkdirAll(filepath.Dir(wtDir), 0o755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "MKDIR_FAILED", "message": err.Error()}})
+		return
+	}
+
+	out, err := runGit(ctx, root, "worktree", "add", wtDir)
+	if err != nil {
+		gitFail(c, "GIT_WORKTREE_FAILED", out, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"path": wtDir}})
+}
+
+// GitWorktreeRemove POST /git/worktree/remove {path} —— 移除指定 worktree（用于创建会话失败时清理）。
+func (a *API) GitWorktreeRemove(c *gin.Context) {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Path == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
+		return
+	}
+	p := filepath.Clean(req.Path)
+	if !filepath.IsAbs(p) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_PATH"}})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+	out, err := runGit(ctx, filepath.Dir(p), "worktree", "remove", "--force", p)
+	if err != nil {
+		gitFail(c, "GIT_WORKTREE_REMOVE_FAILED", out, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}})
+}
+
+// GitIsRepo GET /git/is-repo?path=<dir> —— 检查目录是否为 git 仓库。
+func (a *API) GitIsRepo(c *gin.Context) {
+	dir := filepath.Clean(c.Query("path"))
+	if dir == "" || !filepath.IsAbs(dir) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"repo": false}})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	_, err := runGit(ctx, dir, "rev-parse", "--git-dir")
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"repo": err == nil}})
 }
 
 // GitOp POST /git/op {root, op} —— 远端操作：push / pull / fetch / sync(pull+push)。

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -108,13 +108,16 @@ func New(cfg Config) *gin.Engine {
 		g.POST("/file/mkdir", h.FileMkdir) // 文件侧栏：在当前目录新建子目录
 		g.POST("/upload", h.Upload)        // 上传文件到指定目录（拖拽到对话框 / 文件侧栏）
 
-		g.GET("/git/status", h.GitStatus)    // Git 面板：当前工作目录所属仓库状态
-		g.GET("/git/diff", h.GitDiff)        // Git 面板：单文件差异
-		g.POST("/git/stage", h.GitStage)     // 暂存
-		g.POST("/git/unstage", h.GitUnstage) // 取消暂存
-		g.POST("/git/discard", h.GitDiscard) // 放弃改动
-		g.POST("/git/commit", h.GitCommit)   // 提交（可选 push）
-		g.POST("/git/op", h.GitOp)           // push / pull / fetch / sync
+		g.GET("/git/status", h.GitStatus)                   // Git 面板：当前工作目录所属仓库状态
+		g.GET("/git/diff", h.GitDiff)                       // Git 面板：单文件差异
+		g.POST("/git/stage", h.GitStage)                    // 暂存
+		g.POST("/git/unstage", h.GitUnstage)                // 取消暂存
+		g.POST("/git/discard", h.GitDiscard)                // 放弃改动
+		g.POST("/git/commit", h.GitCommit)                  // 提交（可选 push）
+		g.POST("/git/op", h.GitOp)                          // push / pull / fetch / sync
+		g.POST("/git/worktree", h.GitWorktreeAdd)           // 新建 worktree
+		g.POST("/git/worktree/remove", h.GitWorktreeRemove) // 移除 worktree
+		g.GET("/git/is-repo", h.GitIsRepo)                  // 检查是否 git 仓库
 
 		g.GET("/sessions", h.Sessions)
 		g.POST("/sessions", h.NewSession)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1400,14 +1400,34 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
   const [dir, setDir] = useState('')
   const [pick, setPick] = useState(false)
   const [agent, setAgent] = useState<'none' | 'claude' | 'codex'>('none')
+  const [worktree, setWorktree] = useState(false)
+  const [isGitRepo, setIsGitRepo] = useState(false)
+  const [creating, setCreating] = useState(false)
   const { message } = AntApp.useApp()
   const { t } = useI18n()
   const [prefs] = usePreferences()
-  useEffect(() => { if (open) { setName(''); setDir(''); setAgent('none') } }, [open])
+  useEffect(() => { if (open) { setName(''); setDir(''); setAgent('none'); setWorktree(false); setIsGitRepo(false) } }, [open])
+  useEffect(() => {
+    const d = dir.trim()
+    if (!d) { setIsGitRepo(false); return }
+    let cancelled = false
+    api('GET', `/git/is-repo?path=${encodeURIComponent(d)}`).then((r) => {
+      if (!cancelled) setIsGitRepo(!!r?.data?.repo)
+    }).catch(() => { if (!cancelled) setIsGitRepo(false) })
+    return () => { cancelled = true }
+  }, [dir])
   const ok = async () => {
     if (!name.trim()) return message.error(t('session.nameRequired'))
+    let worktreePath = ''
     try {
-      const res = await api('POST', '/sessions', { name: name.trim(), dir: dir.trim() })
+      setCreating(true)
+      let sessionDir = dir.trim()
+      if (worktree && isGitRepo && sessionDir) {
+        const wt = await api('POST', '/git/worktree', { dir: sessionDir })
+        worktreePath = wt?.data?.path || ''
+        if (worktreePath) sessionDir = worktreePath
+      }
+      const res = await api('POST', '/sessions', { name: name.trim(), dir: sessionDir })
       const actual = res.name || name.trim()
       if (agent !== 'none') {
         const cmd = agent === 'claude' ? (prefs.claudeCommand || 'claude') : (prefs.codexCommand || 'codex')
@@ -1415,11 +1435,18 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
       }
       pushRecentDir(dir); message.success(t('session.created')); onClose(); onDone(actual)
     }
-    catch (e: any) { message.error(e.message) }
+    catch (e: any) {
+      if (worktreePath) {
+        api('POST', '/git/worktree/remove', { path: worktreePath }).catch(() => {})
+      }
+      message.error(e.message)
+    }
+    finally { setCreating(false) }
   }
   return (
     <>
-      <Modal open={open} onCancel={onClose} onOk={ok} okText={t('file.create')} title={t('session.new')} destroyOnClose>
+      <Modal open={open} onCancel={onClose} onOk={ok} okText={t('file.create')} title={t('session.new')} destroyOnClose
+        confirmLoading={creating}>
         <Space direction="vertical" style={{ width: '100%' }}>
           <Input placeholder={t('session.namePlaceholder')} value={name} onChange={(e) => setName(e.target.value)} autoFocus />
           <Space.Compact style={{ width: '100%' }}>
@@ -1439,6 +1466,12 @@ function NewSessionModal({ open, onClose, onDone }: { open: boolean; onClose: ()
                   </Tag>
                 </Tooltip>
               ))}
+            </div>
+          )}
+          {isGitRepo && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <Switch size="small" checked={worktree} onChange={setWorktree} />
+              <span style={{ fontSize: 13 }}>{t('session.worktreeMode')}</span>
             </div>
           )}
           <Radio.Group value={agent} onChange={(e) => setAgent(e.target.value)} optionType="button" buttonStyle="solid"

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -134,6 +134,8 @@ const enUS = {
   'session.agentClaude': 'Launch Claude Code',
   'session.agentCodex': 'Launch Codex',
   'session.dirPlaceholder': 'Working directory (optional, defaults to home; focus to see recent)',
+  'session.worktreeMode': 'Git Worktree mode',
+  'session.worktreeCreating': 'Creating worktree…',
   'session.searchPlaceholder': 'Search sessions…',
   'session.closed': 'Closed',
   'session.swarmPage': 'Swarm page',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -134,6 +134,8 @@ const zhCN = {
   'session.agentClaude': '启动 Claude Code',
   'session.agentCodex': '启动 Codex',
   'session.dirPlaceholder': '工作目录（可空，默认家目录；聚焦看最近）',
+  'session.worktreeMode': 'Git Worktree 模式',
+  'session.worktreeCreating': '正在创建 worktree…',
   'session.searchPlaceholder': '搜索会话名…',
   'session.closed': '已关闭',
   'session.swarmPage': '蜂群页',


### PR DESCRIPTION
## 概要
- 新建会话时，若选择的工作目录是 git 仓库，弹窗自动出现「Git Worktree 模式」开关
- 开启后，系统在 `<repo>/.worktrees/_<时间戳>` 下自动创建隔离工作树，会话在其中运行
- 后端新增 3 个 API：`POST /git/worktree`（创建）、`POST /git/worktree/remove`（清理）、`GET /git/is-repo`（检测）

## 细节
- 时间戳精确到毫秒，防止并发碰撞
- 空仓库（无 commit）会被拦截，不允许创建 worktree
- 如果 worktree 创建成功但后续 session 创建失败，前端会自动调用 remove 清理

## 测试计划
- [ ] 新建会话，选择一个 git 仓库目录，确认出现 Worktree 开关
- [ ] 开启 Worktree 后创建会话，确认 session 在 `.worktrees/_<ts>` 目录中运行
- [ ] 选择非 git 目录，确认不出现 Worktree 开关
- [ ] 不填目录时，确认不出现 Worktree 开关