### PR TITLE
feat(web): 会话右侧文件抽屉统一为树视图（与左侧 Files 页一致）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1122,7 +1122,7 @@ function TerminalPane(props: {
       )}
       {fileDock === 'right' && (
         <FloatingFileDrawer open={showFiles}>
-          <FileBrowser dir={cwd} accent="#58a6ff" onClose={() => setShowFiles(false)} />
+          <FileBrowser dir={cwd} accent="#58a6ff" layout="dock" onClose={() => setShowFiles(false)} />
         </FloatingFileDrawer>
       )}
       <FloatingFileDrawer open={showGit} right={fileDock === 'right' && showFiles ? 'min(420px, 92vw)' : 0}>


### PR DESCRIPTION
## 改动
会话右侧文件抽屉改用 `layout="dock"`，与左侧 Files 页同款：**树视图 + 统一右键菜单 + Modal 预览**，消除「会话里的文件夹像另一个组件、右键菜单一下移就消失」的割裂感。

> 注：本分支原先还包含 概览会话优先 / 文件浏览器右键统一 / AGPLv3 / CLI send bracketed-paste 等改动，rebase 到最新 main 后发现均已通过其它 PR 合入，故最终仅剩本条一行改动。

## 验证
- 前端 `tsc --noEmit` 通过；i18n audit 通过（777 keys）。
- Go 测试通过（pre-commit 质量门禁）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)