### PR TITLE
chore(cli): 移除旧任务编排命令入口，统一走 swarm

### DIFF
--- a/cli/ttmux-cli-go/internal/app/app.go
+++ b/cli/ttmux-cli-go/internal/app/app.go
@@ -95,25 +95,9 @@ func (a App) Run(args []string) error {
 	case "kp":
 		return session.KillPane(a.rt, rest, out)
 
-	// ── task orchestration (native) ──
-	case "spawn":
-		return a.runSpawn(rest)
-	case "wait":
-		return spawn.Wait(a.rt, rest, out)
-	case "agent":
-		return a.runAgent(rest)
+	// ── native helpers ──
 	case "capture":
 		return session.Capture(a.rt, rest, out)
-	case "collect":
-		if len(rest) < 1 {
-			return fmt.Errorf("usage: ttmux collect <group> [--json]")
-		}
-		if len(rest) >= 2 && rest[1] == "--json" {
-			return group.CollectJSON(a.rt, rest[0], out)
-		}
-		return group.CollectText(a.rt, rest[0], out)
-	case "group":
-		return a.runGroup(rest)
 	case "status":
 		return a.runStatus(rest)
 
@@ -139,63 +123,6 @@ func (a App) Run(args []string) error {
 	}
 }
 
-func (a App) runSpawn(args []string) error {
-	switch {
-	case len(args) >= 1 && args[0] == "--agent":
-		rest := args[1:]
-		if len(rest) >= 1 && rest[0] == "--file" {
-			return fileSpawn(a.rt, rest[1:], true)
-		}
-		return spawn.SpawnAgents(a.rt, rest, os.Stdout)
-	case len(args) >= 1 && args[0] == "--file":
-		return fileSpawn(a.rt, args[1:], false)
-	default:
-		return spawn.Spawn(a.rt, args, os.Stdout)
-	}
-}
-
-// fileSpawn parses `<group> <file> [opts]` for the --file spawn forms.
-func fileSpawn(rt runtime.Runtime, args []string, agent bool) error {
-	if len(args) < 2 {
-		return fmt.Errorf("usage: ttmux spawn [--agent] --file <group> <file> [opts]")
-	}
-	return spawn.SpawnFile(rt, args[0], args[1], args[2:], agent, os.Stdout)
-}
-
-func (a App) runAgent(args []string) error {
-	subcmd := "help"
-	if len(args) > 0 {
-		subcmd = args[0]
-		args = args[1:]
-	}
-	switch subcmd {
-	case "spawn":
-		if len(args) >= 1 && args[0] == "--file" {
-			return fileSpawn(a.rt, args[1:], true)
-		}
-		return spawn.SpawnAgents(a.rt, args, os.Stdout)
-	case "status":
-		return a.runStatus(args)
-	case "send":
-		return session.Send(a.rt, a.swarmSessions(), args, os.Stdout)
-	case "collect":
-		if len(args) < 1 {
-			return fmt.Errorf("usage: ttmux agent collect <group> [--json]")
-		}
-		if len(args) >= 2 && args[1] == "--json" {
-			return group.CollectJSON(a.rt, args[0], os.Stdout)
-		}
-		return group.CollectText(a.rt, args[0], os.Stdout)
-	case "kill":
-		if len(args) < 1 {
-			return fmt.Errorf("usage: ttmux agent kill <group>")
-		}
-		return group.Kill(a.rt, args[0], os.Stdout)
-	default:
-		return fmt.Errorf("unknown subcommand: agent %s", subcmd)
-	}
-}
-
 func (a App) runStatus(args []string) error {
 	if len(args) < 1 {
 		_ = session.List(a.rt, a.swarmSessions(), os.Stdout)
@@ -206,36 +133,6 @@ func (a App) runStatus(args []string) error {
 		return group.StatusJSON(a.rt, args[0], os.Stdout)
 	}
 	return group.Status(a.rt, args[0], os.Stdout)
-}
-
-func (a App) runGroup(args []string) error {
-	subcmd := "ls"
-	if len(args) > 0 {
-		subcmd = args[0]
-		args = args[1:]
-	}
-	switch subcmd {
-	case "ls", "list":
-		if has(args, "--json") {
-			return group.ListJSON(a.rt, os.Stdout)
-		}
-		return group.List(a.rt, a.swarmNames(), os.Stdout)
-	case "status":
-		if len(args) < 1 {
-			return fmt.Errorf("usage: ttmux group status <group>")
-		}
-		if len(args) >= 2 && args[1] == "--json" {
-			return group.StatusJSON(a.rt, args[0], os.Stdout)
-		}
-		return group.Status(a.rt, args[0], os.Stdout)
-	case "kill":
-		if len(args) < 1 {
-			return fmt.Errorf("usage: ttmux group kill <group>")
-		}
-		return group.Kill(a.rt, args[0], os.Stdout)
-	default:
-		return fmt.Errorf("unknown subcommand: group %s", subcmd)
-	}
 }
 
 // swarmSessions returns the set of tmux sessions hidden from native session

--- a/cli/ttmux-cli-go/internal/command/completion/completion.go
+++ b/cli/ttmux-cli-go/internal/command/completion/completion.go
@@ -16,7 +16,7 @@ const script = `_ttmux_completions() {
     local cur prev cmds
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    cmds="ls new a attach d detach kill killall rename nw lw kw sp split kp send info source help spawn group capture wait collect status completion agent swarm"
+    cmds="ls new a attach d detach kill killall rename nw lw kw sp split kp send info source help capture status completion swarm"
 
     case "$prev" in
         ttmux)
@@ -26,12 +26,6 @@ const script = `_ttmux_completions() {
             local sessions
             sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null)
             COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
-            return ;;
-        group)
-            COMPREPLY=($(compgen -W "new ls status kill" -- "$cur"))
-            return ;;
-        agent)
-            COMPREPLY=($(compgen -W "spawn status send collect kill" -- "$cur"))
             return ;;
         swarm)
             COMPREPLY=($(compgen -W "new add ls status activate collect migrate adopt done say listen feed watch board task sql archive rm" -- "$cur"))
