### PR TITLE
fix(web): 拖文件到对话插入@引用 + HTML 预览支持同目录相对引用

### DIFF
--- a/backend/api/files.go
+++ b/backend/api/files.go
@@ -259,6 +259,25 @@ func (a *API) FileRaw(c *gin.Context) {
 	c.File(p)
 }
 
+// FileServe GET /file/serve/*path —— 把文件绝对路径直接编进 URL 路径来提供文件
+// （区别于 /file/raw 的 ?path= 查询参数）。这样 HTML 内的同目录相对引用（style.css、
+// ./app.js、../img/x.png）会被浏览器按 URL 相对规则解析到同目录资源，再命中本路由取到
+// 文件，相当于一个以文件系统为根的静态文件服务。暴露面与 /file/raw 一致（都能读任意
+// 可访问的绝对路径文件，已在鉴权后）。仅供 HTML 预览 iframe 使用。
+func (a *API) FileServe(c *gin.Context) {
+	p := filepath.Clean(c.Param("path")) // *path 含前导斜杠 → 即绝对路径；Clean 顺带归一化 .. 段
+	if p == "" || p == "/" || !filepath.IsAbs(p) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_PATH"}})
+		return
+	}
+	info, err := os.Stat(p)
+	if err != nil || info.IsDir() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "NOT_FILE"}})
+		return
+	}
+	c.File(p) // Content-Type 按扩展名嗅探：.css→text/css .js→text/javascript .html→text/html
+}
+
 var officePreviewExt = map[string]bool{
 	".doc": true, ".docx": true, ".odt": true, ".rtf": true,
 	".xls": true, ".xlsx": true, ".xlsm": true, ".ods": true,

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -110,12 +110,13 @@ func New(cfg Config) *gin.Engine {
 		g.GET("/info", h.Info)
 
 		g.GET("/fs", h.FS)
-		g.GET("/files", h.Files)              // 文件侧栏：列目录
-		g.GET("/file", h.File)                // 文件侧栏：读文件
-		g.POST("/file/save", h.FileSave)      // 文件侧栏：编辑器保存（覆盖写入既有文件）
-		g.GET("/file/search", h.FileSearch)   // 文件侧栏：从当前目录递归按文件名搜索
-		g.GET("/file/raw", h.FileRaw)         // 文件侧栏：原始字节（图片预览 / ?dl=1 下载）
-		g.GET("/file/preview", h.FilePreview) // 文件侧栏：Office 转 PDF 预览
+		g.GET("/files", h.Files)                // 文件侧栏：列目录
+		g.GET("/file", h.File)                  // 文件侧栏：读文件
+		g.POST("/file/save", h.FileSave)        // 文件侧栏：编辑器保存（覆盖写入既有文件）
+		g.GET("/file/search", h.FileSearch)     // 文件侧栏：从当前目录递归按文件名搜索
+		g.GET("/file/raw", h.FileRaw)           // 文件侧栏：原始字节（图片预览 / ?dl=1 下载）
+		g.GET("/file/serve/*path", h.FileServe) // 文件侧栏：HTML 预览（绝对路径进 URL，令同目录相对引用可解析）
+		g.GET("/file/preview", h.FilePreview)   // 文件侧栏：Office 转 PDF 预览
 		g.GET("/file/stat", h.FileStat)
 		g.GET("/file/download", h.FileDownload)
 		g.POST("/file/rename", h.FileRename)

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -58,11 +58,13 @@ export default function FileWorkspace({
   const [dirtyFiles, setDirtyFiles] = useState<Set<string>>(new Set())
   const [dropHint, setDropHint] = useState<Group | 'split' | null>(null) // 拖拽落点提示
   const [dragging, setDragging] = useState(false) // 原生拖拽进行中 → 每栏内容盖一层透明接盘层，压过终端/Monaco
+  // 拖的是 tab/会话(需接盘层压过终端才能移栏) 还是文件路径(要落回终端/对话做 @引用注入,不能被接盘层截走)
+  const [dragKind, setDragKind] = useState<'tab' | 'lead' | 'path' | null>(null)
   useEffect(() => {
     // drop 用「冒泡阶段」清理：React 事件委托挂在 document 内层根节点，冒泡到 document 时
     // onDrop 已派发完，此时卸接盘层安全。若用捕获阶段则会赶在 onDrop 前卸掉接盘层 →
     // drop 落到已移除的元素 → onDrop 不触发 → tab 不动。dragend 兜底（拖到界外/取消）。
-    const end = () => { setDropHint(null); setDragging(false) }
+    const end = () => { setDropHint(null); setDragging(false); setDragKind(null) }
     document.addEventListener('dragend', end)
     document.addEventListener('drop', end)
     return () => { document.removeEventListener('dragend', end); document.removeEventListener('drop', end) }
@@ -280,7 +282,7 @@ export default function FileWorkspace({
     const act = activeOf(g) === f
     return (
       <div key={g + f} title={prev ? `${t('file.preview')} · ${rp}` : f} draggable
-        onDragStart={(e) => { e.dataTransfer.setData(TAB_MIME, JSON.stringify({ path: f, from: g })); e.dataTransfer.effectAllowed = 'move'; setDragging(true) }}
+        onDragStart={(e) => { e.dataTransfer.setData(TAB_MIME, JSON.stringify({ path: f, from: g })); e.dataTransfer.effectAllowed = 'move'; setDragging(true); setDragKind('tab') }}
         onPointerDown={(e) => startTouchDrag(e, { kind: 'tab', path: f, from: g }, baseName(f))}
         onClick={() => { if (draggedRef.current) return; setActiveOf(g, f); setFocus(g) }}
         className={`cc-filetab${isDirty ? ' dirty' : ''}`}
@@ -312,7 +314,7 @@ export default function FileWorkspace({
             {primary && hasLeading && (
               <div onClick={() => { if (draggedRef.current) return; setActiveOf('A', null) }} title={leadingTitle}
                 draggable={split}
-                onDragStart={(e) => { e.dataTransfer.setData(LEAD_MIME, '1'); e.dataTransfer.effectAllowed = 'move'; setDragging(true) }}
+                onDragStart={(e) => { e.dataTransfer.setData(LEAD_MIME, '1'); e.dataTransfer.effectAllowed = 'move'; setDragging(true); setDragKind('lead') }}
                 onPointerDown={(e) => { if (split) startTouchDrag(e, { kind: 'lead' }, leadingTitle || '') }}
                 style={{ ...tabBase, gap: 6, padding: '5px 12px', color: leadingActive ? 'var(--text-bright)' : 'var(--text-dim)', background: leadingActive ? 'var(--bg-base)' : 'transparent', borderTop: `2px solid ${leadingActive ? '#58a6ff' : 'transparent'}` }}>
                 {leadingTab}
@@ -345,8 +347,10 @@ export default function FileWorkspace({
             <div style={{ flex: 1, display: 'grid', placeItems: 'center', color: 'var(--text-dimmer)', fontSize: 13 }}>{emptyText || t('file.selectPreview')}</div>
           )}
           {/* 拖拽期透明接盘层：盖在终端/Monaco 之上，抢在它们之前接住 dragover/drop，
-              否则拖 tab 到有终端/编辑器的那一栏时事件被内层吞掉 → 拖不进去 */}
-          {dragging && (
+              否则拖 tab 到有终端/编辑器的那一栏时事件被内层吞掉 → 拖不进去。
+              但拖「文件路径」到正显示会话(终端/对话)的首栏时不盖 → 让终端/ChatShell 自己接住做 @引用注入,
+              否则文件会被当成「开文件/分栏」而进不了对话。tab/lead 拖拽照旧盖(移栏必须压过终端)。 */}
+          {dragging && !(primary && leadingActive && dragKind === 'path') && (
             <div data-drop-group={g} data-drop-content="1" style={{ position: 'absolute', inset: 0, zIndex: 15 }}
               onDragOver={(e) => onContentDragOver(e, g, primary)}
               onDragLeave={(e) => { if (e.currentTarget === e.target) setDropHint(null) }}
@@ -365,7 +369,12 @@ export default function FileWorkspace({
 
   return (
     <div style={{ flex: 1, minHeight: 0, display: 'flex' }}
-      onDragEnter={(e) => { if (!dragging && dragHasPayload(e)) setDragging(true) }}>
+      onDragEnter={(e) => {
+        if (dragging || !dragHasPayload(e)) return
+        setDragging(true)
+        // 文件树拖出的路径:onDragStart 在 FileBrowser 里不置 kind,这里补判(唯一非 tab/lead 的来源)
+        setDragKind(e.dataTransfer.types.includes(PATH_MIME) ? 'path' : e.dataTransfer.types.includes(LEAD_MIME) ? 'lead' : 'tab')
+      }}>
       {explorerOpen && (
         <>
           <div style={{ flex: `0 0 ${dockW}px`, minWidth: 0, minHeight: 0, display: 'flex' }}>

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -43,8 +43,8 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
 
   // 把文本追加进输入框末尾（语音识别结果 / 路径插入共用）
   const appendText = (s: string) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + s + ' ')
-  // 把路径插进输入框（文件侧栏「@」按钮 / 拖拽 / 上传后共用）
-  const insertPath = (p: string) => appendText(p)
+  // 把路径以 @引用 插进输入框（文件侧栏「@」按钮 / 拖拽共用），与终端 toMention 一致
+  const insertPath = (p: string) => appendText('@' + p)
 
   // 图片上传到 /tmp 并把完整路径插进输入框（等同桌面 Ctrl+V：不污染工作目录，模型按绝对路径读取）
   const uploadImagesToTmp = async (images: File[]) => {
@@ -141,6 +141,7 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
         onDragEnter={(e) => { e.preventDefault() }}
         onDragOver={(e) => {
           e.preventDefault()
+          e.stopPropagation() // 对话区自己接住,别冒泡到 FileWorkspace 分栏层(否则会显示「分栏」提示并抢走 drop)
           const isPath = Array.from(e.dataTransfer.types || []).includes('application/x-ttmux-path')
           e.dataTransfer.dropEffect = 'copy'
           setDropMode(isPath ? 'path' : 'upload')
@@ -148,9 +149,9 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
         }}
         onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOver(false) }}
         onDrop={(e) => {
-          e.preventDefault(); setDragOver(false)
+          e.preventDefault(); e.stopPropagation(); setDragOver(false) // 阻断冒泡:否则分栏层还会再把文件当「开文件」打开一次
           const p = e.dataTransfer.getData('application/x-ttmux-path') || e.dataTransfer.getData('text/plain')
-          if (p && !e.dataTransfer.files?.length) { insertPath(p); return } // 从文件侧栏拖来的：插入路径
+          if (p && !e.dataTransfer.files?.length) { insertPath(p); return } // 从文件侧栏拖来的：插入 @路径
           if (e.dataTransfer?.files?.length) doUpload(e.dataTransfer.files) // 从系统拖来的：上传
         }}>
         {dragOver && (

--- a/frontend/src/fileview/FileView.tsx
+++ b/frontend/src/fileview/FileView.tsx
@@ -51,6 +51,8 @@ export function FileView({
   const kind = fileKind(path)
   const { isImg, isMd, isHtml, isPdf, isOffice, isSheet } = kind
   const rawUrl = `/api/file/raw?path=${encodeURIComponent(path)}`
+  // HTML 预览专用：绝对路径编进 URL 路径（逐段转义、保留斜杠），让 iframe 里同目录相对引用能解析
+  const serveUrl = `/api/file/serve${path.split('/').map(encodeURIComponent).join('/')}`
   const previewUrl = `/api/file/preview?path=${encodeURIComponent(path)}`
   const downloadUrl = `${rawUrl}&dl=1`
   const downloadName = fileNameOf(path)
@@ -191,7 +193,7 @@ export function FileView({
                 : isMd && (!source || forcePreview)
                   ? <MarkdownView content={data.content} accent={accent} height={previewHeight} pad={forcePreview ? '0 8px' : undefined} resolveHref={resolvePreviewHref} onLinkClick={openPreviewLink} />
                   : isHtml && (!source || forcePreview)
-                    ? <HtmlView rawUrl={rawUrl} name={name} mtime={data.mtime} height={previewHeight} />
+                    ? <HtmlView rawUrl={serveUrl} name={name} mtime={data.mtime} height={previewHeight} />
                     : <CodeView value={draft} language={monacoLangOf(path)} dark={mode === 'dark'} readOnly={!editable} tabbed={tabbed} height={previewHeight} onChange={setDraft} onSave={() => saveRef.current()} />}
               {data.truncated && <div style={{ color: '#d29922', fontSize: 12, marginTop: 6 }}>⚠ {t('file.truncatedLong')}</div>}
             </>

--- a/frontend/src/fileview/HtmlView.tsx
+++ b/frontend/src/fileview/HtmlView.tsx
@@ -1,5 +1,6 @@
-// HTML 展示：不在前端拼 DOM，直接 iframe 后端服务代理(/api/file/raw 以 text/html
-// 直出)，脚本/样式按原样运行。key 绑 mtime → 文件被外部(cc/codex)改动时 iframe 自动重载。
+// HTML 展示：不在前端拼 DOM，直接 iframe 后端服务代理(/api/file/serve/<绝对路径> 以
+// text/html 直出)，脚本/样式按原样运行；绝对路径进 URL 路径 → 同目录相对引用(css/js/img)
+// 能被浏览器解析到同目录资源。key 绑 mtime → 文件被外部(cc/codex)改动时 iframe 自动重载。
 export function HtmlView({ rawUrl, name, mtime, height }: {
   rawUrl: string
   name: string


### PR DESCRIPTION
## 两个文件面板修复

### 1) 拖文件到对话=插入 `@路径`(之前只会分屏)
根因:分屏的透明「接盘层」(`dragging`,zIndex 15)盖住终端/对话,把从文件树拖来的文件路径全吃成「开文件/分栏」,导致终端的 `onTermDrop`(注入 `@路径`)和 ChatShell 的 `onDrop`(插入)都收不到。

改法:用 `dragKind` 区分 tab/lead/path;接盘层加 `!(primary && leadingActive && dragKind===path)` —— 拖**文件路径**到正显示会话的首栏时不盖,让终端/ChatShell 原生 handler 接住做 @引用;tab/lead 拖拽照旧盖(移栏必须压过终端);右半区/另一栏仍走智能分屏。ChatShell `insertPath` 统一带 `@` 并 `stopPropagation` 免冒泡到接盘层二次开文件。

### 2) HTML 预览支持同目录相对引用
`/api/file/raw?path=` 用查询参数,iframe 里 `style.css` 会解析到 `/api/file/raw/style.css` → 404。新增 `GET /api/file/serve/*path`(绝对路径进 URL 路径),浏览器按相对规则解析同目录 css/js/img;HTML 预览 iframe 改用它。暴露面与 `/file/raw` 一致(鉴权后)。

## 验证
后端路由已上线(401=已注册)。拖拽 + HTML 预览为交互行为,建议真机点验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)