### PR TITLE
refactor(worktree): 合入判定改横向可扩展信号链 + 分叉点守空

### DIFF
--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -370,6 +370,44 @@ func (s *Service) ensureExclude(repo Repo) {
 	_, _ = f.WriteString(line + "\n")
 }
 
+// ── 合入信号链（10 设计 §4）─────────────────────────────────
+
+// mergeSignal 判定 worktree 是否已并入 target；命中返回 (kind, true)，否则 (_, false)。
+// 允许读/标注 w（如 S2 顺手记 AheadUnique）。约定：调用前已确保 ownWork（worktree 真
+// 离开分叉点），故各判据只管「HEAD 是否已进 target」，无需再自防空 worktree。
+type mergeSignal func(ctx context.Context, w *Worktree, target string) (kind string, merged bool)
+
+// mergeSignals 合入判据链，顺序即优先级——命中即止。横向可扩展：加新判据（如
+// note-based、PR 号回填、reflog 溯源…）只需往本表追加一项，List 主流程零改动。
+var mergeSignals = []mergeSignal{
+	// S1 祖先：merge commit / ff / rebase 后 ff——HEAD 已是 target 的祖先。
+	func(ctx context.Context, w *Worktree, target string) (string, bool) {
+		if _, e := git(ctx, w.Path, "merge-base", "--is-ancestor", "HEAD", target); e == nil {
+			return "ancestry", true
+		}
+		return "", false
+	},
+	// S2 补丁等价：squash/逐提交 rebase 后，任务分支提交按 patch-id 全被 target 覆盖
+	// （cherry 全 `-`）。出现 `+` 即有真领先，宁可漏判不错判。
+	func(ctx context.Context, w *Worktree, target string) (string, bool) {
+		if w.CommittedAhead <= 0 {
+			return "", false
+		}
+		out, e := git(ctx, w.Path, "cherry", target, "HEAD")
+		if e != nil {
+			return "", false
+		}
+		plus := 0
+		for _, l := range strings.Split(out, "\n") {
+			if strings.HasPrefix(l, "+ ") {
+				plus++
+			}
+		}
+		w.AheadUnique = plus
+		return "squash", plus == 0 && strings.TrimSpace(out) != ""
+	},
+}
+
 // ── List ─────────────────────────────────────────────────
 
 // List 解析 porcelain 清单并补状态；带 3s 缓存。无任何写副作用。
@@ -463,38 +501,20 @@ func (s *Service) List(ctx context.Context, dir string) ([]Worktree, error) {
 					w.CommittedAhead, _ = strconv.Atoi(parts[1])
 				}
 			}
