### PR TITLE
feat(plugin): 卸载/禁用清理干净——停常驻会话、清孤儿数据、--purge 可选清配置

### DIFF
--- a/backend/api/plugin.go
+++ b/backend/api/plugin.go
@@ -58,8 +58,15 @@ func (a *API) PluginInstall(c *gin.Context) {
 	a.text(c, "plugin", "install", b.Path)
 }
 
-// DELETE /api/plugins/:id —— 卸载外部插件(builtin 由 CLI 拒绝)
-func (a *API) PluginUninstall(c *gin.Context) { a.text(c, "plugin", "uninstall", c.Param("id")) }
+// DELETE /api/plugins/:id —— 卸载外部插件(builtin 由 CLI 拒绝)。
+// ?purge=1 连同清除该插件的 storage/config(默认保留以便重装复用)。
+func (a *API) PluginUninstall(c *gin.Context) {
+	args := []string{"plugin", "uninstall", c.Param("id")}
+	if p := c.Query("purge"); p == "1" || p == "true" {
+		args = append(args, "--purge")
+	}
+	a.text(c, args...)
+}
 
 // POST /api/plugin/track —— 把会话登记给插件跟踪(如新建会话勾选「结束后自动互审」:
 // labels 带 review:auto=true 与 workdir,plugind 在会话退出时通知插件)

--- a/cli/ttmux-cli-go/internal/command/plugin/plugin.go
+++ b/cli/ttmux-cli-go/internal/command/plugin/plugin.go
@@ -145,14 +145,24 @@ func setEnabled(env plugin.Env, enabled bool, args []string, out io.Writer) erro
 		return err
 	}
 	defer store.Close()
-	if err := store.SetEnabled(args[0], enabled); err != nil {
+	p, err := store.Get(args[0])
+	if err != nil {
+		return err
+	}
+	if err := store.SetEnabled(p.Manifest.ID, enabled); err != nil {
 		return err
 	}
 	verb := "已禁用"
 	if enabled {
 		verb = "已启用"
+	} else {
+		// 禁用即停掉该插件的常驻监听会话:ensureIMListener 只在启用时拉起,
+		// 不停的话现存监听会一直挂到 24h invoke 上限才退。
+		if p.Manifest.ID == "roam.im-bridge" && env.RT.HasSession(plugin.IMListenerSession) {
+			_ = env.RT.Tmux("kill-session", "-t", "="+plugin.IMListenerSession)
+		}
 	}
-	ui.Ok(out, "插件 %s %s", ui.Bold(args[0]), verb)
+	ui.Ok(out, "插件 %s %s", ui.Bold(p.Manifest.ID), verb)
 	return nil
 }
 
@@ -404,23 +414,29 @@ func install(env plugin.Env, args []string, out io.Writer) error {
 	return nil
 }
 
-// uninstall 移除外部插件(注册行 + 安装文件;storage/config 保留以便重装)。
+// uninstall 移除外部插件:先停掉插件还在跑的会话,再删注册行/孤儿数据行/
+// 安装文件。默认保留 storage/config 以便重装复用;加 --purge 则连同清除。
 func uninstall(env plugin.Env, args []string, out io.Writer) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: ttmux plugin uninstall <id>")
+	purge := hasFlag(args, "--purge")
+	id := firstNonFlag(args)
+	if id == "" {
+		return fmt.Errorf("usage: ttmux plugin uninstall <id> [--purge]")
 	}
 	store, err := openStore(env)
 	if err != nil {
 		return err
 	}
 	defer store.Close()
-	p, err := store.Get(args[0])
+	p, err := store.Get(id)
 	if err != nil {
 		return err
 	}
 	if p.Manifest.Runtime.Kind == "builtin" {
 		return fmt.Errorf("built-in plugin %s cannot be uninstalled (disable with: ttmux plugin disable %s)", p.Manifest.ID, p.Manifest.Name)
 	}
+	// 先停掉插件还活着的会话(spawn 的评审会话 + im-bridge 常驻监听会话),
+	// 免得进程继续引用即将被删的插件文件。
+	stopPluginSessions(env, store, p.Manifest.ID)
 	if err := store.Remove(p.Manifest.ID); err != nil {
 		return err
 	}
@@ -429,8 +445,38 @@ func uninstall(env plugin.Env, args []string, out io.Writer) error {
 		_ = os.RemoveAll(filepath.Dir(p.InstallPath)) // <id>/ 整目录(含各版本)
 	}
 	env.Audit(plugin.AuditEntry{Plugin: p.Manifest.ID, Version: p.Manifest.Version, Actor: actor(), Action: "plugin.uninstall", Decision: "allowed"})
