### PR TITLE
fix(web): 手机端对话页布局优化——输入区竖排、工具栏横滑、禁下拉刷新

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -924,7 +924,7 @@ function TerminalPane(props: {
     </div>
   )
   const sessionToolbar = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)', flexWrap: 'wrap' }}>
+    <div className="tt-session-toolbar" style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px', borderBottom: '1px solid var(--border-subtle)', flexWrap: 'nowrap', overflowX: 'auto', overflowY: 'hidden', WebkitOverflowScrolling: 'touch' }}>
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-dim)', fontSize: 12 }}>
         <i style={{ width: 8, height: 8, borderRadius: '50%', background: dot }} />
         {activeNeedsInput ? t('session.waiting') : st === 'connected' ? t('terminal.status.connected') : st === 'connecting' ? t('terminal.status.connecting') : t('terminal.status.disconnected')}

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -1,7 +1,7 @@
 // 对话页外壳：头部 / 滚动区 / 交互选择框 / 输入发送 / 文件侧栏。
 // Claude、Codex 共用，差异只在 title、accent、占位文案与消息渲染(renderMessage)。
 import { useEffect, useRef, useState, type ReactNode } from 'react'
-import { Button, Input, App as AntApp } from 'antd'
+import { Button, Grid, Input, App as AntApp } from 'antd'
 import { api, upload, makeClipboardImageFile } from '../api'
 import FileBrowser from '../FileBrowser'
 import FloatingFileDrawer from '../FloatingFileDrawer'
@@ -38,9 +38,13 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
   const atBottom = useRef(true)
   const { message } = AntApp.useApp()
   const { t } = useI18n()
+  const screens = Grid.useBreakpoint()
+  const isMobile = !screens.md // 手机窄屏：输入区换成「文本框独占一行 + 按钮行」竖排，避免挤成一坨
 
+  // 把文本追加进输入框末尾（语音识别结果 / 路径插入共用）
+  const appendText = (s: string) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + s + ' ')
   // 把路径插进输入框（文件侧栏「@」按钮 / 拖拽 / 上传后共用）
-  const insertPath = (p: string) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + p + ' ')
+  const insertPath = (p: string) => appendText(p)
 
   // 图片上传到 /tmp 并把完整路径插进输入框（等同桌面 Ctrl+V：不污染工作目录，模型按绝对路径读取）
   const uploadImagesToTmp = async (images: File[]) => {
@@ -162,7 +166,7 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
           <Button size="small" onClick={onBack}>{t('chat.backToTerminal')}</Button>
         </div>
         <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex' }}>
-          <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '8px 12px' }}>
+          <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch', padding: '8px 12px' }}>
             {messages.length === 0 && !pending && <div style={{ color: 'var(--text-dim)', textAlign: 'center', marginTop: 30 }}>{t('chat.loadingTranscript')}</div>}
             {hidden > 0 && (
               <div style={{ textAlign: 'center', margin: '2px 0 8px' }}>
@@ -183,21 +187,42 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
         {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
         <PromptPanel name={name} accent={accent} />
         {errMsg && <div style={{ color: '#f85149', fontSize: 12, padding: '2px 12px' }}>{errMsg}</div>}
-        <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: 'flex-end' }}>
+        <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 8, padding: 10, borderTop: '1px solid var(--border)', alignItems: isMobile ? 'stretch' : 'flex-end' }}>
           <input ref={fileRef} type="file" multiple style={{ display: 'none' }}
             onChange={(e) => { const fs = e.target.files ? Array.from(e.target.files) : []; e.target.value = ''; if (fs.length) doUpload(fs) }} />
-          <Button title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>
-          <Input.TextArea
-            value={input} onChange={(e) => setInput(e.target.value)}
-            autoSize={{ minRows: 1, maxRows: 5 }} placeholder={placeholder}
-            onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
-            onPaste={onPaste}
-          />
-          {busy && <Button danger title={t('chat.stopTitle')} onClick={stop}>{t('chat.stop')}</Button>}
-          <Button type="primary" loading={sending} onClick={send} style={{ background: accent, borderColor: accent }}>{t('common.send')}</Button>
+          {isMobile ? (
+            // 手机端：文本框独占一行，操作钮（📎 / 语音 / 停止 / 发送）另起一行，语音钮内联进按钮行避免悬浮遮挡。
+            <>
+              <Input.TextArea
+                value={input} onChange={(e) => setInput(e.target.value)}
+                autoSize={{ minRows: 1, maxRows: 6 }} placeholder={placeholder}
+                onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
+                onPaste={onPaste}
+              />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <Button shape="circle" title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>
+                <VoiceInput inline accent={accent} onResult={appendText} />
+                <span style={{ flex: 1 }} />
+                {busy && <Button danger title={t('chat.stopTitle')} onClick={stop}>{t('chat.stop')}</Button>}
+                <Button type="primary" loading={sending} onClick={send} style={{ background: accent, borderColor: accent }}>{t('common.send')}</Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <Button title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>
+              <Input.TextArea
+                value={input} onChange={(e) => setInput(e.target.value)}
+                autoSize={{ minRows: 1, maxRows: 5 }} placeholder={placeholder}
+                onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
+                onPaste={onPaste}
+              />
+              {busy && <Button danger title={t('chat.stopTitle')} onClick={stop}>{t('chat.stop')}</Button>}
+              <Button type="primary" loading={sending} onClick={send} style={{ background: accent, borderColor: accent }}>{t('common.send')}</Button>
+            </>
+          )}
         </div>
