### PR TITLE
fix(cli): ttmux send 用 bracketed-paste 提交，多行 prompt 不再被拆/不发送

### DIFF
--- a/cli/ttmux-cli-go/internal/command/session/commands.go
+++ b/cli/ttmux-cli-go/internal/command/session/commands.go
@@ -234,9 +234,10 @@ func Send(rt runtime.Runtime, exclude map[string]bool, args []string, w io.Write
 		ui.Err(w, "会话 %s 不存在", ui.Bold(target))
 		return fmt.Errorf("session not found: %s", target)
 	}
-	if err := rt.Tmux("send-keys", "-t", target, cmdStr, "C-m"); err != nil {
-		return err
-	}
+	// 用粘贴缓冲 + 独立回车提交：TUI Agent(Claude/Codex)会把 send-keys 里
+	// 尾随的 C-m 当成输入换行而非提交，导致「只打字不发送」。SendPromptSubmit
+	// 走 paste-buffer 落文本再单独按回车，对多行 prompt 和 TUI 都可靠。
+	rt.SendPromptSubmit(target, cmdStr)
 	ui.Ok(w, "已发送到 %s: %s", ui.Bold(target), ui.Dim(cmdStr))
 	return nil
 }

--- a/cli/ttmux-cli-go/internal/command/swarm/plaza.go
+++ b/cli/ttmux-cli-go/internal/command/swarm/plaza.go
@@ -153,19 +153,10 @@ func masterSession(rt runtime.Runtime, st *swarmcore.Store, swarm string) string
 }
 
 // sendPromptSubmit pastes a multi-line prompt into a TUI and submits it
-// (mirrors _tmux_send_prompt_submit).
+// (mirrors _tmux_send_prompt_submit). Delegates to the shared runtime helper
+// so `ttmux send`、广场通知、hostapi 走同一条提交路径。
 func sendPromptSubmit(rt runtime.Runtime, target, message string) {
-	if rt.Tmux("set-buffer", "-b", "ttmux-prompt", message) == nil &&
-		rt.Tmux("paste-buffer", "-d", "-b", "ttmux-prompt", "-t", target) == nil {
-		// pasted
-	} else {
-		_ = rt.Tmux("send-keys", "-t", target, message)
-	}
-	_ = rt.Tmux("send-keys", "-t", target, "Enter")
-	if os.Getenv("TTMUX_FORCE_PROMPT_SUBMIT") != "0" {
-		time.Sleep(50 * time.Millisecond)
-		_ = rt.Tmux("send-keys", "-t", target, "Enter")
-	}
+	rt.SendPromptSubmit(target, message)
 }
 
 func cmdFeed(rt runtime.Runtime, st *swarmcore.Store, args []string, w io.Writer) error {

--- a/cli/ttmux-cli-go/internal/runtime/runtime.go
+++ b/cli/ttmux-cli-go/internal/runtime/runtime.go
@@ -136,6 +136,32 @@ func (r Runtime) InjectEnv(sess string) {
 	_ = r.Tmux("send-keys", "-t", sess, "clear", "C-m")
 }
 
+// SendPromptSubmit pastes a (possibly multi-line) prompt into a session and
+// submits it. TUI agents (Claude/Codex) treat a trailing C-m inside send-keys
+// as an input newline rather than a submit, so a naive `send-keys text C-m`
+// only types the text without sending it. Instead we drop the text via a paste
+// buffer (no embedded submit) then press Enter separately; a second Enter after
+// a short delay reliably fires the submit even when the TUI is still ingesting
+// the paste. Mirrors the swarm sendPromptSubmit / _tmux_send_prompt_submit.
+// Set TTMUX_FORCE_PROMPT_SUBMIT=0 to skip the second Enter (e.g. plain shells).
+func (r Runtime) SendPromptSubmit(target, message string) {
+	// -p 让 paste-buffer 在目标应用开了 bracketed paste 模式(Claude/Codex 等
+	// TUI 都开)时用 ESC[200~..ESC[201~ 包裹，整段多行 prompt 作为「一次粘贴」
+	// 送入、内嵌换行保留为输入换行而非提交；不带 -p 时 tmux 把换行当裸 CR 逐个
+	// 下发，多行 prompt 会在每个换行处被提前提交、拆成多条。对普通 shell(未开
+	// bracketed paste)-p 无副作用，退化为普通粘贴。
+	if r.Tmux("set-buffer", "-b", "ttmux-prompt", message) != nil ||
+		r.Tmux("paste-buffer", "-p", "-d", "-b", "ttmux-prompt", "-t", target) != nil {
+		// Fallback: paste buffer unavailable, send literally.
+		_ = r.Tmux("send-keys", "-t", target, "-l", message)
+	}
+	_ = r.Tmux("send-keys", "-t", target, "Enter")
+	if os.Getenv("TTMUX_FORCE_PROMPT_SUBMIT") != "0" {
+		time.Sleep(50 * time.Millisecond)
+		_ = r.Tmux("send-keys", "-t", target, "Enter")
+	}
+}
+
 func (r Runtime) GroupFile(name string) string {
 	return filepath.Join(r.GroupsDir, name+".group")
 }


### PR DESCRIPTION
## 问题

`ttmux send <会话> <指令>` 对 Claude Code / Codex 这类 TUI 无法可靠提交：

- 原实现 `send-keys text C-m`：尾随 `C-m` 被 TUI 当成输入换行而非提交 → **只打字不发送**（用户实测多行 review 卡在输入框）。
- 更隐蔽：多行 prompt 的换行被 tmux 当裸 CR 逐个下发，Claude 会在**每个换行处提前提交**，一条意见被拆成多条消息。这个坑连原 swarm 代码也踩了。

## 改动

- 新增共享 `runtime.SendPromptSubmit`：`set-buffer` → `paste-buffer -p -d` → 独立 `Enter`（+50ms 补一次）。
  - `-p` 让 tmux 用 **bracketed paste**（`ESC[200~..201~`）整段包裹，多行作为一次粘贴送入、换行保留为输入换行；对未开 bracketed paste 的普通 shell 无副作用。
- `session.Send`（`ttmux send`）改用它。
- swarm `plaza.sendPromptSubmit` 委托到同一路径，**顺带修好 swarm 多行 prompt 同款被拆问题**（单一来源）。

## 测试

1. **bracketed-paste TUI 代理**（确定性）：多行文本 → 带 `-p` 收到「1 次 PASTE + 1 次 SUBMIT」；不带 `-p` / 旧实现收到「每行一次 SUBMIT」。
2. **真 Claude Code**：`ttmux send` 发 3 行 prompt → 落进同一输入框、提交一次、Claude 正常回复。
3. **普通 shell**：单行命令正常执行（`-p` 无副作用）。
4. `go vet` + 全量 `go test` 全绿；pre-commit 质量门（i18n / typecheck / secret scan）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)