-	ui.Ok(out, "已卸载 %s(配置与数据保留在 storage,可重装复用)", ui.Bold(p.Manifest.ID))
+	if purge {
+		_ = os.RemoveAll(env.StorageDir(p.Manifest.ID))
+		ui.Ok(out, "已卸载 %s(含配置与数据,--purge)", ui.Bold(p.Manifest.ID))
+		return nil
+	}
+	ui.Ok(out, "已卸载 %s(配置与数据保留在 storage,可重装复用;彻底清除加 --purge)", ui.Bold(p.Manifest.ID))
 	return nil
+}
+
+// stopPluginSessions kills any live tmux sessions the plugin owns. 用 =name
+// 精确匹配,避免前缀误伤(见 tmux -t 前缀匹配坑)。
+func stopPluginSessions(env plugin.Env, store *plugin.Store, id string) {
+	rows, _ := store.Sessions(id, "")
+	for _, r := range rows {
+		if env.RT.HasSession(r.Session) {
+			_ = env.RT.Tmux("kill-session", "-t", "="+r.Session)
+		}
+	}
+	// im-bridge 的入站监听会话由 plugind 直接拉起,不登记在 plugin_sessions,单独收
+	if id == "roam.im-bridge" && env.RT.HasSession(plugin.IMListenerSession) {
+		_ = env.RT.Tmux("kill-session", "-t", "="+plugin.IMListenerSession)
+	}
+}
+
+// firstNonFlag returns the first positional (non---flag) arg, or "".
+func firstNonFlag(args []string) string {
+	for _, a := range args {
+		if !strings.HasPrefix(a, "--") {
+			return a
+		}
+	}
+	return ""
 }
 
 // track 把一个已存在的会话登记给插件跟踪:plugind 在其退出时向该插件派发
