### PR TITLE
fix(worktree): 详情页「可清理」判据对齐后端概览

### DIFF
--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -636,9 +636,12 @@ function ProjectHome({ proj, loaded, openTerm, refresh }: {
   // 三桶（10 §5）：已合入·待清理（绿，零损失一键清）/ 真·未合并（黄，三选一决策，
   // 含「已合入但有未提交改动」）/ 干净（老 ⇥ 语义，ahead=0）
   const wtDirty = (w: any) => w.dirty > 0 || w.untracked > 0
-  const cleanable = orphans.filter((w: any) => w.mergedInto && w.committedAhead > 0 && !wtDirty(w))
+  // 判据与后端概览 (api/project.go) 对齐：cleanable = 已合入 ∧ 无未提交改动，不看
+  // committedAhead——S1 祖先(FF)合入 committedAhead==0 也算零损失可清，否则外层「可清理」
+  // 计数与详情页对不上（详情把它落进「干净」桶、丢了已合入徽标）。
+  const cleanable = orphans.filter((w: any) => w.mergedInto && !wtDirty(w))
   const unfinished = orphans.filter((w: any) => (w.committedAhead > 0 || wtDirty(w)) && !(w.mergedInto && !wtDirty(w)))
-  const clean = orphans.filter((w: any) => !(w.committedAhead > 0 || wtDirty(w)))
+  const clean = orphans.filter((w: any) => !w.mergedInto && !(w.committedAhead > 0 || wtDirty(w)))
   const wtOf = (s: any) => wts.find((w: any) => w.path === ann[s.name]?.primary?.worktree)
 
   // composer 提交：与 NewSessionModal 完全同款的派生/编排/命名约定（W1 修订 2/3/4）


### PR DESCRIPTION
紧接 #101（空 worktree 秒判已合入）的后续：修内外展示不一致。

## 问题

外层项目概览卡片的 `Cleanable` 计数判据是 `MergedInto!="" && !dirty`（`backend/api/project.go`，不看 committedAhead），但项目详情页的「可清理」桶（`frontend/src/Projects.tsx`）却多要求 `committedAhead > 0`。

结果一个 **S1 祖先(FF)合入、committedAhead==0** 的孤儿 worktree：
- 外层卡片计入「✓N 可清理」
- 进详情却落进「干净」桶、**丢了已合入徽标**

内外对不上。（S2 squash 合入 committedAhead>0，两层一致，故平时不易察觉。）

## 修复

详情页 `cleanable` 去掉 `committedAhead>0` 限制，与后端对齐为 `mergedInto && !dirty`；`clean` 桶补 `!mergedInto` 排除，保持三桶（cleanable/unfinished/clean）互斥全覆盖。`cleanable` 段渲染本就不假设 committedAhead>0，FF 合入项照常显示已合入 + 一键清。

## 验证

前端 typecheck + i18n(1142 keys) 质量门通过；后端未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)