-			// 空 worktree 兜底：新开对话建的 worktree HEAD==本地 base tip，本身就是
-			// target 的祖先，S1 会把它秒判「已合入」。要求相对本地 base 分支确有独占
-			// 提交（真做过事）才进入合入判定；HEAD 一旦被合进 target，本地 base 不 pull
-			// 就还落后 HEAD，own>0 依旧成立（S1 test 的「本地 main 不动」正是此路）。
-			// 本地 base ref 不存在（base 仅在远端）时无从判断，退回旧行为不做抑制。
-			ownWork := true
-			if _, e := git(ctx, w.Path, "rev-parse", "--verify", "-q", "refs/heads/"+w.Base); e == nil {
-				ownWork = false
-				if cnt, e := git(ctx, w.Path, "rev-list", "--count", w.Base+"..HEAD"); e == nil {
-					if n, _ := strconv.Atoi(strings.TrimSpace(cnt)); n > 0 {
-						ownWork = true
-					}
-				}
+			// 合入判定：横向可扩展的信号链（mergeSignals），命中即定 kind、靠前优先。
+			// 统一前置 ownWork——worktree 必须真离开建时分叉点(StartOid)才算干过活；否则
+			// 新开的空 worktree HEAD==分叉点，天然是 target 的祖先，S1 会把它秒判「已合入」。
+			// StartOid 建时锁定、不随本地 base 分支移动/删除而失真，比对本地 base ref 更稳；
+			// 老 worktree 无 StartOid 时退回「相对 target 有领先提交」兜底（空 worktree=0 不判）。
+			ownWork := w.Head != w.StartOid
+			if w.StartOid == "" {
+				ownWork = w.CommittedAhead > 0
 			}
-			// S1 祖先：merge commit / ff / rebase 后 ff 都命中
 			if ownWork {
-				if _, e := git(ctx, w.Path, "merge-base", "--is-ancestor", "HEAD", target); e == nil {
-					w.MergedInto, w.MergedKind = target, "ancestry"
-				} else if w.CommittedAhead > 0 {
-					// S2 补丁等价：squash/逐提交 rebase 后，任务分支提交按 patch-id 全部
-					// 被 target 覆盖（cherry 全 `-`）。出现 `+` 即有真领先，宁可漏判不错判。
-					if out, e := git(ctx, w.Path, "cherry", target, "HEAD"); e == nil {
-						plus := 0
-						for _, l := range strings.Split(out, "\n") {
-							if strings.HasPrefix(l, "+ ") {
-								plus++
-							}
-						}
-						w.AheadUnique = plus
-						if plus == 0 && strings.TrimSpace(out) != "" {
-							w.MergedInto, w.MergedKind = target, "squash"
-						}
+				for _, sig := range mergeSignals {
+					if kind, ok := sig(ctx, w, target); ok {
+						w.MergedInto, w.MergedKind = target, kind
+						break
 					}
 				}
 			}

--- a/backend/worktree/service_test.go
+++ b/backend/worktree/service_test.go
@@ -427,6 +427,54 @@ func TestMergedDetection(t *testing.T) {
 	}
 }
 
+// 分叉点(StartOid)守空 worktree：base 仅在远端、本地无 refs/heads/<base> 时，旧
+// 「相对本地 base 有无独占提交」的兜底判据会退化成放行——空 worktree HEAD==远端 base
+// tip，又是 origin/<base> 的祖先，S1 秒判「已合入」。改用 Head==StartOid 判 ownWork
+// 后与本地 base ref 是否存在无关，空 worktree 恒不合入。
+func TestMergedEmptyWorktreeRemoteOnlyBase(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	repo := mkRepo(t)
+	gitIn := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(scrubGitEnv(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	gitIn(repo, "clone", "--bare", repo, origin)
+	gitIn(repo, "remote", "add", "origin", origin)
+	// base 分支只留在远端：本地建 relbase→推送→删本地，制造「无 refs/heads/relbase」
+	gitIn(repo, "branch", "relbase")
+	gitIn(repo, "push", "-q", "origin", "relbase")
+	gitIn(repo, "branch", "-D", "relbase")
+
+	// 从远端 relbase 建空 worktree（Remote 走 fetch 锁 OID），一行未改
+	wt, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/rel", Base: "relbase", Remote: "origin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.invalidate(Repo{CommonDir: canonical(filepath.Join(repo, ".git"))})
+	list, err := s.List(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range list {
+		if w.Path == wt.Path {
+			if w.MergedInto != "" {
+				t.Fatalf("empty worktree on remote-only base must NOT be merged, got %+v", w)
+			}
+			return
+		}
+	}
+	t.Fatalf("worktree %s not in list", wt.Path)
+}
+
 // 半删残缺态自愈（10 §7 实测）：git 删工作树半路失败会留下 gitfile 已删、注册表
 // 还在的卡死状态——Remove(force) 应能从父目录解析仓库并 RemoveAll+prune 收干净。
 func TestRemoveHalfDeadWorktree(t *testing.T) {


### PR DESCRIPTION
#101 修了空 worktree 秒判已合入，但仍可能复现——本 PR 把判定机制做成横向可扩展，并用分叉点(StartOid)彻底堵住误判。

## 仍复现的场景

#101 的 `ownWork` 用「相对**本地** base 分支有无独占提交」判 worktree 是否干过活。可一旦本地没有 `refs/heads/<base>`（base 只存在于远端），这个判据退化成**放行**：空 worktree HEAD==远端 base tip，又是 `origin/<base>` 的祖先 → S1 `merge-base --is-ancestor` 命中 → 秒判「已合入」。这正是「会话明明没合入却显示已合入」仍会出现的原因之一。

## 改法

**1. 横向可扩展的信号链**（回应「这一块要搞一个横向可扩展的机制」）

把原本内联在 `List` 里的 S1/S2 if-else 抽成判据表：

```go
type mergeSignal func(ctx, w *Worktree, target string) (kind string, merged bool)
var mergeSignals = []mergeSignal{ S1祖先, S2补丁等价 }  // 顺序即优先级，命中即止
```

以后加新判据（git notes 回填、PR 号溯源、reflog 追踪…）只需往 `mergeSignals` 追加一项，`List` 主流程零改动。

**2. ownWork 改用分叉点 StartOid**

worktree 建时把分叉 commit 写进 `roam.startoid`（immutable）。改判 `Head != StartOid`：

- 空 worktree：HEAD==StartOid → 没干过活 → 不进判定 ✅
- 与本地 base ref 是否存在、是否移动**完全无关**，堵住上面的远端-only base 漏洞 ✅
- 无 StartOid 的老 worktree 退回 `CommittedAhead>0` 兜底（空 worktree=0 仍不判）✅

## 验证

- 新增 `TestMergedEmptyWorktreeRemoteOnlyBase`：base 仅在远端时空 worktree 恒不合入。反证过：退回旧兜底即误报 `MergedInto:origin/relbase MergedKind:ancestry`（`Head==StartOid`）。
- `TestMergedDetection`（S1/S2/S3 + 未合并翻回）全过，`go build ./...`、前端质量门通过。

## 部署提醒

⚠️ 合并本 PR 到仓库 ≠ 线上生效。这是 Go 后端改动，运行中的实例仍是旧二进制——需在主仓库 `go build` + `start.sh` 重启后才会消除误判。若你现在还看到误判，很可能就是实例尚未重建。

与 #102（前端「可清理」判据对齐）互不依赖，可分别合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)