### PR TITLE
fix(terminal): 右键菜单前同步 active pane，修复关错窗格

### DIFF
--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -288,6 +288,9 @@ const Term = forwardRef<TermHandle, {
     // 这样无论后端鼠标模式开关，右键都只剩前端这一个菜单。
     const onMouseDownCapture = (e: MouseEvent) => {
       if (e.button === 2) {
+        // 右键菜单里有「关闭当前窗格」等动作，得先把 tmux 服务端 active pane
+        // 同步到右键点击位置，否则菜单操作的还是上一次左键选中的旧 pane。
+        selectPaneAtClient(e.clientX, e.clientY)
         e.stopPropagation()
         return
       }


### PR DESCRIPTION
右键弹出 tmux 操作菜单时跳过了 pane 同步(selectPaneAt 只在左键触发)，
tmux 服务端 active pane 停留在上次左键选中的位置(或新分屏自动抢占的
那个)，导致「关闭当前窗格」等操作作用到错的 pane 上。

## Summary

- 

## Validation

- [ ] `scripts/dev/quality/check.sh full`
- [ ] Manual validation notes included, if UI or terminal behavior changed

## Compliance

- [ ] No secrets, tokens, private URLs, or local `.env` values are committed
- [ ] User-facing frontend text is routed through the i18n layer
- [ ] Runtime behavior changes include tests or a clear validation note
- [ ] Generated files are updated only when their source files changed
