### PR TITLE
feat(mobile): 文件/插件页手机端两级导航——列表→全屏二级详情页

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import CodexChat from './CodexChat'
 import FileBrowser from './FileBrowser'
 import FileWorkspace from './FileWorkspace'
 import FloatingFileDrawer from './FloatingFileDrawer'
+import MobileSubPage from './MobileSubPage'
+import { FileView } from './fileview'
 // 非首屏的重页面（蜂群/Git 面板/浏览器/手机镜像/插件）按路由懒加载：切到对应 tab 才拉 chunk，
 // 缩小首屏 index 块。都渲染在同一个 Suspense 边界内（见 lazyFallback，App 内 page）。
 const GitPanel = lazy(() => import('./GitPanel'))
@@ -187,6 +189,11 @@ function FilesPage({ openTerm }: { openTerm: (name: string) => void }) {
   const { message } = AntApp.useApp()
   const { t } = useI18n()
   const [prefs] = usePreferences()
+  // 手机(窄屏)两级导航：一级整页文件列表，点文件后详情以全屏二级页(MobileSubPage)展开；
+  // 桌面仍是 FileWorkspace(文件树 dock + 多 tab 编辑)。
+  const screens = useBreakpoint()
+  const isMobile = !screens.md
+  const [mobileFile, setMobileFile] = useState<string | null>(null)
   const openAgent = async (kind: 'claude' | 'codex', file: string) => {
     const base = pathBasename(file).replace(/[^a-zA-Z0-9_.-]+/g, '-').slice(0, 28) || 'file'
     const name = `${kind}-${base}-${Date.now().toString(36).slice(-5)}`
@@ -203,6 +210,19 @@ function FilesPage({ openTerm }: { openTerm: (name: string) => void }) {
     } catch (e: any) {
       message.error(t('file.openFailed', { message: e.message }))
     }
+  }
+  if (isMobile) {
+    return (
+      <div style={{ height: '100%', minHeight: 0, display: 'flex' }}>
+        <FileBrowser dir="" accent="#58a6ff" layout="dock" onOpenFile={setMobileFile} onOpenAgent={openAgent} />
+        {mobileFile && (
+          <MobileSubPage onBack={() => setMobileFile(null)}>
+            <FileView path={mobileFile} accent="#58a6ff" inline onBack={() => setMobileFile(null)}
+              onClose={() => setMobileFile(null)} onOpenPath={setMobileFile} onOpenAgent={openAgent} />
+          </MobileSubPage>
+        )}
+      </div>
+    )
   }
   return (
     <div style={{ height: '100%', minHeight: 0, display: 'flex' }}>

--- a/frontend/src/MobileSubPage.tsx
+++ b/frontend/src/MobileSubPage.tsx
@@ -1,0 +1,31 @@
+// 移动端二级页：Android Fragment 式全屏覆盖层——列表页点某项后，详情在上层整页展开。
+// 传 title 则带「← 返回 + 标题」顶栏；不传则无顶栏（内容自带返回入口，如 FileView 的 onBack）。
+// z-index 90：盖过底部导航(50)，低于全屏会话覆盖层(100)与 antd 弹层(≥1000)。
+import { type ReactNode } from 'react'
+import { useI18n } from './i18n'
+
+export default function MobileSubPage({ title, onBack, children }: {
+  title?: ReactNode
+  onBack: () => void
+  children: ReactNode
+}) {
+  const { t } = useI18n()
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 90, background: 'var(--bg-base)',
+      display: 'flex', flexDirection: 'column', paddingTop: 'env(safe-area-inset-top)',
+    }}>
+      {title !== undefined && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid var(--border)', background: 'var(--bg-container)' }}>
+          <button onClick={onBack} title={t('common.back')} style={{ border: 0, background: 'none', color: 'var(--text-bright)', padding: '6px 10px', display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+          </button>
+          <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</div>
+        </div>
+      )}
+      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/PluginsPanel.tsx
+++ b/frontend/src/PluginsPanel.tsx
@@ -3,12 +3,13 @@
 // 数据全部走 backend 薄封装 REST(exec ttmux plugin ... --json),前端不感知 plugind。
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
-  Alert, Button, Card, Checkbox, Descriptions, Divider, Empty, Form, Input, List, Modal, Popconfirm, Select,
+  Alert, Button, Card, Checkbox, Descriptions, Divider, Empty, Form, Grid, Input, List, Modal, Popconfirm, Select,
   Space, Spin, Switch, Table, Tabs, Tag, Tooltip, Typography, Upload, message,
 } from 'antd'
 import { api } from './api'
 import { useI18n } from './i18n'
 import HostMonitorPanel from './HostMonitorPanel'
+import MobileSubPage from './MobileSubPage'
 
 // 有宿主侧内置面板的插件(v1 插件无自定义前端,面板由宿主按 id 挂载)
 const HOST_MONITOR_ID = 'roam.host-monitor'
@@ -67,6 +68,10 @@ export default function PluginsPanel() {
   const [selected, setSelected] = useState('')
   const [startingDaemon, setStartingDaemon] = useState(false)
   const [installOpen, setInstallOpen] = useState(false)
+  // 手机(窄屏)走两级导航：一级整页插件列表，点某项后详情以全屏二级页(MobileSubPage)展开。
+  const screens = Grid.useBreakpoint()
+  const isMobile = !screens.md
+  const [mobileDetail, setMobileDetail] = useState(false)
 
   const reload = useCallback(async () => {
     try {
@@ -112,7 +117,7 @@ export default function PluginsPanel() {
 
   return (
     <div style={{ display: 'flex', gap: 16, height: '100%', minHeight: 0 }}>
-      <Card size="small" style={{ width: 300, flex: '0 0 300px', overflow: 'auto' }} title={t('plugins.title')}
+      <Card size="small" style={isMobile ? { flex: 1, minWidth: 0, overflow: 'auto' } : { width: 300, flex: '0 0 300px', overflow: 'auto' }} title={t('plugins.title')}
         extra={<Space size={4}>
           <Button size="small" type="primary" onClick={() => setInstallOpen(true)}>{t('plugins.install')}</Button>
           <Tooltip title={t('plugins.marketSoon')}>
@@ -128,10 +133,10 @@ export default function PluginsPanel() {
           dataSource={plugins}
           renderItem={(p) => (
             <List.Item
-              onClick={() => setSelected(p.manifest.id)}
+              onClick={() => { setSelected(p.manifest.id); if (isMobile) setMobileDetail(true) }}
               style={{
                 cursor: 'pointer', borderRadius: 8, padding: '8px 10px',
-                background: p.manifest.id === selected ? 'var(--bg-elevated, rgba(88,166,255,.12))' : undefined,
+                background: !isMobile && p.manifest.id === selected ? 'var(--bg-elevated, rgba(88,166,255,.12))' : undefined,
               }}
               actions={[<Switch key="sw" size="small" checked={p.enabled}
                 onClick={(v, e) => { e.stopPropagation(); toggle(p, v) }} />]}
@@ -146,12 +151,23 @@ export default function PluginsPanel() {
           )}
         />
       </Card>
-      <div style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
-        {current
-          ? <PluginDetail key={current.manifest.id} plugin={current} locale={locale} t={t}
-              onChanged={() => { setSelected(''); reload() }} />
-          : <Empty style={{ marginTop: 64 }} />}
-      </div>
+      {!isMobile && (
+        <div style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
+          {current
+            ? <PluginDetail key={current.manifest.id} plugin={current} locale={locale} t={t}
+                onChanged={() => { setSelected(''); reload() }} />
+            : <Empty style={{ marginTop: 64 }} />}
+        </div>
+      )}
+      {isMobile && mobileDetail && current && (
+        <MobileSubPage title={lt(current.manifest.displayName, locale) || current.manifest.name}
+          onBack={() => setMobileDetail(false)}>
+          <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 12 }}>
+            <PluginDetail key={current.manifest.id} plugin={current} locale={locale} t={t}
+              onChanged={() => { setMobileDetail(false); setSelected(''); reload() }} />
+          </div>
+        </MobileSubPage>
+      )}
       <InstallModal open={installOpen} locale={locale} t={t} onClose={() => setInstallOpen(false)}
         onDone={() => { setInstallOpen(false); reload() }} />
     </div>

--- a/frontend/src/fileview/FileView.tsx
+++ b/frontend/src/fileview/FileView.tsx
@@ -25,6 +25,7 @@ export function FileView({
   tabbed,
   forcePreview,
   onClose,
+  onBack,
   onOpenPath,
   onOpenAgent,
   onDirtyChange,
@@ -41,6 +42,8 @@ export function FileView({
   // 专用预览 tab（VSCode「侧栏预览」）：始终渲染 markdown/HTML，不显示编辑器/切换钮。
   forcePreview?: boolean
   onClose: () => void
+  // 移动端二级页语境：标题栏最左显「←」返回（代替右侧关闭 ×），工具按钮可换行。
+  onBack?: () => void
   onOpenPath: (p: string) => void
   onOpenAgent?: (kind: 'claude' | 'codex', path: string) => void
   // 编辑器脏状态上报（供外层 tab 显示未保存圆点）
@@ -145,7 +148,12 @@ export function FileView({
   }
 
   const titleNode = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingRight: inline ? 0 : 28, minWidth: 0 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingRight: inline ? 0 : 28, minWidth: 0, flexWrap: onBack ? 'wrap' : undefined, rowGap: onBack ? 6 : undefined }}>
+      {onBack && (
+        <IconButton title={t('common.back')} onClick={onBack}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+        </IconButton>
+      )}
       {!tabbed && (
         <span style={{ fontFamily: 'ui-monospace, monospace', fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           <span style={{ color: accent }}>▸</span> {name}
@@ -168,7 +176,7 @@ export function FileView({
       <Button size="small" onClick={copyPath}>{t('file.copyPath')}</Button>
       <Button size="small" href={downloadUrl} download={downloadName}>{t('file.download')}</Button>
       <a href={rawUrl} target="_blank" rel="noreferrer" style={{ color: 'var(--text-dim)', fontSize: 12 }}>{t('file.raw')}</a>
-      {inline && !tabbed && <IconButton title={t('file.closePreview')} onClick={onClose}><CloseIcon /></IconButton>}
+      {inline && !tabbed && !onBack && <IconButton title={t('file.closePreview')} onClick={onClose}><CloseIcon /></IconButton>}
     </div>
   )
   const bodyNode = (

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -12,6 +12,7 @@ const enUS = {
   'common.copied': 'Copied',
   'common.copyFailed': 'Copy failed',
   'common.close': 'Close',
+  'common.back': 'Back',
   'common.refresh': 'Refresh',
   'common.more': 'More',
   'common.confirm': 'Confirm',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -12,6 +12,7 @@ const zhCN = {
   'common.copied': '已复制',
   'common.copyFailed': '复制失败',
   'common.close': '关闭',
+  'common.back': '返回',
   'common.refresh': '刷新',
   'common.more': '更多',
   'common.confirm': '确定',


### PR DESCRIPTION
## 摘要

手机视图里「文件」「插件」两页从桌面式分栏布局改为移动端两级导航：一级整页列表，点击后详情以全屏二级页（Android Fragment 式上层覆盖）展开，顶部带「←」返回。

## 改动

- **新增 `MobileSubPage.tsx`**：通用移动端二级页组件——全屏覆盖层（z-index 90，盖过底部导航 50、低于全屏会话层 100），可带「← 返回 + 标题」顶栏，也可无顶栏由内容自带返回入口。
- **插件页 `PluginsPanel.tsx`**：窄屏（<768px）列表占满整页；点插件 → 详情（配置/命令/权限/审计/监控）以全屏二级页展开，顶栏显插件名；卸载后自动退回列表。桌面左右两栏不变。
- **文件页 `App.tsx` FilesPage**：窄屏不再挤 FileWorkspace（文件树 dock + 多 tab），改为整页文件列表（FileBrowser dock 布局，树/平铺、搜索、上传等工具栏保留）；点文件 → 全屏 `FileView` 二级页。桌面 FileWorkspace 不变。
- **`FileView` 新增 `onBack`**：标题栏最左显返回箭头（替代右上关闭 ×），工具按钮（保存/源码/下载等）窄屏允许换行。
- i18n 新增 `common.back`（返回/Back，zh-CN + en-US）。

## 验证

- `npm run build`（含 i18n 审计）与 `tsc --noEmit` 通过；预提交质量门（Go 测试/密钥扫描）通过。
- 无头 Chrome 390×844 手机视口连本地后端实测：
  - 插件：列表 → 点击进全屏详情（主机监控仪表盘正常渲染）→ 返回回列表 ✅
  - 文件：列表 → 打开 AGENTS.md（Markdown 渲染、工具栏齐全）→ 返回回列表 ✅
- 桌面宽度回归：文件/插件页仍走原布局分支，未触碰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
