### PR TITLE
fix(plugin): 自动互审陪跑会话挂到被陪跑会话名下

### DIFF
--- a/cli/ttmux-cli-go/internal/command/plugin/plugin.go
+++ b/cli/ttmux-cli-go/internal/command/plugin/plugin.go
@@ -15,6 +15,7 @@ import (
 	"ttmux-cli-go/internal/plugin"
 	"ttmux-cli-go/internal/plugin/builtin"
 	"ttmux-cli-go/internal/runtime"
+	"ttmux-cli-go/internal/sessmeta"
 	"ttmux-cli-go/internal/ui"
 	"ttmux-cli-go/pkg/plugin/sdk"
 )
@@ -592,6 +593,13 @@ func track(env plugin.Env, args []string, out io.Writer) error {
 			if err := env.RT.Tmux("new-session", "-d", "-s", watchSess, cmd); err != nil {
 				ui.Warn(out, "监控会话拉起失败: %v", err)
 			} else {
+				// meta 记 parent=被陪跑会话:Web 父子树把陪跑会话归到同一组,
+				// 而不是游离的顶层会话(被陪跑会话本身是 fork 出来的时尤其明显)
+				if err := sessmeta.New(env.RT.HomeDir).Put(sessmeta.Row{
+					Session: watchSess, Parent: session, CreatedBy: "review-watch", InitialCwd: labels["workdir"],
+				}); err != nil {
+					ui.Warn(out, "监控会话 parent 元数据写入失败: %v", err)
+				}
 				ui.Ok(out, "监控会话 %s 已陪跑(围观: ttmux a %s)", ui.Bold(watchSess), watchSess)
 			}
 		}


### PR DESCRIPTION
## 问题

勾「空闲自动互审」新建/派生会话时,`ttmux plugin track` 拉起的 `<会话>-review` 陪跑监控会话只走裸 `tmux new-session`,没写 sessmeta parent 元数据。Web 端父子树是 parent 字段的投影,于是陪跑会话成了游离的顶层会话——fork 派生场景尤其明显:子会话在父名下,它的陪跑会话却单独一条。

## 修复

陪跑会话建成后补一行 meta(`parent=被陪跑会话`,`created_by=review-watch`,`initial_cwd=workdir`),与 `ttmux fork` 同一张表、同一投影,前端 `?tree=1` 自然归组;写入失败只警告不回滚(与 fork 容错一致)。被陪跑会话消亡时 `OnKill`/`Reconcile` 照旧孤儿收养,生命周期不变。

`<dev>-review-final` 兜底会话未动:拉起时父会话已死,写 parent 也会被 Reconcile 立即清掉。

## 验证

- `go build ./...` / `go vet` / 全仓 `go test ./...` 全绿
- pre-commit 质量门禁(i18n audit、tsc、secret scan)通过
- 生效需重装 Go CLI 二进制(`~/.local/bin/ttmux`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)