### PR TITLE
fix(web): 文件面板与 Git 面板可并存，不再互斥

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -702,9 +702,10 @@ function TerminalPane(props: {
   const [showFiles, setShowFiles] = useState(fileDock === 'left')
   const [showGit, setShowGit] = useState(false)
   const [cwd, setCwd] = useState('')
-  // 文件栏与 Git 面板共用右侧抽屉位，互斥显示。
-  const toggleFiles = () => setShowFiles((s) => { if (!s) setShowGit(false); return !s })
-  const toggleGit = () => setShowGit((s) => { if (!s) setShowFiles(false); return !s })
+  // 文件栏与 Git 面板可并存：左侧停靠时文件走左栏、Git 走右抽屉，天然并列；
+  // 右侧停靠时两者都是右抽屉，Git 抽屉在文件也开着时向左让位（见下方 right 偏移），并排显示而非互相覆盖。
+  const toggleFiles = () => setShowFiles((s) => !s)
+  const toggleGit = () => setShowGit((s) => !s)
 
   // 从文件/Git 面板把文件拖到终端 → 插入为 @绝对路径。
   const [dragOver, setDragOver] = useState(false)
@@ -1124,7 +1125,7 @@ function TerminalPane(props: {
           <FileBrowser dir={cwd} accent="#58a6ff" onClose={() => setShowFiles(false)} />
         </FloatingFileDrawer>
       )}
-      <FloatingFileDrawer open={showGit}>
+      <FloatingFileDrawer open={showGit} right={fileDock === 'right' && showFiles ? 'min(420px, 92vw)' : 0}>
         <Suspense fallback={<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}><Spin /></div>}>
           <GitPanel dir={cwd} accent="#58a6ff" onClose={() => setShowGit(false)} />
         </Suspense>

--- a/frontend/src/FloatingFileDrawer.tsx
+++ b/frontend/src/FloatingFileDrawer.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-export default function FloatingFileDrawer({ open, children }: { open: boolean; children: ReactNode }) {
+export default function FloatingFileDrawer({ open, children, right = 0 }: { open: boolean; children: ReactNode; right?: number | string }) {
   if (!open) return null
   return (
     <div
@@ -8,7 +8,7 @@ export default function FloatingFileDrawer({ open, children }: { open: boolean; 
       style={{
         position: 'fixed',
         top: 0,
-        right: 0,
+        right,
         bottom: 0,
         height: '100dvh',
         zIndex: 1200,


### PR DESCRIPTION
## 问题

会话终端视图（如 `#/term/<会话>` 全屏页）里「📁 文件」和「Git」两个面板互斥：开一个就自动关掉另一个，无法同时查看。

## 根因

`App.tsx` 的 `toggleFiles` / `toggleGit` 里，打开一个面板前会强制关闭另一个：

```js
const toggleFiles = () => setShowFiles((s) => { if (!s) setShowGit(false); return !s })
const toggleGit   = () => setShowGit((s)   => { if (!s) setShowFiles(false); return !s })
```

但这两个面板其实分处两侧：
- **左侧停靠**（`fileDock='left'`，新标签全屏页）：文件在左栏 `FileWorkspace`，Git 是右浮动抽屉 —— 天然不冲突，互斥纯属多余。
- **右侧停靠**（默认）：两者都是 `right:0` 的浮动抽屉，同时开会重叠。

## 修改

- `toggleFiles` / `toggleGit` 改为各自独立开关，不再互相关闭。
- `FloatingFileDrawer` 新增 `right` 偏移入参。右侧停靠且文件抽屉已开时，Git 抽屉右移一个文件抽屉宽度（`min(420px, 92vw)`），两抽屉**并排**而非互相覆盖；左侧停靠时 Git 仍贴右 `right:0`。

## 测试

- `tsc --noEmit` 通过；提交质量门（i18n / typecheck / secret scan）全绿。
- 仅动 2 个前端文件，无行为面外的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)