### PR TITLE
fix(project): 项目页删会话不关 tab——补 closeTerm 一起清终端标签

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -422,7 +422,7 @@ export default function App() {
   const pages: any = {
     overview: <OverviewPage openTerm={openTerm} />,
     swarm: <Swarm openTerm={openTerm} initialSwarm={swarmSub || undefined} onNav={(n) => { location.hash = n ? '#/swarm/' + encodeURIComponent(n) : '#/swarm' }} />,
-    projects: <Projects openTerm={openTerm} initialKey={projectSub || undefined} />,
+    projects: <Projects openTerm={openTerm} closeTerm={closeTerm} initialKey={projectSub || undefined} />,
     sessions: <Sessions openTerm={openTerm} closeTerm={closeTerm} activeTerm={active} />,
     files: <FilesPage openTerm={openTerm} />,
     settings: <EnvPage />,

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -136,7 +136,7 @@ export function Lifec({ done, cur }: { done: number; cur?: number }) {
   )
 }
 
-export default function Projects({ openTerm, initialKey }: { openTerm: (n: string) => void; initialKey?: string }) {
+export default function Projects({ openTerm, closeTerm, initialKey }: { openTerm: (n: string) => void; closeTerm: (n: string) => void; initialKey?: string }) {
   const [data, setData] = useState<{ projects: Proj[]; loose: ProjSession[] }>({ projects: [], loose: [] })
   const [loaded, setLoaded] = useState(false)
   const load = () => api('GET', '/projects').then((r) => {
@@ -149,7 +149,7 @@ export default function Projects({ openTerm, initialKey }: { openTerm: (n: strin
     <>
       <style>{PRJ_CSS}</style>
       {initialKey
-        ? <ProjectHome proj={data.projects.find((x) => x.key === initialKey)} loaded={loaded} openTerm={openTerm} refresh={load} />
+        ? <ProjectHome proj={data.projects.find((x) => x.key === initialKey)} loaded={loaded} openTerm={openTerm} closeTerm={closeTerm} refresh={load} />
         : <ProjectList data={data} loaded={loaded} openTerm={openTerm} refresh={load} />}
     </>
   )
@@ -429,8 +429,8 @@ function tailLine(raw: string): string {
 }
 
 // ── P2 项目主页：头部 + composer(hero) + 任务流/Worktree/编队/活动 ──
-function ProjectHome({ proj, loaded, openTerm, refresh }: {
-  proj?: Proj; loaded: boolean; openTerm: (n: string) => void; refresh: () => void
+function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
+  proj?: Proj; loaded: boolean; openTerm: (n: string) => void; closeTerm: (n: string) => void; refresh: () => void
 }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
@@ -710,7 +710,7 @@ function ProjectHome({ proj, loaded, openTerm, refresh }: {
     if (!st?.inWorktree || st.external) {
       Modal.confirm({
         title: t('project.killConfirm', { name: n }),
-        onOk: async () => { try { await api('DELETE', '/sessions/' + encodeURIComponent(n)); message.success(t('session.closed')); refresh() } catch (e: any) { message.error(e.message) } },
+        onOk: async () => { try { await api('DELETE', '/sessions/' + encodeURIComponent(n)); message.success(t('session.closed')); closeTerm(n); refresh() } catch (e: any) { message.error(e.message) } },
       })
       return
     }
@@ -1196,7 +1196,7 @@ function ProjectHome({ proj, loaded, openTerm, refresh }: {
         <NewSessionModal open={fullForm || !!forking} parent={forking}
           onClose={() => { setFullForm(false); setForking(null) }}
           onDone={(n) => { openTerm(n); refresh() }} />
-        <CloseWorktreeModal info={closing} onClose={() => setClosing(null)} onDone={() => { setClosing(null); refresh() }} />
+        <CloseWorktreeModal info={closing} onClose={() => setClosing(null)} onDone={(name) => { closeTerm(name); setClosing(null); refresh() }} />
         <FinishModal w={finishing} base={defBranch} onClose={() => setFinishing(null)}
           onDone={() => { setFinishing(null); refresh() }} onRevive={(w) => newCli(w, 'shell')} />
         {/* 给指挥发话 = 广场署名 human 发言（08 §3），编排动作仍去蜂群台 */}


### PR DESCRIPTION
## 问题
删会话时终端 tab 没跟着清掉。

- **Sessions 页**（`App.tsx` 的 `kill`/`closeWith`）删完会话早就调了 `closeTerm(n)` 收 tab —— 正常。
- **Projects 项目主页**（`Projects.tsx` 的 `beginClose`）漏了：它没拿到 `closeTerm`，两条删会话路径删完只 `refresh()`，被删会话的终端标签会残留在 tabStrip 里。

## 修法
把 `closeTerm` 从 `App` 一路透传进 `Projects → ProjectHome`，两条删会话路径都补上：

| 路径 | 触发 | 改动 |
|---|---|---|
| 普通关闭 | `Modal.confirm` → `DELETE /sessions` | 删完加 `closeTerm(n)` |
| worktree 收尾 | `CloseWorktreeModal` 的 `onDone` | `onDone={(name) => { closeTerm(name); … }}`（`onDone` 本就回传会话名，与 Sessions 页用法一致） |

3 处 prop 透传 + 2 处删会话逻辑，共 6 行，照抄现有 Sessions 页写法。无新增 UI 文案。

## 验证
- `tsc --noEmit` 通过
- pre-commit 质量门全绿：Go 测试、i18n audit（1142 keys）、typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)