@@ -515,7 +561,7 @@ func help(out io.Writer) {
 
   ls [--json]                         列出插件与其命令
   install <目录|包.tgz>                安装外部插件(node/exec 运行时,默认未启用)
-  uninstall <id>                      卸载外部插件(builtin 不可卸载)
+  uninstall <id> [--purge]            卸载外部插件(builtin 不可卸载;--purge 连配置数据一并清除)
   info <id> [--json]                  插件详情(manifest、权限、状态)
   enable|disable <id>                 启用 / 禁用插件
   run <插件>.<命令> [--key value ...]  调用插件命令(如 review-mesh.review)

--- a/cli/ttmux-cli-go/internal/plugin/store.go
+++ b/cli/ttmux-cli-go/internal/plugin/store.go
@@ -157,10 +157,26 @@ func (s *Store) migrateRenamedBuiltins() {
 	_, _ = s.db.Exec(`UPDATE plugin_sessions SET plugin=? WHERE plugin=?`, newID, oldID)
 }
 
-// Remove deletes a plugin's registry row (files handled by the caller).
+// Remove deletes a plugin's registry row plus its owned rows in the session/
+// finding/notification tables —— 卸载后不留孤儿数据(会话表按 plugin、通知表
+// 按 source 归属)。安装文件与 storage 目录由调用方处理(见 uninstall)。
 func (s *Store) Remove(id string) error {
-	_, err := s.db.Exec(`DELETE FROM plugins WHERE id=?`, id)
-	return err
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	for _, q := range []string{
+		`DELETE FROM plugins WHERE id=?`,
+		`DELETE FROM plugin_sessions WHERE plugin=?`,
+		`DELETE FROM plugin_findings WHERE plugin=?`,
+		`DELETE FROM plugin_notifications WHERE source=?`,
+	} {
+		if _, err := tx.Exec(q, id); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // List returns all registered plugins.

--- a/frontend/src/PluginsPanel.tsx
+++ b/frontend/src/PluginsPanel.tsx
@@ -3,7 +3,7 @@
 // 数据全部走 backend 薄封装 REST(exec ttmux plugin ... --json),前端不感知 plugind。
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
-  Alert, Button, Card, Descriptions, Divider, Empty, Form, Input, List, Modal, Popconfirm, Select,
+  Alert, Button, Card, Checkbox, Descriptions, Divider, Empty, Form, Input, List, Modal, Popconfirm, Select,
   Space, Spin, Switch, Table, Tabs, Tag, Tooltip, Typography, Upload, message,
 } from 'antd'
 import { api } from './api'
@@ -224,9 +224,10 @@ function PluginDetail({ plugin, locale, t, onChanged }: {
   const m = plugin.manifest
   const fields = m.contributes?.configFields || []
   const commands = m.contributes?.commands || []
+  const [purge, setPurge] = useState(false)
   const uninstall = async () => {
     try {
-      await api('DELETE', `/plugins/${encodeURIComponent(m.id)}`)
+      await api('DELETE', `/plugins/${encodeURIComponent(m.id)}${purge ? '?purge=1' : ''}`)
       message.success(t('plugins.uninstalled'))
       onChanged()
     } catch (e: any) {
@@ -239,7 +240,16 @@ function PluginDetail({ plugin, locale, t, onChanged }: {
         <Tag color={plugin.enabled ? 'green' : undefined}>{t(plugin.enabled ? 'plugins.stateEnabled' : 'plugins.stateDisabled')}</Tag>
         <Tag>{m.runtime?.kind || 'builtin'}</Tag></Space>}
       extra={m.runtime?.kind !== 'builtin' && (
-        <Popconfirm title={t('plugins.uninstallConfirm')} onConfirm={uninstall}>
+        <Popconfirm
+          title={t('plugins.uninstallConfirm')}
+          description={
+            <Checkbox checked={purge} onChange={(e) => setPurge(e.target.checked)}>
+              {t('plugins.uninstallPurge')}
+            </Checkbox>
+          }
+          onConfirm={uninstall}
+          onOpenChange={(open) => { if (!open) setPurge(false) }}
+        >
           <Button size="small" danger>{t('plugins.uninstall')}</Button>
         </Popconfirm>
       )}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -780,7 +780,8 @@ const enUS = {
   'plugins.installFromPath': 'Install',
   'plugins.installedOk': 'Installed (disabled by default; enable it in the list)',
   'plugins.uninstall': 'Uninstall',
-  'plugins.uninstallConfirm': 'Uninstall this plugin? Files are removed; config and data are kept',
+  'plugins.uninstallConfirm': 'Uninstall this plugin? Its sessions are stopped and installed files removed',
+  'plugins.uninstallPurge': 'Also delete config and data (not kept; no reuse on reinstall)',
   'plugins.uninstalled': 'Plugin uninstalled',
 }
 

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -780,7 +780,8 @@ const zhCN = {
   'plugins.installFromPath': '安装',
   'plugins.installedOk': '安装成功(默认未启用,请在列表中启用)',
   'plugins.uninstall': '卸载',
-  'plugins.uninstallConfirm': '卸载该插件?文件将删除,配置与数据保留',
+  'plugins.uninstallConfirm': '卸载该插件?将停掉其会话并删除安装文件',
+  'plugins.uninstallPurge': '同时删除配置与数据(不保留,无法重装复用)',
   'plugins.uninstalled': '插件已卸载',
 }
 


### PR DESCRIPTION
## 背景

插件卸载功能本已存在(CLI `plugin uninstall`、HTTP `DELETE /api/plugins/:id`、前端卸载按钮),但卸载/禁用后会留残骸。本 PR 补齐插件生命周期清理。

## 改动

**1. 停掉插件还活着的会话** — `cli/.../command/plugin/plugin.go`
- 卸载时先停掉该插件 spawn 的评审会话 + `roam.im-bridge` 的常驻监听会话 `_ttmux-im`,再删文件,避免进程继续引用已删文件。用 `=name` 精确匹配防前缀误伤。
- **禁用** im-bridge 时也停掉监听会话:`ensureIMListener` 只在启用时拉起,不停的话现存监听会一直挂到 24h invoke 上限才退(这才是「常驻会话不停」的真正现场,因为 im-bridge 是 builtin、卸载被拒)。

**2. 清孤儿数据库行** — `cli/.../plugin/store.go`
- `store.Remove` 从只 `DELETE FROM plugins` 改为事务里连带清 `plugin_sessions / plugin_findings / plugin_notifications`,不再留死行。

**3. `--purge` 彻底清除(默认仍保留)** — CLI + 后端 + 前端
- CLI:`ttmux plugin uninstall <id> --purge` 连 storage/config 一并删。
- 后端:`DELETE /api/plugins/:id?purge=1` 透传 `--purge`。
- 前端 `PluginsPanel.tsx`:卸载确认框加「同时删除配置与数据」勾选(默认不勾,保留重装复用),中英文案齐全,符合 i18n 规范。

## 验证

- Go CLI + backend 编译通过;`internal/plugin` 单测通过;frontend `tsc` + i18n audit 无错(pre-commit 质量门全绿)。
- 真机 smoke test:
  - install → uninstall(保留数据):注册行/安装文件清除,storage 保留 ✅
  - install → uninstall `--purge`:storage/安装文件/注册行全清 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)