@@ -48,11 +42,6 @@ const script = `_ttmux_completions() {
             local windows
             windows=$(tmux list-windows -F '#{window_index}' 2>/dev/null)
             COMPREPLY=($(compgen -W "$windows" -- "$cur"))
-            return ;;
-        wait|collect)
-            local groups
-            groups=$(ls ~/.local/share/ttmux/groups/*.group 2>/dev/null | xargs -I{} basename {} .group)
-            COMPREPLY=($(compgen -W "$groups" -- "$cur"))
             return ;;
     esac
 }

--- a/cli/ttmux-cli-go/internal/command/help/help.go
+++ b/cli/ttmux-cli-go/internal/command/help/help.go
@@ -29,17 +29,6 @@ func Show(version string, w io.Writer) {
 	fmt.Fprintf(w, "    %s            关闭所有会话\n", g("killall"))
 	fmt.Fprintf(w, "    %s %s  重命名会话\n\n", g("rename"), d("<旧名> <新名>"))
 
-	fmt.Fprintf(w, "  %s %s\n", b("任务编排"), m("(命令 / Agent 统一)"))
-	fmt.Fprintf(w, "    %s %s  批量创建命令任务\n", g("spawn"), d("<组名> <名称> <命令> ..."))
-	fmt.Fprintf(w, "    %s %s  批量创建 Claude/Codex Agent\n", g("spawn"), d("--agent <组名> <名称> <任务> ..."))
-	fmt.Fprintf(w, "    %s %s  查看状态 (命令+Agent)\n", g("status"), d("<组名> [--json]"))
-	fmt.Fprintf(w, "    %s %s  等待任务组完成\n", g("wait"), d("<组名> [--timeout N]"))
-	fmt.Fprintf(w, "    %s %s  收集所有任务输出\n", g("collect"), d("<组名> [--json]"))
-	fmt.Fprintf(w, "    %s %s  向任务/Agent 追加指令\n", g("send"), d("<会话名> <指令>"))
-	fmt.Fprintf(w, "    %s %s  列出 / 清理任务组\n", g("group"), d("ls | kill <组名>"))
-	fmt.Fprintf(w, "    %s %s  捕获会话输出\n", g("capture"), d("<会话> [--lines N]"))
-	fmt.Fprintf(w, "    %s\n\n", d("Agent 选项: --dir <目录>  --model <模型>  --perm <权限模式>  --max-turns <N>"))
-
 	fmt.Fprintf(w, "  %s %s\n", b("蜂群编排"), m("(swarm — 有目标的任务组)"))
 	fmt.Fprintf(w, "    %s %s  新建蜂群\n", g("swarm new"), d("<名> [--goal \"...\"] [--no-master]"))
 	fmt.Fprintf(w, "    %s %s  加成员\n", g("swarm add"), d("<群> <成员> --type task|agent [--kind claude|codex] ..."))

--- a/cli/ttmux-cli-go/internal/command/interactive/interactive.go
+++ b/cli/ttmux-cli-go/internal/command/interactive/interactive.go
@@ -6,7 +6,6 @@ package interactive
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -53,19 +52,8 @@ func Run(rt runtime.Runtime, version string, run Runner) error {
 		case "5":
 			m.swarmMenu()
 		case "6":
-			for _, g := range m.groups() {
-				_ = m.run([]string{"status", g})
-			}
+			_ = m.run([]string{"swarm", "ls"})
 			_ = m.run([]string{"ls"})
-			m.pause()
-		case "7":
-			m.waitCollect()
-			m.pause()
-		case "8":
-			m.taskSend()
-			m.pause()
-		case "9":
-			m.groupKill()
 			m.pause()
 		case "s":
 			if t, ok := m.pickSession("发送命令到"); ok {
@@ -93,8 +81,8 @@ func (m *menu) header(version string) {
 	fmt.Printf("\n  %s %s  %s\n", ui.Bold("ttmux"), ui.Dim("v"+version), ui.Dim("— 交互模式 (q 退出)"))
 	fmt.Printf("  %s%s%s\n", p.Dim, strings.Repeat("─", 44), p.Reset)
 	swarms, _ := m.st.ListSwarms()
-	fmt.Printf("  %s会话: %s%s%d%s%s  任务组: %s%s%d%s%s  蜂群: %s%s%d%s\n\n",
-		p.Dim, p.Reset, p.Bold, len(m.rt.Sessions()), p.Reset, p.Dim, p.Reset, p.Bold, len(m.groups()), p.Reset, p.Dim, p.Reset, p.Bold, len(swarms), p.Reset)
+	fmt.Printf("  %s会话: %s%s%d%s%s  蜂群: %s%s%d%s\n\n",
+		p.Dim, p.Reset, p.Bold, len(m.rt.Sessions()), p.Reset, p.Dim, p.Reset, p.Bold, len(swarms), p.Reset)
 }
 
 func (m *menu) mainMenu() {
@@ -103,76 +91,10 @@ func (m *menu) mainMenu() {
 	fmt.Printf("  %s\n", ui.Bold("会话"))
 	fmt.Printf("    %s) 列出会话          %s) 新建会话\n", c("1"), c("2"))
 	fmt.Printf("    %s) 附加会话          %s) 关闭会话\n\n", c("3"), c("4"))
-	fmt.Printf("  %s %s\n", ui.Bold("任务编排"), p.Magenta+"(蜂群 / swarm)"+p.Reset)
-	fmt.Printf("    %s) 蜂群编排 ▸        %s) 状态总览\n", c("5"), c("6"))
-	fmt.Printf("    %s) 等待并收集        %s) 追加指令\n", c("7"), c("8"))
-	fmt.Printf("    %s) 清理任务组\n\n", c("9"))
+	fmt.Printf("  %s %s\n", ui.Bold("蜂群编排"), p.Magenta+"(swarm)"+p.Reset)
+	fmt.Printf("    %s) 蜂群编排 ▸        %s) 状态总览\n\n", c("5"), c("6"))
 	fmt.Printf("  %s\n", ui.Bold("其他"))
 	fmt.Printf("    %s) 发送命令          %s) 帮助\n\n", c("s"), c("h"))
-}
-
-func (m *menu) waitCollect() {
-	g, ok := m.pickGroup("选择任务组")
-	if !ok {
-		return
-	}
-	_ = m.run([]string{"status", g})
-	p := ui.P()
-	fmt.Printf("  %s\n", ui.Bold("操作:"))
-	fmt.Printf("    %s1%s) 等待完成  %s2%s) 收集输出  %s3%s) 两者都做  %s0%s) 返回\n", p.Cyan, p.Reset, p.Cyan, p.Reset, p.Cyan, p.Reset, p.Cyan, p.Reset)
-	action, _ := ui.ReadLine("  选择: ")
-	switch action {
-	case "1":
-		_ = m.run([]string{"wait", g})
-	case "2":
-		_ = m.run([]string{"collect", g})
-	case "3":
-		_ = m.run([]string{"wait", g})
-		_ = m.run([]string{"collect", g})
-	}
-}
-
-func (m *menu) taskSend() {
-	g, ok := m.pickGroup("选择任务组")
-	if !ok {
-		return
-	}
-	members, _ := m.rt.GroupSessions(g)
-	if len(members) == 0 {
-		ui.Info(os.Stdout, "该任务组还没有成员")
-		return
-	}
-	if sel, ok := m.pickFrom("任务列表", members, m.runningLabel); ok {
-		if msg, _ := ui.ReadLine("  追加指令: "); msg != "" {
-			_ = m.run([]string{"send", sel, msg})
-		}
-	}
-}
-
-func (m *menu) groupKill() {
-	groups := m.groups()
-	if len(groups) == 0 {
-		ui.Info(os.Stdout, "没有任务组")
-		return
-	}
-	p := ui.P()
-	fmt.Printf("\n  %s\n", ui.Bold("选择要清理的任务组:"))
-	fmt.Printf("    %s0%s) %s全部清理%s\n", p.Cyan, p.Reset, p.Red, p.Reset)
-	for i, g := range groups {
-		fmt.Printf("    %s%d%s) %s\n", p.Cyan, i+1, p.Reset, g)
-	}
-	choice, _ := ui.ReadLine("\n  编号: ")
-	if choice == "0" {
-		if ui.Confirm(fmt.Sprintf("确定清理全部 %d 个任务组?", len(groups))) {
-			for _, g := range groups {
-				_ = m.run([]string{"group", "kill", g})
-			}
-		}
-		return
-	}
-	if n, err := strconv.Atoi(choice); err == nil && n >= 1 && n <= len(groups) {
-		_ = m.run([]string{"group", "kill", groups[n-1]})
-	}
 }
 
 // ── helpers ──
@@ -181,15 +103,6 @@ func clear() { fmt.Print("\033[H\033[2J") }
 
 func (m *menu) pause() {
 	_, _ = ui.ReadLine("\n  按回车继续...")
-}
-
-func (m *menu) groups() []string {
-	matches, _ := filepath.Glob(filepath.Join(m.rt.GroupsDir, "*.group"))
-	var out []string
-	for _, f := range matches {
-		out = append(out, strings.TrimSuffix(filepath.Base(f), ".group"))
-	}
-	return out
 }
 
 func (m *menu) runningLabel(sess string) string {
@@ -208,10 +121,6 @@ func (m *menu) pickSession(prompt string) (string, bool) {
 		}
 	}
 	return m.pickFrom(prompt, names, nil)
-}
-
-func (m *menu) pickGroup(prompt string) (string, bool) {
-	return m.pickFrom(prompt, m.groups(), nil)
 }
 
 // pickFrom prints a numbered list and returns the chosen item.


### PR DESCRIPTION
## 背景
`spawn / wait / collect / group / agent` 这套旧「任务编排」命令已被 **swarm 层**取代，界面也不再展示，但仍在 help/补全/交互菜单里作为面向用户的入口存在，易误导。

## 改动（两个 commit）
1. **help 移除旧块** — `ttmux help` 从「会话管理」直接到「蜂群编排」。
2. **干掉命令入口** —
   - `app.go`：删顶层 dispatch `spawn/wait/agent/collect/group` 及 `runSpawn/fileSpawn/runAgent/runGroup`；保留 `status/capture/send`(通用) 与 autoconfirm。
   - `interactive.go`：主菜单去掉 `7)等待并收集 8)追加指令 9)清理任务组`，状态总览改走 `swarm ls`；删 `waitCollect/taskSend/groupKill/pickGroup/groups`。
   - `completion.go`：补全词删 `spawn/wait/collect/group/agent`。

## 保留（重要）
- **spawn/group 包实现保留**：swarm 内部仍依赖 `spawn.One/DefaultAgentConfig`、`group.Status/Collect/Kill` 等。本 PR 只切断用户直连入口。
- 包里只服务旧入口的导出函数（`spawn.Spawn/Wait/SpawnAgents/SpawnFile`、`group.List/ListJSON/StatusJSON`）暂成 dead code，**下一步单独 PR 清理**。

## 验证
- `go build` / `go vet` / `go test ./...` 全过（swarm 包测试仍 ok）。
- 已装 `~/.local/bin/ttmux`：`ttmux spawn/wait` 现回 `unknown command`；`ttmux help` 与交互菜单只剩 swarm。
- pre-push 质量门全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)