-        {/* 右下角悬浮语音按钮：长按说话，识别后回填到输入框，由用户再编辑/发送 */}
-        <VoiceInput accent={accent} onResult={(text) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + text + ' ')} />
+        {/* 桌面端右下角悬浮语音按钮（长按说话，识别回填输入框）；手机端已内联到按钮行。 */}
+        {!isMobile && <VoiceInput accent={accent} onResult={appendText} />}
       </div>
       <FloatingFileDrawer open={showFiles}>
         <FileBrowser dir={dir} accent={accent} onClose={() => setShowFiles(false)} onInsertPath={insertPath} />

--- a/frontend/src/chat/VoiceInput.tsx
+++ b/frontend/src/chat/VoiceInput.tsx
@@ -13,7 +13,7 @@ const CANCEL_DY = 90
 // 录音时长下限：太短的误触不送去识别。
 const MIN_MS = 500
 
-export function VoiceInput({ accent, onResult }: { accent: string; onResult: (text: string) => void }) {
+export function VoiceInput({ accent, onResult, inline = false }: { accent: string; onResult: (text: string) => void; inline?: boolean }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
   // 录音能力探测：getUserMedia/MediaRecorder 仅在安全上下文(HTTPS / localhost)可用。
@@ -160,8 +160,12 @@ export function VoiceInput({ accent, onResult }: { accent: string; onResult: (te
         onPointerUp={(e) => { e.preventDefault(); end() }}
         onPointerCancel={() => { cancelRef.current = true; end() }}
         style={{
-          position: 'absolute', right: 18, bottom: 54, zIndex: 25,
-          width: 54, height: 54, borderRadius: '50%', cursor: 'pointer',
+          // 内联模式：作为输入行里的一枚普通圆钮（手机端，避免悬浮盖住发送键）；
+          // 悬浮模式：右下角「微信式」悬浮麦克风（桌面端）。
+          ...(inline
+            ? { position: 'relative', flex: '0 0 auto', width: 32, height: 32 } // 对齐 antd 默认按钮高度，与 📎/发送 成一排
+            : { position: 'absolute', right: 18, bottom: 54, zIndex: 25, width: 54, height: 54 }),
+          borderRadius: '50%', cursor: 'pointer',
           border: 'none', touchAction: 'none', userSelect: 'none',
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           background: cancelArmed ? '#d23' : accent,
@@ -170,7 +174,7 @@ export function VoiceInput({ accent, onResult }: { accent: string; onResult: (te
           opacity: (configured && micUsable) ? 1 : 0.92,
         }}>
         <span className={(phase === 'recording' || phase === 'transcribing') ? 'cc-pulse' : undefined} style={{ display: 'inline-flex' }}>
-          <MicIcon size={26} />
+          <MicIcon size={inline ? 18 : 26} />
         </span>
       </button>
     </>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,8 @@
 }
 
 html, body, #root { height: 100%; margin: 0; }
+/* 禁掉移动端「下拉刷新」与滚动链/边缘回弹：轻微下拉不再误触整页刷新 */
+html, body { overscroll-behavior: none; }
 body {
   background: var(--bg-base);
   /* 精修字体栈：优先界面无衬线 + 中文黑体；数字等宽对齐更整齐 */
@@ -87,6 +89,11 @@ body {
 }
 *::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); background-clip: content-box; }
 *::-webkit-scrollbar-corner { background: transparent; }
+
+/* 会话工具栏：单行横向滑动（手机上原本换行占 3 行）；子项不收缩、隐藏滚动条 */
+.tt-session-toolbar > * { flex: 0 0 auto; }
+.tt-session-toolbar { scrollbar-width: none; }
+.tt-session-toolbar::-webkit-scrollbar { height: 0; width: 0; }
 
 /* 选区色：主色低透明，克制 */
 ::selection { background: rgba(88, 166, 255, 0.26); }


### PR DESCRIPTION
## 背景
手机端 Claude/Codex 对话页布局若干问题（真机 5G 反馈）：输入区挤成一坨、语音钮悬浮遮住发送键、会话工具栏换行占 3 行、以及轻微下拉误触整页刷新。

## 改动（`frontend/src`）
- **输入区竖排**（`ChatShell.tsx`，窄屏 `!screens.md`）：文本框独占一行，操作钮（📎 / 语音 / 停止 / 发送）另起一行。桌面端布局不变。
- **语音钮内联**（`VoiceInput.tsx` 新增 `inline`）：手机端麦克风做成 32px 圆钮内联进按钮行，与 📎 成对、不再悬浮遮挡发送键；桌面仍是右下角「微信式」悬浮钮。
- **会话工具栏横向滑动**（`App.tsx` + `index.css`）：由 `flex-wrap: wrap`（占 3 行）改为单行 `nowrap + overflow-x:auto`，子项不收缩、隐藏滚动条，手机左右滑动够到重连/字号/滚屏等钮，省出竖向空间。
- **禁下拉刷新**（`index.css` + `ChatShell.tsx`）：`html/body` 加 `overscroll-behavior:none`，对话滚动区加 `overscroll-behavior:contain`，轻微下拉不再误触刷新，也不产生滚动链。

## 验证
- `tsc --noEmit` 通过；i18n audit 通过（802 keys）；Go 测试通过（pre-commit 质量门禁）。
- 已在真机（Android Chrome，LAN HTTPS）逐条回归：输入区、语音钮、工具栏横滑、下拉不再刷新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)