### PR TITLE
fix(project): 非 git 项目详情页补全会话——按 cwd 前缀认领而非只取 top2

### DIFF
--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -567,8 +567,13 @@ function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
   const mine = useMemo(() => {
     if (!dir) return []
     if (isGit) return sessions.filter((s) => ann[s.name]?.primary?.repo === dir)
-    return sessions.filter((s) => (proj?.top || []).some((x) => x.name === s.name))
-  }, [sessions, ann, dir, isGit, proj])
+    // 非 git 项目：按 pane cwd 目录前缀认领（对齐后端 project.go 的两阶段归属），
+    // 而不是只取 P1 卡片的 top(≤2)——否则该项目的第 3+ 个会话在详情页永远不出现。
+    // 已被某 git 仓库认领的会话(annotation 有 primary.repo)排除，避免嵌套 git 子项目
+    // 的会话重复挂到非 git 父目录下。
+    const under = (c: string) => !!c && (c === dir || c.startsWith(dir + '/'))
+    return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(s.cwd))
+  }, [sessions, ann, dir, isGit])
   // 蜂群归属（08 §2.2）：swarm ls 无 dir 字段——按「指挥/成员会话 ∈ 本项目会话」现算
   const mineKey = useMemo(() => mine.map((s) => s.name).sort().join('\n'), [mine])
   useEffect(() => {


### PR DESCRIPTION
## 问题

某些会话「在列表里展示不出来」——具体是**项目详情页(P2)**下会话缺失。

排查发现减号开头的会话名（如 `-ssh-root@192`）后端全程正常（`ls`/`capture`/`cwd`/`worktree-status` 都对，会话列表页也正常渲染）。真正的 bug 在项目详情页：cwd 落在非 git 目录（如 `/home/ai/codes`）下的会话被归到「非 git 项目」，而 `ProjectHome` 的 `mine` 计算里**非 git 分支只取了 P1 卡片的 `proj.top`（最多 2 个活跃会话）**：

- 该目录下第 3+ 个会话在详情页永远不出现；
- `top` 按活跃度动态选，谁掉出 top-2 谁就从列表消失 → 表现为「时有时无」。

后端 `project.go` 本身是两阶段归属（git 按 worktree annotation，非 git 按 pane cwd 目录前缀），前端非 git 分支没对齐。

## 改动

`frontend/src/Projects.tsx` `ProjectHome.mine`：非 git 分支改为对齐后端——按 pane cwd 目录前缀认领，并排除已被某 git 子仓库认领（annotation 有 `primary.repo`）的会话，避免嵌套 git 子项目的会话重复挂到非 git 父目录下。git 分支（`ann.primary.repo === dir`）本就与后端一致，未动。

## 验证

- `tsc --noEmit` / `npm run build` / 后端 `go test` 全过（pre-commit 质量门通过）。
- 线上热部署后经已登录浏览器实测：
  - 修复前 `codes` 详情页只有 2 个会话；修复后 3 个全出（补回此前被隐藏的会话）。
  - `ttmux` 详情页（git 项目）仍只显示自己的 worktree 会话，未被非 git 父目录会话污染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
