### PR TITLE
fix(activity): 最近活跃时间滞后 + 列表绿点语义 + 蜂群前缀匹配

### DIFF
--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -139,6 +139,33 @@ func paneToolDir(name string, match func(int) bool) string {
 // paneClaudeDir 返回会话中正在跑 claude 的 pane 的工作目录；没有则返回 ""。
 func paneClaudeDir(name string) string { return paneToolDir(name, cmdlineHasClaude) }
 
+// runningAgentSessions 一次性扫全部 pane 的进程树，返回跑着 claude / codex 的会话集合。
+// 供项目列表批量判「活跃」——绿点语义（设计 W2）：agent 进程在跑才算活跃。避免前端
+// 逐会话打 /claude+/codex（N×2 请求），也纠正原先拿 session_attached（有没有人 attach）
+// 当活跃代理的误判：后台干活没人看=灰、开着终端却 idle=绿 的反相。
+func runningAgentSessions() map[string]bool {
+	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_pid}").Output()
+	if err != nil {
+		return nil
+	}
+	children := procChildren()
+	running := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 || running[parts[0]] {
+			continue
+		}
+		pid, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		if treeMatch(pid, children, 0, cmdlineHasClaude) || treeMatch(pid, children, 0, cmdlineHasCodex) {
+			running[parts[0]] = true
+		}
+	}
+	return running
+}
+
 // newestJSONL 返回目录中最近修改的 .jsonl（即当前活跃会话记录）。
 func newestJSONL(dir string) string {
 	ents, err := os.ReadDir(dir)

--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -28,6 +28,7 @@ import (
 type projectSession struct {
 	Name         string `json:"name"`
 	Attached     bool   `json:"attached"`
+	Running      bool   `json:"running"` // 会话里跑着 claude/codex 进程——绿点语义（设计 W2）
 	LastActivity int64  `json:"lastActivity"`
 	Branch       string `json:"branch,omitempty"` // 落在 worktree 里才有
 	Linked       bool   `json:"linked,omitempty"`
@@ -125,10 +126,12 @@ func (a *API) ProjectsList(c *gin.Context) {
 	var nonGit []pending
 	var cwds map[string][]string // 懒取：有非 git 项目才拉
 
+	agentRunning := runningAgentSessions() // 一次进程树扫描，供绿点判活跃（设计 W2）
+
 	addSession := func(p *projectSummary, top *[]projectSession, name string, attached bool, last int64, branch string, linked bool) {
 		claimed[name] = true
 		p.Sessions++
-		ps := projectSession{Name: name, Attached: attached, LastActivity: last, Linked: linked, Branch: branch}
+		ps := projectSession{Name: name, Attached: attached, Running: agentRunning[name], LastActivity: last, Linked: linked, Branch: branch}
 		if ps.Attached {
 			p.Attached++
 		}
@@ -248,7 +251,7 @@ func (a *API) ProjectsList(c *gin.Context) {
 
 	for _, s := range sessions {
 		if !claimed[s.Name] {
-			loose = append(loose, projectSession{Name: s.Name, Attached: rawInt(s.Attached) > 0, LastActivity: rawInt(s.LastActivity)})
+			loose = append(loose, projectSession{Name: s.Name, Attached: rawInt(s.Attached) > 0, Running: agentRunning[s.Name], LastActivity: rawInt(s.LastActivity)})
 		}
 	}
 	// 散会话同样稳定排序（按名称）——活动时间只展示，不参与排序防跳变

--- a/cli/ttmux-cli-go/internal/command/session/fork.go
+++ b/cli/ttmux-cli-go/internal/command/session/fork.go
@@ -223,7 +223,8 @@ func buildTree(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool
 	rows := meta.All()
 
 	// 会话基础信息（一次 list-sessions）
-	out, _ := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}\t#{session_activity}")
+	// window_activity 补 session_activity 盲区（后台有输出但无人 attach 时不动),取较大值。
+	out, _ := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}\t#{session_activity}\t#{window_activity}")
 	nodes := map[string]*treeNode{}
 	var order []string
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
@@ -236,6 +237,9 @@ func buildTree(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool
 		fmt.Sscanf(parts[3], "%d", &n.Attached)
 		if len(parts) > 4 {
 			n.LastActivity = parts[4]
+		}
+		if len(parts) > 5 {
+			n.LastActivity = maxNumeric(n.LastActivity, parts[5])
 		}
 		nodes[n.Name] = n
 		order = append(order, n.Name)

--- a/cli/ttmux-cli-go/internal/command/session/session.go
+++ b/cli/ttmux-cli-go/internal/command/session/session.go
@@ -29,7 +29,10 @@ type infoJSON struct {
 }
 
 func ListJSON(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
-	out, err := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}\t#{session_activity}")
+	// window_activity 补上 session_activity 的盲区：tmux 只在 attach/输入/焦点变化时
+	// 刷新 session_activity,后台无人 attach 的会话即便一直有输出(agent 干活)也不动;
+	// window_activity 会随前台窗口的 pane 输出走。取两者较大值 = 真正的「最近活跃」。
+	out, err := rt.TmuxOutput("list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}\t#{session_activity}\t#{window_activity}")
 	if err != nil {
 		// tmux server 未启动时输出的是 stderr 错误文本（out 非空），只看 err
 		_, _ = io.WriteString(w, "[]\n")
@@ -52,6 +55,9 @@ func ListJSON(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
 		lastActivity := ""
 		if len(parts) > 4 {
 			lastActivity = parts[4]
+		}
+		if len(parts) > 5 {
+			lastActivity = maxNumeric(lastActivity, parts[5]) // max(session_activity, window_activity)
 		}
 		sessions = append(sessions, sessionInfo{
 			Name:         parts[0],
@@ -115,6 +121,17 @@ func Capture(rt runtime.Runtime, args []string, w io.Writer) error {
 
 func must(s string, _ error) string {
 	return s
+}
+
+// maxNumeric returns whichever of two tmux epoch strings is the larger number,
+// tolerating empty/garbage (parses as 0). Keeps the string form for the JSON.
+func maxNumeric(a, b string) string {
+	na, _ := strconv.ParseInt(strings.TrimSpace(a), 10, 64)
+	nb, _ := strconv.ParseInt(strings.TrimSpace(b), 10, 64)
+	if nb > na {
+		return b
+	}
+	return a
 }
 
 func IsTerminal() bool {

--- a/cli/ttmux-cli-go/internal/swarm/swarm.go
+++ b/cli/ttmux-cli-go/internal/swarm/swarm.go
@@ -400,7 +400,7 @@ func liveStatus(opt Options, meta swarmMeta, m SwarmMember) string {
 		}
 		return "exited"
 	}
-	dead := strings.TrimSpace(runTmux(opt.TmuxBin, "display-message", "-t", m.Session, "-p", "#{pane_dead}"))
+	dead := strings.TrimSpace(runTmux(opt.TmuxBin, "display-message", "-t", "="+m.Session, "-p", "#{pane_dead}"))
 	if dead == "1" {
 		return "done"
 	}
@@ -430,7 +430,9 @@ func liveStatus(opt Options, meta swarmMeta, m SwarmMember) string {
 }
 
 func tmuxHasSession(bin, session string) bool {
-	cmd := exec.Command(bin, "has-session", "-t", session)
+	// "=" 强制精确匹配:tmux -t 默认按前缀匹配,dev 会话死后 has-session
+	// 会命中它的陪跑会话 <dev>-review,导致存活误判、退出/完成事件永不触发。
+	cmd := exec.Command(bin, "has-session", "-t", "="+session)
 	return cmd.Run() == nil
 }
 
@@ -443,7 +445,7 @@ func runTmux(bin string, args ...string) string {
 }
 
 func captureRecent(bin, session string) string {
-	out := runTmux(bin, "capture-pane", "-t", session, "-p", "-J", "-S", "-80")
+	out := runTmux(bin, "capture-pane", "-t", "="+session, "-p", "-J", "-S", "-80")
 	lines := strings.Split(out, "\n")
 	if len(lines) > 18 {
 		lines = lines[len(lines)-18:]

--- a/cli/ttmux-cli-go/internal/swarm/write.go
+++ b/cli/ttmux-cli-go/internal/swarm/write.go
@@ -222,7 +222,7 @@ func (s *Store) MemberDone(swarm, member string) bool {
 	}
 	sess := swarm + "-" + member
 	if tmuxHasSession(s.opt.TmuxBin, sess) {
-		dead := strings.TrimSpace(runTmux(s.opt.TmuxBin, "display-message", "-t", sess, "-p", "#{pane_dead}"))
+		dead := strings.TrimSpace(runTmux(s.opt.TmuxBin, "display-message", "-t", "="+sess, "-p", "#{pane_dead}"))
 		return dead == "1"
 	}
 	_, err := os.Stat(filepath.Join(s.opt.DataDir, "logs", sess+".log"))

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -21,7 +21,7 @@ const RaceCreateModal = lazy(() => import('./Race').then((m) => ({ default: m.Ra
 const RaceComparePanel = lazy(() => import('./Race').then((m) => ({ default: m.RaceComparePanel })))
 const NewSwarmModal = lazy(() => import('./Swarm').then((m) => ({ default: m.NewSwarmModal })))
 
-type ProjSession = { name: string; attached: boolean; lastActivity: number; branch?: string; linked?: boolean }
+type ProjSession = { name: string; attached: boolean; running?: boolean; lastActivity: number; branch?: string; linked?: boolean }
 type Proj = {
   key: string; name: string; dir: string; git: boolean; pinned: boolean
   sessions: number; attached: number; worktrees: number; unfinished: number; cleanable: number; races: number
@@ -276,7 +276,7 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
                 }}>
                   {p.top!.map((s) => (
                     <div key={s.name} style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
-                      {dot(s.attached)}
+                      {dot(false, s.running ? '#3fb950' : undefined)}
                       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
                       {s.branch && <Tag color="cyan" style={{ margin: 0, fontSize: 10.5, lineHeight: '16px', padding: '0 5px' }}>⎇</Tag>}
                       <span style={{ marginLeft: 'auto', color: 'var(--text-dimmer)', fontSize: 11.5, flex: '0 0 auto' }}>{relTime(s.lastActivity, t)}</span>
@@ -295,7 +295,7 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
             </div>
             {data.loose.map((s) => (
               <div key={s.name} className="prj-row" onClick={() => openTerm(s.name)}>
-                <span style={{ marginTop: 5, display: 'inline-flex' }}>{dot(s.attached)}</span>
+                <span style={{ marginTop: 5, display: 'inline-flex' }}>{dot(false, s.running ? '#3fb950' : undefined)}</span>
                 <span style={{ fontWeight: 600 }}>{s.name}</span>
                 <span style={{ color: 'var(--text-dimmer)', fontSize: 12, marginTop: 2 }}>{relTime(s.lastActivity, t)}</span>
                 <span style={{ flex: 1 }} />


### PR DESCRIPTION
排查「活跃检测」牵出三个独立 bug，全部收在本 PR。

## 1 — 最近活跃时间滞后（用户实际看到的症状）

`ttmux ls --json` / 会话树读的 tmux `#{session_activity}` **只在 attach / 键盘输入 / 焦点变化时刷新**；无人 attach 的后台会话即便 pane 一直有输出也不动。ttmux 的 agent 会话都后台跑（网页轮询 capture + 按需 attach），所以忙碌 agent 的活跃时间会卡在"上次有人 attach/发消息"的时刻，显示成"42分钟前"却其实在忙。

实测（detached 会话每秒 echo）：`session_activity` 冻结、`window_activity` 每秒 +1。

**改法**：list-sessions 同时取 `session_activity` 与 `window_activity`，`last_activity` 取两者较大值。端到端验证：新二进制活跃时间跟着墙钟实时走。已装到 `~/.local/bin/ttmux` 线上即时生效（后端 shell 调 `ttmux ls`）。

## 2 — 项目列表绿点语义错（拿 attach 当活跃）

列表卡片状态点原先 `dot(s.attached)`：绿 = 有 tmux 客户端 attach 着，跟 agent 忙不忙无关 → 后台干活没人看=灰、开着终端却 idle=绿，语义反相；且与详情页(`cc||cx` running)和代码里写死的**设计 W2「绿=agent 正在干活」**自相矛盾。

**改法**：后端 `/projects` 一次性扫全部 pane 进程树（`runningAgentSessions`，复用 `treeMatch` + `cmdlineHasClaude/Codex`），给每会话带上 `running`；前端列表点改成 `running` 才绿。避免前端逐会话 N×2 请求。

> 待输入（黄）暂未上列表：需逐会话 capture-pane + 移植 `detectPrompt` 解析器，成本/风险不成比例，留作后续；当前 idle 与待输入都归灰。

## 3 — 蜂群成员活跃检测漏加 `=` 精确匹配（顺带发现）

`liveStatus` / `MemberDone` 的 `has-session`、`display-message`、`capture-pane` 拿裸会话名做 `-t` 目标，tmux 默认前缀匹配：`dev` 死后 `has-session -t dev` 命中陪跑会话 `<dev>-review` → 存活误判、`pane_dead` 读到兄弟会话、`done`/`exited` 永远检测不出。复用 `runtime.HasSession` 早有的 `"="+name` 约定补齐 swarm 那套三处调用。

## 验证

- CLI：`go build/vet/gofmt/test` 全绿；新二进制端到端验证活跃时间实时走。
- Web 后端：`go build/vet ./api/... && go test ./api/...` 全绿。
- 前端：改动最小、复用同文件既有 `dot(false, …)` 签名（此 worktree 缺 node_modules 未跑 tsc）。

⚠️ 注意：第 2、3 个改动分别在 web 后端和前端，**上线需重建 ttmux-web + 重启 web（会断当前连接）+ 前端 build 拷 dist**，比 CLI 热替换重，未自动部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
