### PR TITLE
fix(web): 拖文件后中文打字不再重放 @路径（xterm 隐藏输入框残值）

### DIFF
--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -318,6 +318,16 @@ const Term = forwardRef<TermHandle, {
       }
     }
     el.addEventListener('paste', onPasteCapture, { capture: true })
+    // 拖文件落进终端的兜底：xterm 会把隐藏 helper textarea 挪到「终端光标所在格」（正好是
+    // TUI 输入行、用户拖放的落点）。若 drop 默认行为没被上层拦掉，Chrome 会把 text/plain
+    // 原生插进这个 textarea——xterm 只认 insertText，不处理 insertFromDrop、也不清值，
+    // 残留路径随后会被中文输入法(keydown 229)的差分逻辑整段重放进终端，淹没正在输入的字。
+    // 这里对容器内所有 drop 统一 preventDefault（不拦冒泡，上层注入 @路径/上传照常）并清残值。
+    const onDropGuard = (e: DragEvent) => {
+      e.preventDefault()
+      if (textarea && !composing) textarea.value = ''
+    }
+    el.addEventListener('drop', onDropGuard)
 
     connect()
 
@@ -335,6 +345,7 @@ const Term = forwardRef<TermHandle, {
       el.removeEventListener('touchend', onTouchEnd)
       el.removeEventListener('contextmenu', onCtx)
       el.removeEventListener('paste', onPasteCapture, { capture: true } as any)
+      el.removeEventListener('drop', onDropGuard)
       if (textarea) {
         textarea.removeEventListener('compositionstart', onCompStart)
         textarea.removeEventListener('compositionend', onCompEnd)


### PR DESCRIPTION
## 问题

Windows Chrome 下，把文件从文件树拖进终端（Claude Code TUI）后，再用中文输入法打字，`@路径` 文字会被反复打进输入框，淹没正在输入的字。

## 根因

三个因素叠加：

1. xterm 的 `_syncTextArea` 会把隐藏 helper textarea 挪到「终端光标所在格」——恰好是 TUI 输入行、用户拖文件的天然落点，且该点 hit-test 命中的就是这个 textarea；
2. drop 落点经过的路径上若默认行为未被 `preventDefault`（如右半区早退分支、text/plain-only 拖拽），Chrome 会把 text/plain 原生插进这个 textarea。xterm 的 `_inputEvent` 只认 `insertText`，对 `insertFromDrop` 不处理也不清值 → 路径残留；
3. 中文输入法每个键都发 keydown 229，xterm `CompositionHelper._handleAnyTextareaChanges` 用 `新值.replace(旧值,'')` 做差分。残值让差分错位，把含路径的残值整段重放进终端。

## 修复

`Terminal.tsx`：Term 容器统一给 `drop` 兜底 `preventDefault` 并清 helper textarea 残值。不拦冒泡，上层 `onTermDrop` 的 @路径注入 / 系统文件拖入上传照常。

## 验证

用 CDP（`Input.setInterceptDrags` 真实页内拖拽 + `Input.imeSetComposition` IME 序列）对真实 Claude Code TUI 会话复现：

- 修复前：光标格投放后 textarea 残留 `xyz/tmp/dragfile-test.txt字`，IME 打字触发重放乱序；
- 修复后：同一投放（含绕开上层 handler 的 text/plain-only 载荷）textarea 保持空；
- 左半区拖文件 → `@路径` 注入一次成功，功能不受影响；typecheck / i18n audit / go test 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)