### PR TITLE
fix(web): 终端拖入系统文件走上传注入 + 粘图去重

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -723,6 +723,8 @@ function TerminalPane(props: {
   const readDropPath = (e: React.DragEvent) =>
     e.dataTransfer.getData('application/x-ttmux-path') || e.dataTransfer.getData('text/plain') || ''
   const isPathDrag = (e: React.DragEvent) => e.dataTransfer.types.includes('application/x-ttmux-path')
+  // 系统文件拖入（非内部路径拖拽）：types 含 'Files'。不接住的话浏览器会把文件当新标签打开。
+  const isFileDrag = (e: React.DragEvent) => e.dataTransfer.types.includes('Files')
   const allowPathDrop = (e: React.DragEvent) => {
     if (!isPathDrag(e)) return
     e.preventDefault()
@@ -733,8 +735,32 @@ function TerminalPane(props: {
     const r = e.currentTarget.getBoundingClientRect()
     return e.clientX > r.left + r.width / 2
   }
+  // 从系统拖入真实文件：上传后把绝对路径以 @ 注入当前会话（等同 Ctrl+V 粘图）。
+  // 图片走 /tmp（不污染工作目录），其余文件走会话工作目录。
+  const onTermFileDrop = async (e: React.DragEvent) => {
+    const files = Array.from(e.dataTransfer.files || [])
+    if (!files.length || !active) return
+    const imgs = files.filter((f) => f.type.startsWith('image/'))
+    const rest = files.filter((f) => !f.type.startsWith('image/'))
+    const saved: string[] = []
+    try {
+      if (imgs.length) saved.push(...(await upload('/tmp', imgs)).saved)
+      if (rest.length) {
+        if (!cwd) { message.error(t('chat.cwdMissing')) }
+        else saved.push(...(await upload(cwd, rest)).saved)
+      }
+    } catch (err: any) { message.error(t('terminal.imageUploadFailed', { message: err.message })); return }
+    if (!saved.length) return
+    exitCopyMode()
+    termRefs.current[active]?.send(saved.map((p) => '@' + p).join(' ') + ' ', true)
+  }
   // 拖到终端区：直接把 @路径 送进当前会话（claude/codex TUI 或 shell 提示符的光标处）。
   const onTermDrop = (e: React.DragEvent) => {
+    if (isFileDrag(e) && e.dataTransfer.files?.length) { // 系统文件：上传并注入（无视左右半区，不做分栏）
+      e.preventDefault(); e.stopPropagation(); setDragOver(false)
+      onTermFileDrop(e)
+      return
+    }
     if (!isPathDrag(e)) return
     if (inTermSplitZone(e)) { setDragOver(false); return } // 右半区：不拦截，冒泡给 FileWorkspace 分栏
     e.preventDefault()
@@ -818,8 +844,8 @@ function TerminalPane(props: {
           for (const item of items) {
             for (const type of item.types) {
               if (type.startsWith('image/')) {
-                const blob = await item.getType(type)
-                imageFiles.push(new File([blob], 'image', { type }))
+                // 同一张图多种 MIME 只取一张，避免重复上传出现两次 @路径
+                if (!imageFiles.length) { const blob = await item.getType(type); imageFiles.push(new File([blob], 'image', { type })) }
               } else if (type === 'text/plain') {
                 text = await (await item.getType(type)).text()
               }
@@ -977,6 +1003,7 @@ function TerminalPane(props: {
   const terminalArea = (
     <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}
       onDragOver={(e) => {
+        if (isFileDrag(e)) { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = 'copy'; setDragOver(true); return } // 系统文件：允许放下并上传
         if (!isPathDrag(e)) return
         if (inTermSplitZone(e)) { setDragOver(false); return } // 右半区：让事件冒泡给 FileWorkspace 显示分栏提示
         e.stopPropagation(); allowPathDrop(e); setDragOver(true)

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -302,17 +302,19 @@ const Term = forwardRef<TermHandle, {
     el.addEventListener('contextmenu', onCtx)
     const onPasteCapture = (e: ClipboardEvent) => {
       if (!e.clipboardData?.items) return
-      const files: File[] = []
+      // 一次粘贴只取一张图：同一张截图常以多种 MIME(image/png + image/jpeg…)重复出现，
+      // 全收会重复上传 → 终端里出现两次 @路径。取到第一张就停。
+      let file: File | null = null
       for (let i = 0; i < e.clipboardData.items.length; i++) {
         if (e.clipboardData.items[i].type.startsWith('image/')) {
           const f = e.clipboardData.items[i].getAsFile()
-          if (f) files.push(f)
+          if (f) { file = f; break }
         }
       }
-      if (files.length > 0) {
+      if (file) {
         e.preventDefault()
         e.stopPropagation()
-        onImagePaste?.(files)
+        onImagePaste?.([file])
       }
     }
     el.addEventListener('paste', onPasteCapture, { capture: true })

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -78,12 +78,13 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
 
   const onPaste = async (e: React.ClipboardEvent) => {
     if (!e.clipboardData?.items) return
+    // 一次粘贴只取一张图：同一张截图常以多种 MIME 重复出现，全收会插入两次 @路径
     const imageFiles: File[] = []
     for (let i = 0; i < e.clipboardData.items.length; i++) {
       const item = e.clipboardData.items[i]
       if (item.type.startsWith('image/')) {
         const f = item.getAsFile()
-        if (f) imageFiles.push(makeClipboardImageFile(f, item.type, imageFiles.length))
+        if (f) { imageFiles.push(makeClipboardImageFile(f, item.type, imageFiles.length)); break }
       }
     }
     if (imageFiles.length > 0) {


### PR DESCRIPTION
## 背景

`#/term/<会话>` 页面上报两个问题：

1. **拖动文件到终端(对话框)不生效，浏览器直接新开标签打开文件** —— 分栏修复(8a0df0e)后暴露。终端拖放区此前只处理内部路径拖拽(`application/x-ttmux-path`)，对系统拖入的真实文件(`dataTransfer.files`)完全不拦截，走浏览器默认行为 → 把文件当新标签打开。
2. **Ctrl+V 粘贴图片后出现两次 `@xx.png`** —— 同一张截图常以多种 MIME(`image/png` + `image/jpeg` …)同时出现在剪贴板，逐项全收会把同一张图重复上传、插入两次 `@路径`。

## 修复

**Bug 1 — 终端支持系统文件拖入上传**
- `terminalArea` 的 `onDragOver`/`onDrop` 新增 `isFileDrag` 分支：拖入系统文件时 `preventDefault` 并上传——图片走 `/tmp`（不污染工作目录）、其余文件走会话工作目录——再把绝对路径以 `@` 注入当前会话，等同 Ctrl+V 粘图。无视左右半区、不触发分栏。

**Bug 2 — 一次粘贴只取一张图**
- `Terminal.tsx onPasteCapture`、`App.tsx pasteClipboard`、`ChatShell.tsx onPaste` 三处收图循环统一「取到第一张就停」，避免同图多 MIME 重复上传。

## 验证
- `tsc --noEmit` 通过；`npm run build` 通过；仓库质量门(i18n / typecheck / tests / secret scan)全绿。
- 复用既有 i18n key（`terminal.dropToMention` / `terminal.imageUploadFailed` / `chat.cwdMissing`），无新增硬编码文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)