### PR TITLE
feat(worktree): 新建会话可基于远端分支建 worktree

### DIFF
--- a/backend/api/worktree.go
+++ b/backend/api/worktree.go
@@ -155,12 +155,12 @@ func (a *API) WorktreePrune(c *gin.Context) {
 func (a *API) GitBranches(c *gin.Context) {
 	ctx, cancel := wtCtx(c)
 	defer cancel()
-	branches, def, err := a.WT.Branches(ctx, filepath.Clean(c.Query("dir")))
+	branches, def, remotes, err := a.WT.Branches(ctx, filepath.Clean(c.Query("dir")))
 	if err != nil {
 		wtErr(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"branches": branches, "default": def}})
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"branches": branches, "default": def, "remotes": remotes}})
 }
 
 // ── Session API 增量 ─────────────────────────────────────
@@ -298,7 +298,7 @@ func (a *API) SessionFork(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"session": b.Child, "parent": parent}, "name": b.Child})
 }
 
-// SessionForkWorktree POST /sessions/:name/fork-worktree {child, branch?, base?, dir?}
+// SessionForkWorktree POST /sessions/:name/fork-worktree {child, branch?, base?, remote?, dir?}
 // 编排（先 subSession 后 worktree）：ttmux fork（cwd=父仓库目录，meta 记 parent）→
 // 建 worktree（分支缺省自动占位）→ 子会话内注入 cd；失败反向补偿 kill 子会话。
 func (a *API) SessionForkWorktree(c *gin.Context) {
@@ -307,6 +307,7 @@ func (a *API) SessionForkWorktree(c *gin.Context) {
 		Child  string `json:"child"`
 		Branch string `json:"branch"`
 		Base   string `json:"base"`
+		Remote string `json:"remote"`
 		Dir    string `json:"dir"`
 	}
 	if err := c.ShouldBindJSON(&b); err != nil || b.Child == "" {
@@ -342,7 +343,7 @@ func (a *API) SessionForkWorktree(c *gin.Context) {
 	if branch == "" {
 		branch = autoBranch(b.Child)
 	}
-	wt, err := a.WT.Create(ctx, worktree.CreateReq{Dir: dir, Branch: branch, Base: b.Base})
+	wt, err := a.WT.Create(ctx, worktree.CreateReq{Dir: dir, Branch: branch, Base: b.Base, Remote: b.Remote})
 	if err != nil {
 		_, _ = a.TT.Run("kill", b.Child, "--yes")
 		wtErr(c, err)

--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -1050,14 +1050,16 @@ func (s *Service) remoteBranches(ctx context.Context, repo Repo) []RemoteBranch 
 	if len(remotes) == 0 {
 		return nil
 	}
-	out, e := git(ctx, repo.Root, "for-each-ref", "refs/remotes", "--format=%(refname:short)", "--sort=-committerdate")
+	// 全名 %(refname) 自己剥前缀：%(refname:short) 在歧义时（如本地分支恰叫
+	// origin/foo）会输出 remotes/origin/foo，按 remote 前缀匹配失败被静默漏掉。
+	out, e := git(ctx, repo.Root, "for-each-ref", "refs/remotes", "--format=%(refname)", "--sort=-committerdate")
 	if e != nil {
 		return nil
 	}
 	var list []RemoteBranch
 	for _, l := range strings.Split(out, "\n") {
-		short := strings.TrimSpace(l)
-		if short == "" {
+		short := strings.TrimPrefix(strings.TrimSpace(l), "refs/remotes/")
+		if short == "" || short == strings.TrimSpace(l) {
 			continue
 		}
 		match := ""

--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -1007,15 +1007,23 @@ func (s *Service) Head(ctx context.Context, path string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-// Branches 返回本地分支列表与默认 base（W1 start-from 选择器用）。
-func (s *Service) Branches(ctx context.Context, dir string) ([]string, string, error) {
+// RemoteBranch 远端分支（结构化拆开 remote 与分支名：分支名可含 /，
+// 前端按 "remote/name" 字符串猜切分会错，真相源在这里拆好）。
+type RemoteBranch struct {
+	Remote string `json:"remote"`
+	Name   string `json:"name"`
+}
+
+// Branches 返回本地分支列表、默认 base 与已知远端分支（W1 start-from 选择器用）。
+// 远端分支来自本地已有的 remote-tracking ref（不主动 fetch——Create 选定后会 fetch 锁 OID）。
+func (s *Service) Branches(ctx context.Context, dir string) ([]string, string, []RemoteBranch, error) {
 	repo, err := s.ResolveRepo(ctx, dir)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	out, e := git(ctx, repo.Root, "for-each-ref", "refs/heads", "--format=%(refname:short)", "--sort=-committerdate")
 	if e != nil {
-		return nil, "", errf("GIT_ERROR", "%s", out)
+		return nil, "", nil, errf("GIT_ERROR", "%s", out)
 	}
 	var branches []string
 	for _, l := range strings.Split(out, "\n") {
@@ -1023,7 +1031,51 @@ func (s *Service) Branches(ctx context.Context, dir string) ([]string, string, e
 			branches = append(branches, strings.TrimSpace(l))
 		}
 	}
-	return branches, s.defaultBase(ctx, repo), nil
+	return branches, s.defaultBase(ctx, repo), s.remoteBranches(ctx, repo), nil
+}
+
+// remoteBranches 列 refs/remotes 下的远端分支，按 remote 名精确切前缀
+// （remote 名取自 git remote，最长匹配——分支名可含 /）；跳过 HEAD 符号引用。
+func (s *Service) remoteBranches(ctx context.Context, repo Repo) []RemoteBranch {
+	remOut, e := git(ctx, repo.Root, "remote")
+	if e != nil {
+		return nil
+	}
+	var remotes []string
+	for _, l := range strings.Split(remOut, "\n") {
+		if r := strings.TrimSpace(l); r != "" {
+			remotes = append(remotes, r)
+		}
+	}
+	if len(remotes) == 0 {
+		return nil
+	}
+	out, e := git(ctx, repo.Root, "for-each-ref", "refs/remotes", "--format=%(refname:short)", "--sort=-committerdate")
+	if e != nil {
+		return nil
+	}
+	var list []RemoteBranch
+	for _, l := range strings.Split(out, "\n") {
+		short := strings.TrimSpace(l)
+		if short == "" {
+			continue
+		}
+		match := ""
+		for _, r := range remotes {
+			if strings.HasPrefix(short, r+"/") && len(r) > len(match) {
+				match = r
+			}
+		}
+		if match == "" {
+			continue
+		}
+		name := short[len(match)+1:]
+		if name == "" || name == "HEAD" {
+			continue
+		}
+		list = append(list, RemoteBranch{Remote: match, Name: name})
+	}
+	return list
 }
 
 func dedup(in []string) []string {

--- a/backend/worktree/service_test.go
+++ b/backend/worktree/service_test.go
@@ -261,22 +261,31 @@ func TestBranchesAndCreateFromRemote(t *testing.T) {
 	local := mkRepo(t)
 	gitIn(local, "remote", "add", "origin", upstream)
 	gitIn(local, "fetch", "-q", "origin")
+	// 歧义引用名：本地分支恰叫 origin/main 时 %(refname:short) 会输出
+	// remotes/origin/main——远端分支不能因此被漏掉
+	gitIn(local, "branch", "origin/main")
 
 	_, _, remotes, err := s.Branches(ctx, local)
 	if err != nil {
 		t.Fatalf("branches: %v", err)
 	}
-	found := false
+	foundFeat, foundMain := false, false
 	for _, rb := range remotes {
 		if rb.Remote == "origin" && rb.Name == "feat/remote-only" {
-			found = true
+			foundFeat = true
+		}
+		if rb.Remote == "origin" && rb.Name == "main" {
+			foundMain = true
 		}
 		if rb.Name == "HEAD" {
 			t.Fatalf("HEAD should be skipped: %+v", remotes)
 		}
 	}
-	if !found {
+	if !foundFeat {
 		t.Fatalf("origin/feat/remote-only not listed: %+v", remotes)
+	}
+	if !foundMain {
+		t.Fatalf("origin/main dropped under ambiguous local branch name: %+v", remotes)
 	}
 
 	// 基于远端分支建 worktree：本地无 feat/remote-only，Create fetch 后锁 OID

--- a/backend/worktree/service_test.go
+++ b/backend/worktree/service_test.go
@@ -236,6 +236,63 @@ func TestMergeSquashAndConflict(t *testing.T) {
 	}
 }
 
+// 远端分支：Branches 列出 remote-tracking 分支（结构化拆 remote/name，含 / 的
+// 分支名不靠字符串猜），Create 可基于本地不存在、仅远端有的分支建 worktree。
+func TestBranchesAndCreateFromRemote(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	upstream := mkRepo(t)
+	gitIn := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(scrubGitEnv(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+	// 上游造一个仅远端存在的分支（带 /，验证切分）
+	gitIn(upstream, "checkout", "-q", "-b", "feat/remote-only")
+	commitFile(t, upstream, "remote.txt", "r\n", "remote change")
+	gitIn(upstream, "checkout", "-q", "main")
+
+	local := mkRepo(t)
+	gitIn(local, "remote", "add", "origin", upstream)
+	gitIn(local, "fetch", "-q", "origin")
+
+	_, _, remotes, err := s.Branches(ctx, local)
+	if err != nil {
+		t.Fatalf("branches: %v", err)
+	}
+	found := false
+	for _, rb := range remotes {
+		if rb.Remote == "origin" && rb.Name == "feat/remote-only" {
+			found = true
+		}
+		if rb.Name == "HEAD" {
+			t.Fatalf("HEAD should be skipped: %+v", remotes)
+		}
+	}
+	if !found {
+		t.Fatalf("origin/feat/remote-only not listed: %+v", remotes)
+	}
+
+	// 基于远端分支建 worktree：本地无 feat/remote-only，Create fetch 后锁 OID
+	resp, err := s.Create(ctx, CreateReq{Dir: local, Branch: "roam/from-remote", Base: "feat/remote-only", Remote: "origin"})
+	if err != nil {
+		t.Fatalf("create from remote: %v", err)
+	}
+	tip := strings.TrimSpace(gitIn(upstream, "rev-parse", "feat/remote-only"))
+	if resp.StartOid != tip {
+		t.Fatalf("start oid = %s, want upstream tip %s", resp.StartOid, tip)
+	}
+	if _, err := os.Stat(filepath.Join(resp.Path, "remote.txt")); err != nil {
+		t.Fatal("worktree missing file from remote branch")
+	}
+}
+
 func TestExpectedHeadGuard(t *testing.T) {
 	ctx := context.Background()
 	s := New()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1536,8 +1536,11 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
   const [creating, setCreating] = useState(false)
   // worktree 展开态（W1）：只选「基于」。分支不提前指定——后端按会话名占位，
   // Agent 开工后按任务 git branch -m 语义化（交互修订 4：先建会话再建 worktree）。
+  // base 选中值：本地分支存裸名；远端分支存 remote:<remote>:<branch> 编码
+  // （冒号在 git ref 名里非法，编码无歧义），提交前拆回 {base, remote}
   const [base, setBase] = useState('')
   const [branches, setBranches] = useState<string[]>([])
+  const [remoteBranches, setRemoteBranches] = useState<{ remote: string; name: string }[]>([])
   const [defBranch, setDefBranch] = useState('')
   const { message } = AntApp.useApp()
   const { t } = useI18n()
@@ -1545,7 +1548,7 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
   useEffect(() => {
     if (!open) return
     setPrompt(''); setName(''); setNameTouched(false); setDir(''); setAgent('claude'); setWtMode('repo'); setAutoReview(false); setIsGitRepo(false)
-    setBase(''); setBranches([]); setDefBranch(''); setExistingWts([]); setWtPath('')
+    setBase(''); setBranches([]); setRemoteBranches([]); setDefBranch(''); setExistingWts([]); setWtPath('')
     // 派生模式：目录默认父会话 cwd（可改成任意目录，与新建一致）
     if (parent) {
       let cancelled = false
@@ -1575,7 +1578,7 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
     }).catch(() => { if (!cancelled) setExistingWts([]) })
     return () => { cancelled = true }
   }, [isGitRepo, dir])
-  // 选「新建 worktree」时拉本地分支做「基于」候选
+  // 选「新建 worktree」时拉本地+远端分支做「基于」候选
   useEffect(() => {
     if (wtMode !== 'new' || !isGitRepo || !dir.trim()) return
     let cancelled = false
@@ -1583,8 +1586,9 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
       if (cancelled) return
       const bs: string[] = r?.data?.branches || []
       const def: string = r?.data?.default || ''
-      setBranches(bs); setDefBranch(def)
-      setBase((prev) => (prev && bs.includes(prev) ? prev : def))
+      const rs: { remote: string; name: string }[] = r?.data?.remotes || []
+      setBranches(bs); setDefBranch(def); setRemoteBranches(rs)
+      setBase((prev) => (prev && (bs.includes(prev) || rs.some((x) => `remote:${x.remote}:${x.name}` === prev)) ? prev : def))
     }).catch(() => {})
     return () => { cancelled = true }
   }, [wtMode, isGitRepo, dir])
@@ -1606,12 +1610,18 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
       if (wtMode === 'new' && isGitRepo && sessionDir) {
         // 组合 API（先会话后 worktree）：分支不传——后端按会话名占位，Agent 开工后语义化；
         // 派生模式走 fork-worktree（同编排 + meta 记父子）
+        let baseReq: { base?: string; remote?: string } = base ? { base } : {}
+        if (base.startsWith('remote:')) {
+          const rest = base.slice('remote:'.length)
+          const sep = rest.indexOf(':')
+          baseReq = { base: rest.slice(sep + 1), remote: rest.slice(0, sep) }
+        }
         const res = parent
           ? await api('POST', `/sessions/${encodeURIComponent(parent)}/fork-worktree`, {
-            child: finalName, dir: sessionDir, ...(base ? { base } : {}),
+            child: finalName, dir: sessionDir, ...baseReq,
           })
           : await api('POST', '/worktree-sessions', {
-            name: finalName, dir: sessionDir, ...(base ? { base } : {}),
+            name: finalName, dir: sessionDir, ...baseReq,
           })
         actual = res.name || res.data?.session || finalName
         sessionDir = res.data?.path || sessionDir
@@ -1734,13 +1744,25 @@ function NewSessionModal({ open, parent, onClose, onDone }: { open: boolean; par
                   <Select size="small" showSearch optionFilterProp="label" style={{ flex: 1, minWidth: 0 }}
                     value={base || undefined} onChange={(v) => setBase(v)}
                     placeholder={t('session.wt.basePlaceholder')}
-                    options={[
-                      ...(defBranch ? [{ value: defBranch, label: t('session.wt.defaultBranch', { name: defBranch }) }] : []),
-                      ...branches.filter((b) => b !== defBranch).map((b) => ({ value: b, label: b })),
-                    ]} />
+                    options={(() => {
+                      type Opt = { value?: string; label: string; options?: { value: string; label: string }[] }
+                      const locals = [
+                        ...(defBranch ? [{ value: defBranch, label: t('session.wt.defaultBranch', { name: defBranch }) }] : []),
+                        ...branches.filter((b) => b !== defBranch).map((b) => ({ value: b, label: b })),
+                      ]
+                      if (!remoteBranches.length) return locals as Opt[]
+                      return [
+                        { label: t('session.wt.localBranches'), options: locals },
+                        {
+                          label: t('session.wt.remoteBranches'),
+                          options: remoteBranches.map((rb) => ({ value: `remote:${rb.remote}:${rb.name}`, label: `${rb.remote}/${rb.name}` })),
+                        },
+                      ] as Opt[]
+                    })()} />
                 </div>
                 <div style={{ color: 'var(--text-dimmer)', fontSize: 12 }}>
-                  {agent !== 'none' ? t('session.wt.autoNote') : t('session.wt.autoNoteNoAgent')}
+                  {base.startsWith('remote:') ? t('session.wt.remoteFetchNote')
+                    : agent !== 'none' ? t('session.wt.autoNote') : t('session.wt.autoNoteNoAgent')}
                 </div>
               </div>
             )}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -821,6 +821,9 @@ const enUS = {
   'session.wt.autoNote': 'Branch and directory are created automatically; the agent renames the branch after it reads the task',
   'session.wt.autoNoteNoAgent': 'Branch and directory are auto-created from the session name; rename later with git branch -m',
   'session.wt.defaultBranch': '{name} (default)',
+  'session.wt.localBranches': 'Local branches',
+  'session.wt.remoteBranches': 'Remote branches',
+  'session.wt.remoteFetchNote': 'Based on a remote branch: its latest commits are fetched at creation',
 
   // W4 worktree management drawer
   'worktree.entry': 'Worktrees',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -821,6 +821,9 @@ const zhCN = {
   'session.wt.autoNote': '分支与目录自动创建;Agent 开工后会按任务给分支起语义化名字',
   'session.wt.autoNoteNoAgent': '分支与目录按会话名自动创建,之后可自行 git branch -m 改名',
   'session.wt.defaultBranch': '{name}（默认）',
+  'session.wt.localBranches': '本地分支',
+  'session.wt.remoteBranches': '远端分支',
+  'session.wt.remoteFetchNote': '基于远端分支:创建时会先 fetch 该分支的最新提交',
 
   // W4 Worktree 管理抽屉
   'worktree.entry': 'Worktree 管理',


### PR DESCRIPTION
## 概要

新建会话选「新建 worktree」时，「基于」选择器现在分组展示本地/远端分支，可直接基于远端分支（如同事的 PR 分支、最新的 origin/main）建 worktree，创建时先 fetch 该分支锁定最新提交。

## 改动

- **后端** `worktree.Branches`：增列 remote-tracking 分支，返回结构化 `{remote, name}`（remote 名从 `git remote` 取、最长前缀匹配——分支名可含 `/`，前端按字符串猜会切错）；用全名 `%(refname)` 自剥 `refs/remotes/` 前缀，规避 `%(refname:short)` 在歧义引用名下输出 `remotes/...` 导致漏分支；跳过 `HEAD` 符号引用。列表不主动 fetch，创建走 `Create` 已有的 fetch+锁 OID 逻辑。
- **API**：`GET /git/branches` 响应新增 `remotes` 字段（对现有消费方纯增量）；`POST /sessions/:name/fork-worktree` 透传 `remote`（`/worktree-sessions` 原已支持）。
- **前端** NewSessionModal：远端分支编码为 `remote:<remote>:<branch>`（冒号在 ref 名非法，无歧义），提交前拆回 `{base, remote}`；选中远端分支时提示「创建时会先 fetch」。i18n 中英文各加 3 个 key。
- **测试**：`TestBranchesAndCreateFromRemote` 覆盖含 `/` 的远端分支切分、HEAD 跳过、歧义引用名（本地分支恰叫 `origin/main`）、基于纯远端分支建 worktree（StartOid=上游 tip）。

## 说明

`roam.baseref` 语义保持不变（存裸分支名，diff 靠 git DWIM 解析），本 PR 只做能力暴露。review-mesh 互审 j1783 的短名歧义问题已修（2290ffa）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)