### PR TITLE
fix(project): git 子目录不再误入册——瞬时错误不当非 git，读时 Rekey 自愈

### DIFF
--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -172,6 +172,11 @@ func (a *API) ProjectsList(c *gin.Context) {
 			}
 			continue // 一时读不出（锁竞争/超时）：保留台账，本轮跳过
 		}
+		// 自愈：条目 dir 指向仓库子目录（历史脏数据/瞬时误判）→ 归位到仓库根
+		if repo, rerr := a.WT.ResolveRepo(ctx, e.Dir); rerr == nil && repo.Root != e.Dir {
+			a.Projects.Rekey(key, repo.Root)
+			continue // 本轮跳过，下轮以根条目出现（或并入已有根条目）
+		}
 		p.Git = true
 		roamWts := 0
 		for _, w := range wts {
@@ -286,6 +291,11 @@ func (a *API) ProjectCreate(c *gin.Context) {
 	git := true
 	if repo, err := a.WT.ResolveRepo(ctx, dir); err == nil {
 		dir = repo.Root
+	} else if we, ok := err.(*worktree.Err); !ok || we.Code != "NOT_GIT_REPO" {
+		// 瞬时错误（锁竞争/超时）不能当「非 git」处理——否则 git 子目录会被
+		// 存成独立项目（dir 未归位仓库根）。老实报错让用户重试。
+		wtErr(c, err)
+		return
 	} else {
 		// 非 git：目录不存在则创建（新建项目 = 也可以新建文件夹）；canonical 化对齐 cwd join 口径
 		if st, serr := os.Stat(dir); serr != nil {

--- a/backend/project/service.go
+++ b/backend/project/service.go
@@ -252,3 +252,32 @@ func (s *Store) ReadTrace(repoDir string, limit int) []TraceEntry {
 	}
 	return out
 }
+
+// Rekey 把条目迁移到新目录（typically 仓库子目录归位到根）。目标 key 已存在则
+// 合并：置顶/origin=user/显示名等「用户意志」按或语义保留，不丢。
+func (s *Store) Rekey(oldKey, newDir string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.repos[oldKey]
+	if !ok {
+		return
+	}
+	delete(s.repos, oldKey)
+	newKey := KeyFor(newDir)
+	if dst, exists := s.repos[newKey]; exists {
+		dst.Pinned = dst.Pinned || e.Pinned
+		if dst.Origin == "" {
+			dst.Origin = e.Origin
+		}
+		if dst.DisplayName == "" {
+			dst.DisplayName = e.DisplayName
+		}
+		if e.FirstSeen > 0 && (dst.FirstSeen == 0 || e.FirstSeen < dst.FirstSeen) {
+			dst.FirstSeen = e.FirstSeen
+		}
+	} else {
+		e.Dir = newDir
+		s.repos[newKey] = e
+	}
+	s.save()
+}

--- a/backend/project/service_test.go
+++ b/backend/project/service_test.go
@@ -54,3 +54,25 @@ func TestSetPrefsUnknownKey(t *testing.T) {
 		t.Fatal("不在册 key 必须拒绝（API 防任意路径探测的前提）")
 	}
 }
+
+func TestRekeyMergesUserIntent(t *testing.T) {
+	s := NewStore(t.TempDir())
+	// 子目录脏条目（置顶过）+ 已存在的根条目
+	sub := s.Add("/repo/.worktrees", "")
+	s.SetPrefs(sub, func(p *Prefs) { p.Pinned = true })
+	root := s.Touch("/repo")
+	s.Rekey(sub, "/repo")
+	if _, ok := s.Dir(sub); ok {
+		t.Fatal("旧子目录条目应被移除")
+	}
+	e := s.Entries()[root]
+	if !e.Pinned || e.Origin != "user" {
+		t.Fatalf("合并须保留用户意志(置顶/origin=user): %+v", e)
+	}
+	// 目标不存在时 = 平移改 dir
+	k2 := s.Touch("/other/.worktrees")
+	s.Rekey(k2, "/other")
+	if d, ok := s.Dir(KeyFor("/other")); !ok || d != "/other" {
+		t.Fatal("目标不存在时应平移条目到新目录")
+	}
+}


### PR DESCRIPTION
## 问题

合并 #93 后线上出现名为 `.worktrees` 的项目——git 仓库的子目录被存成了独立项目条目（dir 未归位仓库根）。

## 根因

`ProjectCreate` 里 `ResolveRepo` 的**瞬时失败**（仓库锁竞争/超时）也会落入「非 git → 建目录入册」分支，把 git 子目录当非 git 项目原样存下。

## 修复

1. **创建**：只有明确 `NOT_GIT_REPO` 才走非 git 分支；其余错误原样报出让用户重试。
2. **读时自愈**：`ProjectsList` 发现 git 条目的 dir ≠ 仓库根时调 `Store.Rekey` 归位——目标根条目已存在则合并（置顶 / origin=user / 显示名等用户意志按或语义保留，firstSeen 取更早），历史脏数据下一轮自动消失。含 Rekey 合并语义单测。

线上脏条目已手动清除；本修复防复发 + 自愈存量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)