### PR TITLE
feat(term): 终端输入体验对齐原生——点按移光标 + 触摸选区/复制/粘贴

### DIFF
--- a/backend/pty/pty.go
+++ b/backend/pty/pty.go
@@ -146,6 +146,86 @@ func tmuxSelectPaneAt(name string, col, row int) {
 	}
 }
 
+// tmuxMoveCursorAt 把前端「单击/轻点」的窗口格子坐标翻译成方向键，移动点中 pane 里应用的
+// 输入光标，对齐原生输入框「点哪光标到哪」的体验——镜像终端的光标在远端 TUI/shell 手里，
+// 点击本身移不动，此前只能靠丝带/键盘上的方向键一格格挪。
+//   - 备用屏(全屏 TUI：Claude Code/Codex/vim)：先竖直 ↑/↓ 再水平 ←/→，越界由应用自己钳住；
+//     竖直距离过远(>8 行)视为无意编辑（点的是对话区/输出区），忽略，避免 ↑ 连发误触发
+//     TUI 的历史回填。
+//   - 普通屏(shell readline)：↑/↓ 会翻命令历史，绝不能发；把竖直距离按 pane 宽折算成
+//     字符数（折行的长命令 ←/→ 本就会跨行走），只发 ←/→，越过行首行尾由 readline 钳住。
+//   - pane 处于 copy-mode 等模式时不动作（按键会被导航吃掉）。
+func tmuxMoveCursorAt(name string, col, row int) {
+	if col < 0 || row < 0 {
+		return
+	}
+	out, err := exec.Command("tmux", "list-panes", "-t", name, "-F",
+		"#{pane_id}\t#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}\t#{alternate_on}\t#{cursor_x}\t#{cursor_y}\t#{pane_in_mode}").Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.Split(line, "\t")
+		if len(parts) != 9 {
+			continue
+		}
+		nums := make([]int, 8)
+		ok := true
+		for i := 1; i < len(parts); i++ {
+			n, err := strconv.Atoi(parts[i])
+			if err != nil {
+				ok = false
+				break
+			}
+			nums[i-1] = n
+		}
+		if !ok {
+			continue
+		}
+		left, top, width, height := nums[0], nums[1], nums[2], nums[3]
+		alt, cx, cy, inMode := nums[4] == 1, nums[5], nums[6], nums[7] == 1
+		if col < left || col >= left+width || row < top || row >= top+height {
+			continue
+		}
+		if inMode {
+			return
+		}
+		dx, dy := (col-left)-cx, (row-top)-cy
+		if alt {
+			if dy > 8 || dy < -8 {
+				return
+			}
+			sendArrows(parts[0], dy, dx)
+		} else {
+			if dy > 3 || dy < -3 {
+				return
+			}
+			sendArrows(parts[0], 0, dy*width+dx)
+		}
+		return
+	}
+}
+
+// sendArrows 先竖直后水平发方向键。用 tmux 命名键(Up/Down/Left/Right)而非裸序列，
+// 让 tmux 按应用的光标键模式(DECCKM)选 CSI/SS3 编码。
+func sendArrows(pane string, dy, dx int) {
+	send := func(key string, n int) {
+		if n > 0 {
+			_ = exec.Command("tmux", "send-keys", "-t", pane, "-N", strconv.Itoa(n), key).Run()
+		}
+	}
+	if dy > 0 {
+		send("Down", dy)
+	} else {
+		send("Up", -dy)
+	}
+	if dx > 0 {
+		send("Right", dx)
+	} else {
+		send("Left", -dx)
+	}
+}
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
@@ -262,6 +342,10 @@ func Handler(c *gin.Context) {
 					continue
 				case "select-pane":
 					tmuxSelectPaneAt(name, ctrl.Col, ctrl.Row)
+					continue
+				case "move-cursor":
+					// 若 pane 停在 copy-mode(含本连接滚动进入的)，内部会跳过，不打断浏览历史。
+					tmuxMoveCursorAt(name, ctrl.Col, ctrl.Row)
 					continue
 				}
 			}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -887,6 +887,7 @@ function TerminalPane(props: {
     { type: 'divider' as const },
     { key: 'scroll-up', label: t('terminal.scrollHistory') },
     { key: 'bottom', label: t('terminal.toBottom') },
+    { key: 'redraw', label: t('terminal.redraw') },
     { key: 'reconnect', label: t('terminal.reconnect') },
     { type: 'divider' as const },
     {
@@ -911,6 +912,7 @@ function TerminalPane(props: {
     else if (key === 'manual-paste') openManualPaste(ctx.session)
     else if (key === 'scroll-up') h?.scroll(-12)
     else if (key === 'bottom') h?.toBottom()
+    else if (key === 'redraw') h?.redraw()
     else if (key === 'reconnect') h?.reconnect()
     else h?.send(key)
     setCtx(null)
@@ -1000,6 +1002,7 @@ function TerminalPane(props: {
       <Tooltip title={t('terminal.toBottom')}><Button size="small" onClick={() => active && termRefs.current[active]?.toBottom()}>{t('terminal.bottomShort')}</Button></Tooltip>
       <Tooltip title={t('terminal.decreaseFont')}><Button size="small" onClick={() => setFontSize(Math.max(10, fontSize - 1))}>A-</Button></Tooltip>
       <Tooltip title={t('terminal.increaseFont')}><Button size="small" onClick={() => setFontSize(Math.min(22, fontSize + 1))}>A+</Button></Tooltip>
+      <Tooltip title={t('terminal.redraw')}><Button size="small" onClick={() => active && termRefs.current[active]?.redraw()}>{t('terminal.redrawShort')}</Button></Tooltip>
       <Tooltip title={t('terminal.reconnect')}><Button size="small" onClick={() => active && termRefs.current[active]?.reconnect()}>{t('terminal.reconnectShort')}</Button></Tooltip>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1059,6 +1059,8 @@ function TerminalPane(props: {
       {!inChat && (
         <div style={{ display: 'flex', gap: 6, padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
           <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
+          {/* 触屏没有 Ctrl+Shift+V / 右键菜单在长按选词后也不再弹出，丝带上补一个直达粘贴 */}
+          {isTouch && <Button onMouseDown={noBlur} onClick={() => active && pasteClipboard(active)} style={{ flex: '0 0 auto' }}>{t('terminal.pasteAction')}</Button>}
           {(prefsData.quickCommands || []).map((cmd) => (
             <Button key={cmd} onMouseDown={noBlur} onClick={() => { if (isTouch) { setLine(cmd); requestAnimationFrame(() => mobileInputRef.current?.focus()) } else { sendRaw(cmd) } }} style={{ flex: '0 0 auto' }}>{cmd}</Button>
           ))}

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -106,16 +106,35 @@ const Term = forwardRef<TermHandle, {
     if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'scroll', dir, lines }))
   }
 
-  const selectPaneAtClient = (clientX: number, clientY: number) => {
-    const t = termRef.current, el = elRef.current, ws = wsRef.current
-    if (!t || !el || !ws || ws.readyState !== 1 || t.cols <= 0 || t.rows <= 0) return
+  // 视口像素坐标 → 终端单元格坐标（与 tmux 窗口坐标一致）
+  const cellAt = (clientX: number, clientY: number) => {
+    const t = termRef.current, el = elRef.current
+    if (!t || !el || t.cols <= 0 || t.rows <= 0) return null
     const rect = el.getBoundingClientRect()
-    if (rect.width <= 0 || rect.height <= 0) return
-    const col = Math.max(0, Math.min(t.cols - 1, Math.floor(((clientX - rect.left) / rect.width) * t.cols)))
-    const row = Math.max(0, Math.min(t.rows - 1, Math.floor(((clientY - rect.top) / rect.height) * t.rows)))
-    ws.send(JSON.stringify({ type: 'select-pane', col, row }))
+    if (rect.width <= 0 || rect.height <= 0) return null
+    return {
+      col: Math.max(0, Math.min(t.cols - 1, Math.floor(((clientX - rect.left) / rect.width) * t.cols))),
+      row: Math.max(0, Math.min(t.rows - 1, Math.floor(((clientY - rect.top) / rect.height) * t.rows))),
+    }
+  }
+
+  const selectPaneAtClient = (clientX: number, clientY: number) => {
+    const ws = wsRef.current, cell = cellAt(clientX, clientY)
+    if (!cell || !ws || ws.readyState !== 1) return
+    ws.send(JSON.stringify({ type: 'select-pane', ...cell }))
   }
   const selectPaneAt = (e: MouseEvent) => { if (e.button === 0) selectPaneAtClient(e.clientX, e.clientY) }
+
+  // 单击/轻点把远端光标移到点按的格子：镜像终端的光标在远端 TUI/shell 手里，点击本身移不动
+  // （此前只能靠丝带/键盘方向键一格格挪）。后端按 tmux 真实光标位置合成方向键，
+  // 对齐原生输入框「点哪光标到哪」的体验。
+  const sendMoveCursor = (clientX: number, clientY: number) => {
+    const t = termRef.current, ws = wsRef.current, cell = cellAt(clientX, clientY)
+    if (!t || !cell || !ws || ws.readyState !== 1) return
+    // 本地视口不在底部时行号对不上远端屏幕坐标（正常不会发生：滚动都交后端）
+    if (t.buffer.active.viewportY !== t.buffer.active.baseY) return
+    ws.send(JSON.stringify({ type: 'move-cursor', ...cell }))
+  }
 
   const connect = () => {
     if (unmounted.current) return
@@ -253,7 +272,14 @@ const Term = forwardRef<TermHandle, {
     let lastY = 0
     let acc = 0
     const lineH = () => (termRef.current?.options.fontSize || 13) * 1.3
-    const onTS = (e: TouchEvent) => { lastY = e.touches[0].clientY; acc = 0 }
+    // 轻点/单击(非拖选)判定用：起点坐标 + 触屏结束时间(去重触屏后浏览器补发的合成 mouse 事件)
+    let tapStart: { x: number; y: number } | null = null
+    let mouseDownAt: { x: number; y: number } | null = null
+    let lastTouchEndAt = 0
+    const onTS = (e: TouchEvent) => {
+      lastY = e.touches[0].clientY; acc = 0
+      tapStart = e.touches.length === 1 ? { x: e.touches[0].clientX, y: e.touches[0].clientY } : null
+    }
     // 捕获阶段 + stopPropagation：开了 tmux mouse 后，xterm 会把滚轮/触摸转成
     // 鼠标事件发给 tmux，与我们的 copy-mode 滚动重复。这里抢先独占，避免双重滚动。
     const onTM = (e: TouchEvent) => {
@@ -271,12 +297,35 @@ const Term = forwardRef<TermHandle, {
     }
     const onMouseUp = (e: MouseEvent) => {
       const sel = termRef.current?.getSelection() || ''
-      if (sel.trim()) onSelectionMenu?.({ x: e.clientX, y: e.clientY, selection: sel })
+      if (sel.trim()) {
+        onSelectionMenu?.({ x: e.clientX, y: e.clientY, selection: sel })
+        mouseDownAt = null
+        return
+      }
+      // 左键单击(无拖选、无修饰键、几乎未移动) → 移光标到点按处；触屏 tap 已在 touchend 处理，
+      // 靠时间窗滤掉其后补发的合成 mouseup，避免重复移动。
+      if (e.button === 0 && mouseDownAt && !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey
+        && performance.now() - lastTouchEndAt > 700
+        && Math.abs(e.clientX - mouseDownAt.x) < 5 && Math.abs(e.clientY - mouseDownAt.y) < 5) {
+        sendMoveCursor(e.clientX, e.clientY)
+      }
+      mouseDownAt = null
     }
     const onTouchEnd = (e: TouchEvent) => {
+      lastTouchEndAt = performance.now()
       const sel = termRef.current?.getSelection() || ''
       const t = e.changedTouches[0]
-      if (sel.trim() && t) onSelectionMenu?.({ x: t.clientX, y: t.clientY, selection: sel })
+      if (sel.trim() && t) {
+        onSelectionMenu?.({ x: t.clientX, y: t.clientY, selection: sel })
+        tapStart = null
+        return
+      }
+      // 单指轻点(所有手指已离屏、几乎未移动、无选区) → 移光标到点按处
+      if (t && tapStart && e.touches.length === 0
+        && Math.hypot(t.clientX - tapStart.x, t.clientY - tapStart.y) < 12) {
+        sendMoveCursor(t.clientX, t.clientY)
+      }
+      tapStart = null
     }
     // 右键改为 Roam 菜单：有选区时优先复制；无选区时提供粘贴/重连/tmux 常用动作。
     const onCtx = (e: MouseEvent) => {
@@ -294,6 +343,7 @@ const Term = forwardRef<TermHandle, {
         e.stopPropagation()
         return
       }
+      if (e.button === 0) mouseDownAt = { x: e.clientX, y: e.clientY }
       selectPaneAt(e)
     }
     el.addEventListener('touchstart', onTS, { passive: true, capture: true })

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -17,6 +17,9 @@ export interface TermHandle {
   toBottom: () => void
   // 按视口坐标激活该处的 tmux pane（分窗时拖放/点击定位到正确窗格）
   selectPaneAt: (clientX: number, clientY: number) => void
+  // 尺寸抖动(cols−1→cols)触发两次 SIGWINCH，逼全屏 TUI 整屏重排重绘。
+  // 窄屏(手机)下 Claude Code 等 ink TUI 折行重绘错位会满屏堆叠垃圾行，等价于「拖一下窗口就好了」。
+  redraw: () => void
 }
 
 // xterm 不认 CSS var()，需具体色值：读 <html> 上的同名变量，随黑/白主题切换。
@@ -136,6 +139,19 @@ const Term = forwardRef<TermHandle, {
     }
   }
 
+  // 尺寸抖动重绘：cols−1 再复原，两次 SIGWINCH 让 TUI(ink) 整屏重排、清掉错位堆积的垃圾行。
+  // 后端 resize 有 cols<20 保护，抖动后一定复原到真实尺寸。
+  const jiggleResize = () => {
+    const t = termRef.current, ws = wsRef.current
+    if (!t || !ws || ws.readyState !== 1 || t.cols <= 21 || t.rows < 6) return
+    ws.send(JSON.stringify({ type: 'resize', cols: t.cols - 1, rows: t.rows }))
+    setTimeout(() => {
+      const t2 = termRef.current, ws2 = wsRef.current
+      if (!t2 || !ws2 || ws2.readyState !== 1) return
+      ws2.send(JSON.stringify({ type: 'resize', cols: t2.cols, rows: t2.rows }))
+    }, 150)
+  }
+
   const selectPaneAtClient = (clientX: number, clientY: number) => {
     const ws = wsRef.current, cell = cellAt(clientX, clientY)
     if (!cell || !ws || ws.readyState !== 1) return
@@ -238,7 +254,12 @@ const Term = forwardRef<TermHandle, {
     const ws = new WebSocket(`${proto}://${location.host}/api/term/${encodeURIComponent(name)}`)
     ws.binaryType = 'arraybuffer'
     wsRef.current = ws
-    ws.onopen = () => { onStatus?.('connected'); termRef.current?.focus(); sendResize() }
+    ws.onopen = () => {
+      onStatus?.('connected'); termRef.current?.focus(); sendResize()
+      // attach 尺寸常与上个客户端不同(桌面↔手机)，宽行重折行会在 TUI 屏上留错位垃圾；
+      // 等首次 resize 生效后自动抖动重绘一次，进来就是干净画面。
+      setTimeout(jiggleResize, 600)
+    }
     ws.onmessage = (e) => {
       const t = termRef.current
       if (!t) return
@@ -266,6 +287,7 @@ const Term = forwardRef<TermHandle, {
     scroll: (lines) => sendScroll(lines < 0 ? 'up' : 'down', Math.abs(lines)),
     toBottom: () => sendScroll('bottom', 0),
     selectPaneAt: (clientX, clientY) => selectPaneAtClient(clientX, clientY),
+    redraw: () => jiggleResize(),
   }))
 
   useEffect(() => {

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import type { CSSProperties, TouchEvent as RTouchEvent } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
@@ -49,6 +50,13 @@ function stripMouseEnableBytes(buf: Uint8Array): Uint8Array {
   return new Uint8Array(out)
 }
 const stripMouseEnableStr = (s: string) => s.replace(/\x1b\[\?(?:1000|1001|1002|1003)h/g, '')
+
+// 终端单元格坐标（0 基，含端点）
+type Cell = { col: number; row: number }
+const cmpCell = (a: Cell, b: Cell) => a.row - b.row || a.col - b.col
+
+// 触摸长按选词的分词符（近似 xterm 双击选词 wordSeparator 的缺省值）
+const WORD_SEPS = new Set([' ', '\t', '(', ')', '[', ']', '{', '}', "'", '"', '`', ',', ';', '|'])
 
 // 跨 http（局域网非安全上下文）也能用的复制
 function copyText(s: string) {
@@ -106,15 +114,25 @@ const Term = forwardRef<TermHandle, {
     if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'scroll', dir, lines }))
   }
 
-  // 视口像素坐标 → 终端单元格坐标（与 tmux 窗口坐标一致）
-  const cellAt = (clientX: number, clientY: number) => {
+  // 单元格像素尺寸：优先取 xterm 渲染器的真实值（私有 API，升级失效则回退按容器等分——
+  // 容器右/下常留半格空白，等分会向右下略漂）
+  const cellSize = () => {
     const t = termRef.current, el = elRef.current
     if (!t || !el || t.cols <= 0 || t.rows <= 0) return null
     const rect = el.getBoundingClientRect()
     if (rect.width <= 0 || rect.height <= 0) return null
+    const cell = (t as any)._core?._renderService?.dimensions?.css?.cell
+    if (cell?.width > 0 && cell?.height > 0) return { rect, cw: cell.width as number, ch: cell.height as number }
+    return { rect, cw: rect.width / t.cols, ch: rect.height / t.rows }
+  }
+
+  // 视口像素坐标 → 终端单元格坐标（与 tmux 窗口坐标一致）
+  const cellAt = (clientX: number, clientY: number): Cell | null => {
+    const t = termRef.current, m = cellSize()
+    if (!t || !m) return null
     return {
-      col: Math.max(0, Math.min(t.cols - 1, Math.floor(((clientX - rect.left) / rect.width) * t.cols))),
-      row: Math.max(0, Math.min(t.rows - 1, Math.floor(((clientY - rect.top) / rect.height) * t.rows))),
+      col: Math.max(0, Math.min(t.cols - 1, Math.floor((clientX - m.rect.left) / m.cw))),
+      row: Math.max(0, Math.min(t.rows - 1, Math.floor((clientY - m.rect.top) / m.ch))),
     }
   }
 
@@ -134,6 +152,83 @@ const Term = forwardRef<TermHandle, {
     // 本地视口不在底部时行号对不上远端屏幕坐标（正常不会发生：滚动都交后端）
     if (t.buffer.active.viewportY !== t.buffer.active.baseY) return
     ws.send(JSON.stringify({ type: 'move-cursor', ...cell }))
+  }
+
+  // ── 触摸选区：手机长按选词 → 按住拖动扩选 → 松手自动复制，随后留手柄微调 ──
+  // xterm 自身不处理触摸，且 touchmove 被滚动手势独占，手机上原本完全无法选中终端文本。
+  const [handles, setHandles] = useState<{ sx: number; sy: number; ex: number; ey: number } | null>(null)
+  const touchRangeRef = useRef<{ start: Cell; end: Cell } | null>(null)
+  const suppressCtx = useRef(0) // 长按选词/拖手柄期间，屏蔽长按呼出的 contextmenu 菜单
+
+  const applyTouchRange = (r: { start: Cell; end: Cell }) => {
+    const t = termRef.current
+    if (!t) return
+    const len = (r.end.row - r.start.row) * t.cols + (r.end.col - r.start.col) + 1
+    if (len <= 0) return
+    touchRangeRef.current = r
+    t.select(r.start.col, t.buffer.active.viewportY + r.start.row, len)
+  }
+
+  const updateHandles = () => {
+    const m = cellSize(), r = touchRangeRef.current
+    if (!m || !r) { setHandles(null); return }
+    setHandles({
+      sx: r.start.col * m.cw, sy: (r.start.row + 1) * m.ch,
+      ex: (r.end.col + 1) * m.cw, ey: (r.end.row + 1) * m.ch,
+    })
+  }
+
+  const clearTouchSel = () => {
+    touchRangeRef.current = null
+    setHandles(null)
+    termRef.current?.clearSelection()
+  }
+
+  // 长按点位所在的「词」：以分词符为界向两侧扩展。宽字符(CJK)右半格 getWidth()=0，归属左边字符
+  const wordRangeAt = (cell: Cell): { start: Cell; end: Cell } => {
+    const t = termRef.current
+    const line = t?.buffer.active.getLine(t.buffer.active.viewportY + cell.row)
+    if (!t || !line) return { start: cell, end: cell }
+    const isWord = (x: number) => {
+      const c = line.getCell(x)
+      if (!c) return false
+      if (c.getWidth() === 0) return true
+      const s = c.getChars()
+      return !!s && !WORD_SEPS.has(s)
+    }
+    if (!isWord(cell.col)) return { start: cell, end: cell }
+    let s = cell.col, e = cell.col
+    while (s > 0 && isWord(s - 1)) s--
+    while (e < t.cols - 1 && isWord(e + 1)) e++
+    return { start: { col: s, row: cell.row }, end: { col: e, row: cell.row } }
+  }
+
+  // 拖选区手柄微调：固定另一端、跟随手指重选，松手自动复制（原生手机文本选择体验）
+  const dragHandle = (which: 'start' | 'end') => (e: RTouchEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const r0 = touchRangeRef.current
+    if (!r0) return
+    const fixed = which === 'start' ? r0.end : r0.start
+    suppressCtx.current = performance.now() + 1500
+    const onMove = (ev: TouchEvent) => {
+      ev.preventDefault()
+      const cell = cellAt(ev.touches[0].clientX, ev.touches[0].clientY)
+      if (!cell) return
+      applyTouchRange(cmpCell(cell, fixed) < 0 ? { start: cell, end: fixed } : { start: fixed, end: cell })
+      updateHandles()
+      suppressCtx.current = performance.now() + 1500
+    }
+    const onEnd = () => {
+      window.removeEventListener('touchmove', onMove)
+      window.removeEventListener('touchend', onEnd)
+      window.removeEventListener('touchcancel', onEnd)
+      const sel = termRef.current?.getSelection() || ''
+      if (sel.trim()) onSelectionMenu?.({ x: 0, y: 0, selection: sel })
+    }
+    window.addEventListener('touchmove', onMove, { passive: false })
+    window.addEventListener('touchend', onEnd)
+    window.addEventListener('touchcancel', onEnd)
   }
 
   const connect = () => {
@@ -276,14 +371,59 @@ const Term = forwardRef<TermHandle, {
     let tapStart: { x: number; y: number } | null = null
     let mouseDownAt: { x: number; y: number } | null = null
     let lastTouchEndAt = 0
+    // 长按选词手势：400ms 未移动进入，之后 touchmove 变扩选、touchend 自动复制
+    let lpTimer: any = null
+    let touchSelecting = false
+    let selAnchor: { start: Cell; end: Cell } | null = null
     const onTS = (e: TouchEvent) => {
       lastY = e.touches[0].clientY; acc = 0
+      clearTimeout(lpTimer)
       tapStart = e.touches.length === 1 ? { x: e.touches[0].clientX, y: e.touches[0].clientY } : null
+      if (tapStart) {
+        const { x, y } = tapStart
+        lpTimer = setTimeout(() => {
+          const cell = cellAt(x, y)
+          if (!cell) return
+          touchSelecting = true
+          suppressCtx.current = performance.now() + 1500
+          try { navigator.vibrate?.(15) } catch {}
+          selAnchor = wordRangeAt(cell)
+          applyTouchRange(selAnchor)
+        }, 400)
+      }
+      // 触摸目标(xterm 内层 span/decoration)在手势中途被重绘移除时，后续 touchmove/touchend
+      // 仍派发到已脱离的旧节点、不再冒泡到容器——手势断在半路（长按松手不复制、滚动卡住）。
+      // 终端常态在重绘(TUI spinner)，这里在目标上补挂监听，仅当目标已脱离(冒泡断链)时代为转发。
+      const tgt = e.target as HTMLElement | null
+      if (tgt && tgt !== el) {
+        const cleanup = () => {
+          tgt.removeEventListener('touchmove', fm)
+          tgt.removeEventListener('touchend', fe)
+          tgt.removeEventListener('touchcancel', fc)
+        }
+        const fm = (ev: TouchEvent) => { if (!el.contains(tgt)) onTM(ev) }
+        const fe = (ev: TouchEvent) => { if (!el.contains(tgt)) onTouchEnd(ev); cleanup() }
+        const fc = () => { if (!el.contains(tgt)) onTouchCancel(); cleanup() }
+        tgt.addEventListener('touchmove', fm, { passive: false })
+        tgt.addEventListener('touchend', fe)
+        tgt.addEventListener('touchcancel', fc)
+      }
     }
     // 捕获阶段 + stopPropagation：开了 tmux mouse 后，xterm 会把滚轮/触摸转成
     // 鼠标事件发给 tmux，与我们的 copy-mode 滚动重复。这里抢先独占，避免双重滚动。
     const onTM = (e: TouchEvent) => {
-      const y = e.touches[0].clientY
+      const x = e.touches[0].clientX, y = e.touches[0].clientY
+      if (touchSelecting) {
+        // 长按选词后不抬手直接拖：从锚点词向两侧扩选（跟随手指，不再滚动）
+        const cell = cellAt(x, y)
+        if (cell && selAnchor) {
+          applyTouchRange(cmpCell(cell, selAnchor.start) < 0 ? { start: cell, end: selAnchor.end }
+            : cmpCell(cell, selAnchor.end) > 0 ? { start: selAnchor.start, end: cell } : selAnchor)
+        }
+        e.preventDefault(); e.stopPropagation()
+        return
+      }
+      if (tapStart && Math.hypot(x - tapStart.x, y - tapStart.y) > 10) clearTimeout(lpTimer) // 明显位移=滚动，取消长按
       acc += (y - lastY) / lineH() // 下滑(dy>0)看更早；上滑看更新
       lastY = y
       const n = Math.trunc(acc)
@@ -312,11 +452,22 @@ const Term = forwardRef<TermHandle, {
       mouseDownAt = null
     }
     const onTouchEnd = (e: TouchEvent) => {
+      clearTimeout(lpTimer)
       lastTouchEndAt = performance.now()
       const sel = termRef.current?.getSelection() || ''
       const t = e.changedTouches[0]
-      if (sel.trim() && t) {
-        onSelectionMenu?.({ x: t.clientX, y: t.clientY, selection: sel })
+      if (touchSelecting) {
+        // 长按选区手势结束：有选中即自动复制（同桌面拖选），并留下手柄供微调
+        touchSelecting = false
+        selAnchor = null
+        if (sel.trim() && t) { onSelectionMenu?.({ x: t.clientX, y: t.clientY, selection: sel }); updateHandles() }
+        else clearTouchSel()
+        tapStart = null
+        return
+      }
+      if (sel.trim()) {
+        // 已有选区时点按空白：仅清除选区/手柄，不复制不移光标（原生输入框行为）
+        clearTouchSel()
         tapStart = null
         return
       }
@@ -327,9 +478,12 @@ const Term = forwardRef<TermHandle, {
       }
       tapStart = null
     }
+    const onTouchCancel = () => { clearTimeout(lpTimer); touchSelecting = false; selAnchor = null }
     // 右键改为 Roam 菜单：有选区时优先复制；无选区时提供粘贴/重连/tmux 常用动作。
     const onCtx = (e: MouseEvent) => {
       e.preventDefault()
+      // 触屏长按已是「选词」手势，屏蔽随之而来的 contextmenu，避免菜单盖住选区
+      if (touchSelecting || performance.now() < suppressCtx.current) return
       const sel = termRef.current?.getSelection() || ''
       onContextMenu?.({ x: e.clientX, y: e.clientY, selection: sel })
     }
@@ -343,6 +497,15 @@ const Term = forwardRef<TermHandle, {
         e.stopPropagation()
         return
       }
+      if (e.button === 1) {
+        // 中键粘贴，对齐 Linux 终端习惯：拖选已自动进剪贴板，中键≈primary selection 粘贴。
+        // 点哪先激活哪个 pane 再贴（X11 point-to-paste）；preventDefault 拦掉浏览器中键自动滚屏。
+        e.preventDefault()
+        e.stopPropagation()
+        selectPaneAtClient(e.clientX, e.clientY)
+        onPaste?.()
+        return
+      }
       if (e.button === 0) mouseDownAt = { x: e.clientX, y: e.clientY }
       selectPaneAt(e)
     }
@@ -352,7 +515,12 @@ const Term = forwardRef<TermHandle, {
     el.addEventListener('mousedown', onMouseDownCapture, { capture: true })
     el.addEventListener('mouseup', onMouseUp)
     el.addEventListener('touchend', onTouchEnd)
+    el.addEventListener('touchcancel', onTouchCancel)
     el.addEventListener('contextmenu', onCtx)
+    // 选区被外部清掉（重连/resize/复制后 clearSelection 等）时，同步撤掉触摸手柄
+    const selDisp = term.onSelectionChange(() => {
+      if (touchRangeRef.current && !term.hasSelection()) { touchRangeRef.current = null; setHandles(null) }
+    })
     const onPasteCapture = (e: ClipboardEvent) => {
       if (!e.clipboardData?.items) return
       // 一次粘贴只取一张图：同一张截图常以多种 MIME(image/png + image/jpeg…)重复出现，
@@ -396,7 +564,10 @@ const Term = forwardRef<TermHandle, {
       el.removeEventListener('mousedown', onMouseDownCapture, { capture: true } as any)
       el.removeEventListener('mouseup', onMouseUp)
       el.removeEventListener('touchend', onTouchEnd)
+      el.removeEventListener('touchcancel', onTouchCancel)
       el.removeEventListener('contextmenu', onCtx)
+      clearTimeout(lpTimer)
+      selDisp.dispose()
       el.removeEventListener('paste', onPasteCapture, { capture: true } as any)
       el.removeEventListener('drop', onDropGuard)
       if (textarea) {
@@ -427,7 +598,25 @@ const Term = forwardRef<TermHandle, {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])
 
-  return <div ref={elRef} style={{ width: '100%', height: '100%' }} />
+  // 触摸选区手柄（Android 风格泪滴）：start 挂在选区首字符左下、end 挂在末字符右下，可拖动微调
+  const handleStyle = (which: 'start' | 'end'): CSSProperties => ({
+    position: 'absolute',
+    left: which === 'start' ? (handles?.sx ?? 0) - 22 : handles?.ex ?? 0,
+    top: (which === 'start' ? handles?.sy : handles?.ey) ?? 0,
+    width: 22, height: 22, zIndex: 6, touchAction: 'none',
+    background: '#58a6ff',
+    border: '1.5px solid rgba(255,255,255,.9)',
+    boxShadow: '0 1px 4px rgba(0,0,0,.4)',
+    borderRadius: which === 'start' ? '50% 0 50% 50%' : '0 50% 50% 50%',
+  })
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%', WebkitTouchCallout: 'none' } as CSSProperties}>
+      <div ref={elRef} style={{ width: '100%', height: '100%' }} />
+      {handles && (['start', 'end'] as const).map((which) => (
+        <div key={which} onTouchStart={dragHandle(which)} style={handleStyle(which)} />
+      ))}
+    </div>
+  )
 })
 
 export default Term

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -60,6 +60,8 @@ const enUS = {
   'terminal.manualPaste': 'Manual paste…',
   'terminal.scrollHistory': 'Scroll history',
   'terminal.toBottom': 'Jump to latest',
+  'terminal.redraw': 'Redraw screen (fix garbled output)',
+  'terminal.redrawShort': 'Redraw',
   'terminal.reconnect': 'Reconnect',
   'terminal.tmuxCopyMode': 'tmux copy mode',
   'terminal.tmuxWindowList': 'tmux window list',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -60,6 +60,8 @@ const zhCN = {
   'terminal.manualPaste': '手动粘贴…',
   'terminal.scrollHistory': '上翻历史',
   'terminal.toBottom': '回到最新',
+  'terminal.redraw': '重绘画面（修复花屏错位）',
+  'terminal.redrawShort': '重绘',
   'terminal.reconnect': '重新连接',
   'terminal.tmuxCopyMode': 'tmux 复制模式',
   'terminal.tmuxWindowList': 'tmux 窗口列表',


### PR DESCRIPTION
## 背景

镜像终端的输入/选择体验和原生客户端差距大：

1. 光标由远端 TUI/shell 控制，点击/点按移不动，改输入只能靠丝带或键盘方向键一格格挪。
2. 手机上 touchmove 被滚动手势独占、xterm 不处理触摸，终端文本**完全无法选中复制**。
3. 桌面缺中键粘贴；手机缺直达粘贴入口（iOS 连长按菜单都没有）。

## 改动

### 点按/单击移光标（commit 1）
前端把单击/轻点(非拖选)的格子坐标以 `move-cursor` 消息发后端，后端按 tmux 真实光标位置合成方向键：备用屏(Claude/Codex/vim)先↑/↓再←/→（竖直>8行忽略防误触历史回填）；普通屏(shell)不能发↑/↓，按 pane 宽折算成←/→（折行长命令也能定位）；copy-mode 中不动作；用 tmux 命名键按 DECCKM 编码。

### 触摸选区对齐原生（commit 2）
- 长按 400ms 震动选词（近似 xterm 双击分词，CJK 宽字符归位）→ 不抬手拖动扩选 → 松手自动复制
- 选区两端留 Android 风格泪滴手柄可拖动微调，松手重新复制；点空白清除选区
- 长按期间屏蔽 contextmenu；触屏 tap 后补发的合成 mouse 事件按时间窗去重
- **修了一个隐蔽 bug**：触摸目标是 xterm 内层 span，手势中途被重绘移除后 touchmove/touchend 不再冒泡（终端常态在重绘），touchstart 时在目标上补挂转发监听兜底
- 桌面补中键粘贴（点哪个 pane 先激活再贴）；触屏丝带加「粘贴」按钮（复用现有 i18n key）

### 花屏重绘（commit 3）
手机 attach 把窗口挤窄后，Claude Code 等 ink TUI 宽行重折行清屏行数算错，spinner 每帧堆叠垃圾行（满屏重复不再被覆盖）。新增 `redraw()`：尺寸抖动(cols−1→cols)连发两次 SIGWINCH 逼 TUI 整屏重排（等价「拖一下窗口就好了」）；attach/重连后 600ms 自动抖一次，另有工具栏「重绘」按钮和右键菜单入口手动救。验证：往 less(备用屏) pane tty 注入垃圾行模拟花屏，attach 自动重绘 12→0 行、按钮 6→0 行、内容尺寸完好。

## 验证

- CDP 驱动真实前后端全链路（隔离实例 + 真 tmux + headless Chrome），8 项全过且复跑稳定：桌面单击移光标、远距点击防误触、触屏轻点移光标、长按选词自动复制、手柄出现、拖手柄扩选、点空白清选区、长按拖动扩选、中键粘贴。
- tmux 侧单独验证 `send-keys -N n Left/Right` 与折算一致。
- `scripts/dev/quality/check.sh full` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)