### PR TITLE
fix(worktree): 空 worktree 秒判「已合入」

### DIFF
--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -463,22 +463,38 @@ func (s *Service) List(ctx context.Context, dir string) ([]Worktree, error) {
 					w.CommittedAhead, _ = strconv.Atoi(parts[1])
 				}
 			}
-			// S1 祖先：merge commit / ff / rebase 后 ff 都命中
-			if _, e := git(ctx, w.Path, "merge-base", "--is-ancestor", "HEAD", target); e == nil {
-				w.MergedInto, w.MergedKind = target, "ancestry"
-			} else if w.CommittedAhead > 0 {
-				// S2 补丁等价：squash/逐提交 rebase 后，任务分支提交按 patch-id 全部
-				// 被 target 覆盖（cherry 全 `-`）。出现 `+` 即有真领先，宁可漏判不错判。
-				if out, e := git(ctx, w.Path, "cherry", target, "HEAD"); e == nil {
-					plus := 0
-					for _, l := range strings.Split(out, "\n") {
-						if strings.HasPrefix(l, "+ ") {
-							plus++
-						}
+			// 空 worktree 兜底：新开对话建的 worktree HEAD==本地 base tip，本身就是
+			// target 的祖先，S1 会把它秒判「已合入」。要求相对本地 base 分支确有独占
+			// 提交（真做过事）才进入合入判定；HEAD 一旦被合进 target，本地 base 不 pull
+			// 就还落后 HEAD，own>0 依旧成立（S1 test 的「本地 main 不动」正是此路）。
+			// 本地 base ref 不存在（base 仅在远端）时无从判断，退回旧行为不做抑制。
+			ownWork := true
+			if _, e := git(ctx, w.Path, "rev-parse", "--verify", "-q", "refs/heads/"+w.Base); e == nil {
+				ownWork = false
+				if cnt, e := git(ctx, w.Path, "rev-list", "--count", w.Base+"..HEAD"); e == nil {
+					if n, _ := strconv.Atoi(strings.TrimSpace(cnt)); n > 0 {
+						ownWork = true
 					}
-					w.AheadUnique = plus
-					if plus == 0 && strings.TrimSpace(out) != "" {
-						w.MergedInto, w.MergedKind = target, "squash"
+				}
+			}
+			// S1 祖先：merge commit / ff / rebase 后 ff 都命中
+			if ownWork {
+				if _, e := git(ctx, w.Path, "merge-base", "--is-ancestor", "HEAD", target); e == nil {
+					w.MergedInto, w.MergedKind = target, "ancestry"
+				} else if w.CommittedAhead > 0 {
+					// S2 补丁等价：squash/逐提交 rebase 后，任务分支提交按 patch-id 全部
+					// 被 target 覆盖（cherry 全 `-`）。出现 `+` 即有真领先，宁可漏判不错判。
+					if out, e := git(ctx, w.Path, "cherry", target, "HEAD"); e == nil {
+						plus := 0
+						for _, l := range strings.Split(out, "\n") {
+							if strings.HasPrefix(l, "+ ") {
+								plus++
+							}
+						}
+						w.AheadUnique = plus
+						if plus == 0 && strings.TrimSpace(out) != "" {
+							w.MergedInto, w.MergedKind = target, "squash"
+						}
 					}
 				}
 			}

--- a/backend/worktree/service_test.go
+++ b/backend/worktree/service_test.go
@@ -354,6 +354,15 @@ func TestMergedDetection(t *testing.T) {
 		return Worktree{}
 	}
 
+	// ── 空 worktree：新建即秒判「已合入」的回归（HEAD==base tip，是 target 祖先）──
+	we, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/empty", Base: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := find(we.Path); w.MergedInto != "" {
+		t.Fatalf("empty worktree must NOT be merged, got %+v", w)
+	}
+
 	// ── S1 祖先：远端 main fast-forward 到任务分支，本地 main 不动 ──
 	wa, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/feat-a", Base: "main"})
 	if err != nil {


### PR DESCRIPTION
本 PR 修两处 worktree 合入判定问题（后端误判 + 内外展示不一致）。

## 1. 空 worktree 秒判「已合入」（backend）

新开对话即新建 worktree 时立刻显示「已合入」。零提交的空 worktree HEAD 就是 base(main) 的 tip，**天然是 target 的祖先**，S1 `merge-base --is-ancestor` 直接成立 → 被判 `ancestry` 合入。S2(squash) 有 `CommittedAhead > 0` 兜底，唯独 S1 没有。

修复：进入合入判定前先算 `ownWork` —— 相对**本地 base 分支**有无独占提交（`git rev-list --count <base>..HEAD`）：

- 空 worktree：HEAD==本地 base tip → own=0 → 不判合入 ✅
- 真被 FF 合入：远端 main 前进但本地 base 不 pull，HEAD 仍领先本地 base → own>0，S1 照常翻绿 ✅
- 本地 base ref 不存在（base 仅在远端）：退回旧行为不抑制，避免误伤 ✅

新增回归测试 `empty worktree must NOT be merged`（反证过：去掉 guard 即报 `MergedInto:main MergedKind:ancestry`）。

## 2. 详情页三桶判据对齐后端概览（frontend）

外层项目卡片 `Cleanable` 判据是 `MergedInto!="" && !dirty`（不看 committedAhead），详情页 `cleanable` 却多要求 `committedAhead > 0`。结果 S1 祖先(FF)合入、`committedAhead==0` 的孤儿 worktree：外层计入「✓N 可清理」，进详情却落进「干净」桶、丢了已合入徽标，内外对不上。

修复：详情页 `cleanable` 去掉 `committedAhead>0` 限制与后端对齐；`clean` 桶补 `!mergedInto` 排除，保持三桶互斥全覆盖。

## 验证

`TestMergedDetection`（S1/S2/S3 + 未合并翻回）全过，`go build ./...` 通过，前端 i18n(1142 keys)/typecheck 质量门通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)