### PR TITLE
fix(web): 侧栏底部按钮左对齐，图标与上方导航对齐

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@
 //   电脑 ≥1200 → 三栏：导航 Sider | 列表(页面) | 终端面板(常驻, 多标签)
 //   平板/手机   → 终端为全屏覆盖层；手机底部 Tab 导航
 // 终端：多标签 / 字号调节 / 复制 / 更多快捷键 / 断线自动重连。
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState, type CSSProperties } from 'react'
 import {
   Layout, Menu, Button, Card, List, Tag, Form, Input, Select, Segmented, Tabs, Descriptions,
   Statistic, Row, Col, Space, Popconfirm, Empty, Modal, Grid, App as AntApp, Typography, Spin, Tooltip, Dropdown, Checkbox, Progress, AutoComplete, Radio, Switch,
@@ -417,6 +417,16 @@ export default function App() {
     />
   )
 
+  // 底部按钮：antd v5 Button 是 flex+居中，textAlign 无效，须用 justifyContent。
+  // 展开时左对齐并让图标与上方 inline Menu 项的图标严格对齐：二者左边缘都在 8px
+  // (菜单项 margin / 底部容器 padding 各 8)，菜单项 paddingLeft=24px 使图标落在 32px，
+  // 故底部按钮同样取 paddingLeft 24px。折叠时居中只显图标。
+  const bottomBtnStyle: CSSProperties = {
+    color: 'var(--text-dim)',
+    justifyContent: collapsed ? 'center' : 'flex-start',
+    paddingInline: collapsed ? undefined : '24px 15px',
+  }
+
   return (
     <Layout style={{ height: '100dvh', overflow: 'hidden', background: 'var(--bg-base)' }}>
       <UpdateBanner />
@@ -443,22 +453,22 @@ export default function App() {
             {/* 底部：收起 在上，其次 全屏，最后 退出，始终竖向堆叠（展开带文字，折叠仅图标居中）。*/}
             <div style={{ borderTop: '1px solid var(--border-subtle)', padding: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
               <Button type="text" block onClick={() => go('about')} title={t('nav.about')}
-                style={{ color: tab === 'about' ? '#58a6ff' : 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }}>
+                style={{ ...bottomBtnStyle, color: tab === 'about' ? '#58a6ff' : 'var(--text-dim)' }}>
                 {collapsed ? ICONS.github : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{ICONS.github}{t('nav.about')}</span>}
               </Button>
-              <Button type="text" block onClick={() => setCollapsed((c) => !c)} style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }}
+              <Button type="text" block onClick={() => setCollapsed((c) => !c)} style={bottomBtnStyle}
                 title={collapsed ? t('common.expand') : t('common.collapse')}>
                 {(() => { const icon = svg(collapsed ? <><polyline points="9 6 15 12 9 18" /></> : <><polyline points="15 6 9 12 15 18" /></>)
                   return collapsed ? icon : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{icon}{t('common.collapse')}</span> })()}
               </Button>
               {fsSupported && (
-                <Button type="text" block onClick={toggleFs} style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }}
+                <Button type="text" block onClick={toggleFs} style={bottomBtnStyle}
                   title={isFs ? t('common.exitFullscreen') : t('common.fullscreen')}>
                   {collapsed ? fsIcon : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{fsIcon}{isFs ? t('common.exitFullscreen') : t('common.fullscreen')}</span>}
                 </Button>
               )}
               <Popconfirm title={t('common.logoutConfirm')} okText={t('common.logout')} cancelText={t('common.cancel')} onConfirm={logout} placement="topRight">
-                <Button type="text" block style={{ color: 'var(--text-dim)', textAlign: collapsed ? 'center' : 'left' }} title={t('common.exit')}>
+                <Button type="text" block style={bottomBtnStyle} title={t('common.exit')}>
                   {(() => { const icon = svg(<><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></>)
                     return collapsed ? icon : <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>{icon}{t('common.exit')}</span> })()}
                 </Button>


### PR DESCRIPTION
## 问题

侧栏底部的 About / Collapse / Fullscreen / Exit 显示为**居中**，与上方导航（Overview…Settings）的靠左图标不在同一竖线，看起来没对齐。

根因：这几个按钮本用 `textAlign: 'left'`，但 **antd v5 `Button` 是 `inline-flex` + `justify-content: center`**，`textAlign` 对其内容不生效，所以实际居中。

## 改动（`frontend/src/App.tsx`）

- 新增共享 `bottomBtnStyle`，用 `justifyContent: collapsed ? 'center' : 'flex-start'` 取代无效的 `textAlign`。
- `paddingLeft` 设为 **24px**，与上方 inline Menu 项对齐：菜单项与底部按钮左边缘都在 8px，菜单项 `paddingLeft=24px` 使图标落在 **32px**，底部同样取 24px 对齐。
- 折叠态仍居中只显图标（`paddingInline: undefined`）。
- 四个按钮重复的内联样式收敛为一个 `bottomBtnStyle`；`import` 补 `type CSSProperties`。

## 验证

- **chrome-cli 真实 Chrome 实测**：上方导航图标 svgLeft=32、底部四个图标 svgLeft=33，`justify-content: flex-start`（对齐在 1px 内，肉眼无差）。
- `tsc --noEmit` 通过；pre-commit 质量门（i18n / typecheck / secret scan）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)