### PR TITLE
fix(session): 改名后子会话变孤儿——rename 两条路径漏同步 meta parent

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -144,7 +144,9 @@ func (a *API) RenameSession(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"data": gin.H{"name": newName}})
 		return
 	}
-	out, err := a.TT.Run("rename-session", "-t", oldName, newName)
+	// 走 ttmux rename（而非裸 rename-session 透传到 tmux）：改名后 CLI 内
+	// 会同步 meta parent 外键，子会话才不会被 Reconcile 当孤儿收养。
+	out, err := a.TT.Run("rename", oldName, newName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
 		return

--- a/cli/ttmux-cli-go/internal/app/app.go
+++ b/cli/ttmux-cli-go/internal/app/app.go
@@ -91,11 +91,12 @@ func (a App) Run(args []string) error {
 	case "killall":
 		return session.KillAll(a.rt, a.swarmSessions(), out)
 	case "rename":
-		if err := session.Rename(a.rt, a.swarmSessions(), rest, out); err != nil {
+		old, neu, err := session.Rename(a.rt, a.swarmSessions(), rest, out)
+		if err != nil {
 			return err
 		}
-		if len(rest) >= 2 { // 显式双参改名成功后同步 meta 外键
-			_ = a.meta().OnRename(rest[0], rest[1])
+		if old != "" && neu != "" { // 改名成功后同步 meta 外键（含交互式选名）
+			_ = a.meta().OnRename(old, neu)
 		}
 		return nil
 	case "send":

--- a/cli/ttmux-cli-go/internal/command/session/commands.go
+++ b/cli/ttmux-cli-go/internal/command/session/commands.go
@@ -183,8 +183,10 @@ func KillAll(rt runtime.Runtime, exclude map[string]bool, w io.Writer) error {
 	return nil
 }
 
-// Rename renames a session (mirrors the `rename` case).
-func Rename(rt runtime.Runtime, exclude map[string]bool, args []string, w io.Writer) error {
+// Rename renames a session (mirrors the `rename` case). 返回解析后的
+// (旧名, 新名) 供调用方同步 meta parent 外键——交互式改名时 args 不含名字，
+// 必须靠返回值而非 args 来同步，否则子会话会被 Reconcile 当孤儿收养。
+func Rename(rt runtime.Runtime, exclude map[string]bool, args []string, w io.Writer) (string, string, error) {
 	var old, neu string
 	switch {
 	case len(args) >= 2:
@@ -195,22 +197,22 @@ func Rename(rt runtime.Runtime, exclude map[string]bool, args []string, w io.Wri
 		} else {
 			t, err := PickSession(rt, exclude, "重命名会话", w)
 			if err != nil {
-				return err
+				return "", "", err
 			}
 			old = t
 		}
 		n, ok := ui.ReadLine("   新名称: ")
 		if !ok || n == "" {
 			ui.Err(w, "名称不能为空")
-			return fmt.Errorf("empty name")
+			return "", "", fmt.Errorf("empty name")
 		}
 		neu = n
 	}
 	if err := rt.Tmux("rename-session", "-t", old, neu); err != nil {
-		return err
+		return "", "", err
 	}
 	ui.Ok(w, "%s → %s", ui.Bold(old), ui.Bold(neu))
-	return nil
+	return old, neu, nil
 }
 
 // Send sends a command line to a session (mirrors the top-level `send` case).


### PR DESCRIPTION
## 问题

会话（如 `session`）改名后，其 `fork` 出来的子会话丢失 parent 关系，变成独立的根节点，不再挂在原会话下。

## 根因

改名没同步 `meta.db` 里的 `parent` 外键，紧接着任意一次 `Reconcile()`（`ls --tree`/`children` 等触发）就把旧名当成死会话，执行 `UPDATE sessions SET parent=NULL WHERE parent=<旧名>`，把全部子会话「孤儿收养」成根。两条漏同步的路径：

1. **CLI 交互式改名** — `app.go` 仅在 `len(rest)>=2`（显式 `ttmux rename <old> <new>`）时才调 `OnRename`；走 picker 或单参 `/dev/tty` 提示输入新名时 `rest` 不含名字，同步被跳过。
2. **Web / 后端** — `RenameSession` 调 `ttmux rename-session`，它不是 ttmux 子命令，落进 `default` 分支裸透传到 tmux，完全绕过 `OnRename`（大概率是实际触发路径）。

## 改动

- `session.Rename` 返回解析后的 `(old, neu)`，`app.go` 只要两者非空就同步 `OnRename`（覆盖交互式选名）。
- 后端 `RenameSession` 改走 `ttmux rename <old> <new>`，经 CLI 内部同步 meta。

## 验证（隔离 tmux socket + 临时 home）

- 双参路径：`kid` 的 parent `parent → boss` ✓
- 交互式 `/dev/tty` 路径（原本坏掉的那条，用 pty 驱动）：`kid` 的 parent `parent → boss` ✓
- `go test ./...` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)