### PR TITLE
perf(web): 修复首屏误载 4MB monaco 块；静态资源 gzip 预压缩 + 长缓存

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -8,6 +8,7 @@ package server
 import (
 	_ "embed"
 	"log"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -244,7 +245,33 @@ func mountWeb(r *gin.Engine, frontendDir string) {
 	useReact := fileExists(indexPath)
 
 	if useReact {
-		r.Static("/assets", filepath.Join(frontendDir, "assets"))
+		assetsDir := filepath.Join(frontendDir, "assets")
+		serveAsset := func(c *gin.Context) {
+			fp := filepath.Join(assetsDir, filepath.Clean("/"+c.Param("filepath")))
+			if !strings.HasPrefix(fp, assetsDir) || !fileExists(fp) {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			// 产物文件名带内容 hash（内容变则名变），可放心让浏览器缓存一年且免回源验证；
+			// 否则每次打开页面都对全部 JS/CSS 发条件请求甚至重新下载，首屏明显变慢。
+			c.Header("Cache-Control", "public, max-age=31536000, immutable")
+			c.Header("Vary", "Accept-Encoding")
+			// 构建期预压缩的 .gz 旁路文件（见 frontend/scripts/compress-dist.mjs）：
+			// 客户端支持 gzip 就直接下发，几 MB 的 JS 传输量降到约 1/3。
+			if gz := fp + ".gz"; strings.Contains(c.GetHeader("Accept-Encoding"), "gzip") && fileExists(gz) {
+				ct := mime.TypeByExtension(filepath.Ext(fp))
+				if ct == "" {
+					ct = "application/octet-stream"
+				}
+				c.Header("Content-Type", ct)
+				c.Header("Content-Encoding", "gzip")
+				c.File(gz)
+				return
+			}
+			c.File(fp)
+		}
+		r.GET("/assets/*filepath", serveAsset)
+		r.HEAD("/assets/*filepath", serveAsset)
 		log.Printf("前端: React (磁盘 %s)", frontendDir)
 	} else {
 		log.Printf("前端: 内嵌回退页 —— 运行 ./start.sh --dev 会构建 React")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run i18n:check && vite build",
+    "build": "npm run i18n:check && vite build && node scripts/compress-dist.mjs",
     "i18n:check": "node scripts/i18n-audit.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"

--- a/frontend/scripts/compress-dist.mjs
+++ b/frontend/scripts/compress-dist.mjs
@@ -1,0 +1,33 @@
+// 构建后预压缩 dist 静态产物（nginx gzip_static 模式）：
+// 为可压缩文件生成 .gz 旁路文件，后端按 Accept-Encoding 直接下发，
+// 免去每次请求现压的 CPU 开销。跳过压缩收益差的格式（woff2/png/webp 本身已压缩）。
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import zlib from 'node:zlib'
+import { promisify } from 'node:util'
+
+const gzip = promisify(zlib.gzip)
+const DIST = path.resolve(process.cwd(), 'dist')
+const COMPRESSIBLE = /\.(?:js|mjs|css|html|svg|json|webmanifest|txt|ttf)$/
+
+async function* walk(dir) {
+  for (const ent of await fs.readdir(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name)
+    if (ent.isDirectory()) yield* walk(p)
+    else yield p
+  }
+}
+
+let count = 0
+let saved = 0
+for await (const file of walk(DIST)) {
+  if (!COMPRESSIBLE.test(file)) continue
+  const raw = await fs.readFile(file)
+  if (raw.length < 1024) continue // 太小不值得，省往返头开销有限
+  const gz = await gzip(raw, { level: 9 })
+  if (gz.length >= raw.length * 0.9) continue // 压不动的不生成
+  await fs.writeFile(file + '.gz', gz)
+  count++
+  saved += raw.length - gz.length
+}
+console.log(`compress-dist: ${count} 个文件生成 .gz，共节省 ${(saved / 1024 / 1024).toFixed(1)} MB 传输量`)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
         // 把第三方库按用途拆成独立 vendor 块：避免挤成一个 ~3MB 巨块，
         // 各块可被浏览器分别缓存（改业务代码不致使整包失效），按需并行加载。
         manualChunks(id) {
+          // Vite 动态 import 的 preload 辅助模块被所有含懒加载的 chunk 共享。不显式指定时
+          // rollup 可能把它塞进某个懒加载重块（曾落入 monaco 块 → index 静态依赖 monaco，
+          // 4.3MB JS + 146KB 阻塞 CSS 全进首屏，懒加载失效）。固定进 vendor（入口本就依赖）。
+          if (id.includes('vite/preload-helper')) return 'vendor'
           if (!id.includes('node_modules')) return
           // Office 预览（docx/xlsx/pptx）很重，仅看 Office 文件时才用 → 独立块（配合 FileBrowser 懒加载按需取）
           if (/docx-preview|xlsx|pptx|jvmr/.test(id)) return 'office'


### PR DESCRIPTION
## 问题

Web 打开很慢。排查出三个叠加的根因：

## 根因与修复

### 1. 首屏被迫下载 4.3MB monaco 块（主因）
Vite 动态 import 的 preload-helper 是所有含懒加载 chunk 共享的模块，rollup 把它塞进了 monaco 巨块，导致 index 入口静态 import monaco 块 → `index.html` 里 `modulepreload` 了 4.3MB 的 monaco JS，146KB 的 monaco.css 还是阻塞渲染的 —— CodeEditor 的懒加载形同虚设。

**修复**：`manualChunks` 显式把 preload-helper 固定进 vendor 块。修后 `index.html` 不再引用 monaco 块，monaco.css 也随 chunk 变为按需加载。

### 2. 静态资源无压缩
后端 `r.Static` 裸伺服，首屏 ~2.2MB JS 原样传输（gzip 后只有 ~650KB）。

**修复**：构建后用 `scripts/compress-dist.mjs`（Node 内置 zlib，零依赖）预压缩生成 `.gz` 旁路文件（nginx `gzip_static` 模式，共省 14.6MB），后端按 `Accept-Encoding` 直接下发，无每请求现压的 CPU 开销。

### 3. hash 资源无缓存头
`/assets` 文件名带内容 hash 却没有 Cache-Control，浏览器每次都回源验证甚至重下。

**修复**：加 `public, max-age=31536000, immutable`，二次打开直接命中本地缓存。`index.html` 维持 no-store 不变，保证发版即生效。

## 效果（本地实测）

| 指标 | 修前 | 修后 |
|---|---|---|
| 首屏 JS（含 preload） | ~6.5MB 原样传输 | ~650KB gzip |
| monaco.css 阻塞渲染 | 是 | 否（按需） |
| 二次打开 | 全量条件请求 | 直接用本地缓存 |

## 验证

- `npm run build` 后 `index.html` 无 monaco preload/css ✅
- 起测试后端 curl 验证：gzip 下发 747KB→229KB、Content-Type 正确、304 条件请求正常、HEAD 正常、`/assets/../../etc/passwd` 路径穿越 404 ✅
- `scripts/dev/quality/check.sh quick` 通过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)