### PR TITLE
fix(web): 拖文件/tab 到右半区分栏（编辑器区+终端区）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -704,11 +704,17 @@ function TerminalPane(props: {
     e.preventDefault()
     e.dataTransfer.dropEffect = 'copy'
   }
+  // 落点是否在终端区右半 → 让给 FileWorkspace 做分栏（VSCode 式：右半区拆栏，左/中区注入@）。
+  const inTermSplitZone = (e: React.DragEvent) => {
+    const r = e.currentTarget.getBoundingClientRect()
+    return e.clientX > r.left + r.width / 2
+  }
   // 拖到终端区：直接把 @路径 送进当前会话（claude/codex TUI 或 shell 提示符的光标处）。
   const onTermDrop = (e: React.DragEvent) => {
     if (!isPathDrag(e)) return
+    if (inTermSplitZone(e)) { setDragOver(false); return } // 右半区：不拦截，冒泡给 FileWorkspace 分栏
     e.preventDefault()
-    e.stopPropagation() // 别再冒泡到 FileWorkspace 的分栏 drop：拖到终端=注入@，不触发分栏
+    e.stopPropagation() // 左/中区：拖到终端=注入@，不冒泡到分栏
     setDragOver(false)
     const mention = toMention(readDropPath(e))
     if (!mention || !active) return
@@ -946,7 +952,11 @@ function TerminalPane(props: {
   )
   const terminalArea = (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}
-      onDragOver={(e) => { if (isPathDrag(e)) { e.stopPropagation(); allowPathDrop(e); setDragOver(true) } }}
+      onDragOver={(e) => {
+        if (!isPathDrag(e)) return
+        if (inTermSplitZone(e)) { setDragOver(false); return } // 右半区：让事件冒泡给 FileWorkspace 显示分栏提示
+        e.stopPropagation(); allowPathDrop(e); setDragOver(true)
+      }}
       onDragLeave={(e) => { if (e.currentTarget === e.target) setDragOver(false) }}
       onDrop={onTermDrop}>
       {dragOver && (

--- a/frontend/src/CodeEditor.tsx
+++ b/frontend/src/CodeEditor.tsx
@@ -54,6 +54,10 @@ export default function CodeEditor({
       options={{
         readOnly,
         fontSize: 13,
+        // Monaco 默认会拦截拖到编辑器上的 drop（dropIntoEditor：插入文件/文本）并阻止其冒泡，
+        // 导致把文件 tab 拖到编辑器区想「分栏」时，drop 被 Monaco 吃掉、外层 FileWorkspace 收不到。
+        // 关掉它，让 drop 冒泡到外层做分栏。（编辑器内选中文本拖动 dragAndDrop 保留不动。）
+        dropIntoEditor: { enabled: false },
         minimap: { enabled: true }, // 右侧代码缩略图：显示整段代码长度与当前所在位置（VSCode 同款）
         lineNumbers: 'on',
         // 行号装订线：关掉字形边距/折叠栏（那才是之前的大缝隙），保留 VSCode 同款行号↔代码间距

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -229,7 +229,11 @@ export default function FileWorkspace({
           onDrop={(e) => {
             if (!dragHasPayload(e)) return
             e.preventDefault()
-            const target: Group = (!split && primary && dropHint === 'split') ? 'B' : g
+            // 分栏判断直接用落点位置，不依赖 React 状态 dropHint：快速拖放时最后一帧 dragover
+            // 与 drop 之间来不及 re-render 提交 dropHint，读状态会失效（还会被全局 drop 清理干扰）。
+            const r = e.currentTarget.getBoundingClientRect()
+            const inRightHalf = e.clientX > r.left + r.width / 2
+            const target: Group = (!split && primary && inRightHalf) ? 'B' : g
             setDropHint(null); applyDrop(e, target)
           }}>
           {primary && leadingContent}


### PR DESCRIPTION
## 问题
在会话页/文件工作区，拖文件 tab 或文件到右半区想「分栏」（VSCode 式左右双栏）失效。

## 根因
1. `FileWorkspace` 的 onDrop 分栏判断依赖 React 状态 `dropHint`（dragover 时设）。快速拖放时最后一帧 dragover 与 drop 之间来不及 re-render 提交 `dropHint`，读到的还是旧值 → 判断失效。
2. 拖到编辑器区，真实 drop 被 **Monaco 自己的 `dropIntoEditor`** 吃掉、不冒泡到外层。
3. 单终端页里终端铺满内容区，拖到它上面一律 `stopPropagation` 走 @mention，右半区也没法分栏。

## 修复
- **onDrop 按落点位置判断分栏**，不依赖 `dropHint` 状态时序（免受快速拖放/全局 drop 清理影响）。
- **CodeEditor 关 Monaco `dropIntoEditor`**：让 drop 冒泡到外层做分栏（编辑器内选中文本拖动 `dragAndDrop` 保留）。
- **终端拖放区**：落点在右半区让事件冒泡给 FileWorkspace 分栏（VSCode 式），左/中区仍插入 @文件引用。

## 验证
真实浏览器（CDP HTML5 拖放）：
- 拖 tab 到编辑器右半区 → 分栏 ✓
- 拖树里的文件到终端右半区 → 出现「拖到这里分栏」、分栏（文件开到第二栏）✓
- 拖到终端左/中区 → 仍插入 @文件引用、不误分栏 ✓
- `tsc` / 密钥扫描 / 文件策略通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)