### PR TITLE
feat(project): 「开干」需求框支持传图片（Ctrl+V 粘贴/📎 选图）

### DIFF
--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -7,9 +7,9 @@
 // 视觉基调：终端工业风的克制精修——居中 880px 阅读列、composer 是全页唯一 hero
 // （渐变卡面 + focus 辉光环）、git 数据一律等宽字、行 hover 左导轨渐显、
 // 分区头沿用设计图纸体例、入场一次性 stagger。全部颜色走 index.css token。
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { App as AntApp, AutoComplete, Button, Input, Modal, Popconfirm, Segmented, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd'
-import { api } from './api'
+import { api, upload, makeClipboardImageFile } from './api'
 import { useI18n } from './i18n'
 import { usePreferences } from './preferences'
 import { detectPrompt } from './prompt'
@@ -458,6 +458,8 @@ function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [peeks, setPeeks] = useState<Record<string, string>>({})
   const [creating, setCreating] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
   const [wtOpen, setWtOpen] = useState(false)
   const [gitOpen, setGitOpen] = useState(false)
   const [fullForm, setFullForm] = useState(false)
@@ -652,6 +654,29 @@ function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
   const unfinished = orphans.filter((w: any) => (w.committedAhead > 0 || wtDirty(w)) && !(w.mergedInto && !wtDirty(w)))
   const clean = orphans.filter((w: any) => !w.mergedInto && !(w.committedAhead > 0 || wtDirty(w)))
   const wtOf = (s: any) => wts.find((w: any) => w.path === ann[s.name]?.primary?.worktree)
+
+  // 图片上传到 /tmp 并把绝对路径插进需求框：开干时路径会随命令传给 agent，模型按绝对路径读图（同对话页 Ctrl+V）
+  const uploadImages = async (images: File[]) => {
+    if (!images.length || uploading) return
+    setUploading(true)
+    try {
+      const res = await upload('/tmp', images)
+      setPrompt((v) => (v ? v.replace(/\s*$/, ' ') : '') + res.saved.join(' ') + ' ')
+      message.success(t('chat.uploadedFiles', { count: images.length, dir: '/tmp' }))
+    } catch (e: any) { message.error(t('chat.uploadFailed', { message: e.message })) }
+    finally { setUploading(false) }
+  }
+
+  // Ctrl+V 粘贴图片：一次只取一张（同张截图常以多种 MIME 重复出现，全收会插入两次）
+  const onPasteComposer = (e: React.ClipboardEvent) => {
+    if (!e.clipboardData?.items) return
+    for (const item of Array.from(e.clipboardData.items)) {
+      if (item.type.startsWith('image/')) {
+        const f = item.getAsFile()
+        if (f) { e.preventDefault(); uploadImages([makeClipboardImageFile(f, item.type, 0)]); return }
+      }
+    }
+  }
 
   // composer 提交：与 NewSessionModal 完全同款的派生/编排/命名约定（W1 修订 2/3/4）
   const goCreate = async () => {
@@ -866,8 +891,12 @@ function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
         <div className="prj-composer prj-in" style={{ animationDelay: '60ms' }}>
           <Input.TextArea value={prompt} onChange={(e) => setPrompt(e.target.value)}
             placeholder={isGit ? t('project.composerPlaceholder') : t('project.composerPlain')} autoSize={{ minRows: 2, maxRows: 6 }} variant="borderless"
+            onPaste={onPasteComposer}
             onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) { e.preventDefault(); goCreate() } }} />
+          <input ref={fileRef} type="file" accept="image/*" multiple style={{ display: 'none' }}
+            onChange={(e) => { const fs = e.target.files ? Array.from(e.target.files) : []; e.target.value = ''; if (fs.length) uploadImages(fs) }} />
           <div className="prj-cbar">
+            <Button size="small" type="text" title={t('project.attachImage')} loading={uploading} onClick={() => fileRef.current?.click()} style={{ padding: '0 4px' }}>📎</Button>
             {isGit && (<>
               <span className={`prj-pill cyan${wtMode === 'new' ? ' on' : ''}`} onClick={() => setWtMode('new')}>⎇ {t('project.where.new')}</span>
               <span className={`prj-pill${wtMode === 'repo' ? ' on' : ''}`} onClick={() => setWtMode('repo')}>{t('project.where.repo')}</span>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1149,6 +1149,7 @@ const enUS = {
   'project.removeConfirm': 'Remove this project from the list? Directory, worktrees and sessions are untouched',
   'project.composerPlain': 'Describe a task and press Enter — opens a session in the project directory',
   'project.autoName': 'Name auto-derived',
+  'project.attachImage': 'Paste or pick an image (Ctrl+V works)',
   'project.basedOn': 'Based on {base}',
   'project.tab.race': 'Formations',
   'project.tab.activity': 'Activity',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1149,6 +1149,7 @@ const zhCN = {
   'project.removeConfirm': '从列表移除该项目？不动目录、worktree 与会话',
   'project.composerPlain': '描述任务，回车开干 —— 在项目目录里开一个会话',
   'project.autoName': '名称自动派生',
+  'project.attachImage': '粘贴或选图片（Ctrl+V 直接贴）',
   'project.basedOn': '基于 {base}',
   'project.tab.race': '编队',
   'project.tab.activity': '活动',


### PR DESCRIPTION
## 背景

项目详情页最上面的「开干」需求框此前只能输文字。这次让它支持传图片，最常用的就是 Ctrl+V 直接粘一张截图。

## 改动

- **Ctrl+V 粘贴图片**：`Input.TextArea` 加 `onPaste`，检测到剪贴板图片就上传到 `/tmp`，把返回的绝对路径追加进需求文本。一次只取一张（同张截图常带多种 MIME，全收会插两遍）。
- **📎 选图按钮**：工具栏加一个 📎 + 隐藏 `<input type=file accept=image/*>`，给手机端（没 Ctrl+V）和不知道能粘贴的用户一个显式入口。
- 复用 `api.ts` 已有的 `upload()` / `makeClipboardImageFile()`，带 loading 态和成功/失败 toast。
- 新增 i18n 文案 `project.attachImage`（中英）。

## 为什么插绝对路径就够

开干时 `goCreate` 把整段需求 `shq` 引用后拼进 `claude/codex …` 命令发给会话，图片路径随命令一起进 agent，模型按绝对路径直接读图——和对话页 ChatShell 的 Ctrl+V 完全一致的机制。图片落 `/tmp` 不污染项目工作目录。

## 验证

- `npm run typecheck` ✅
- `npm run build` ✅（i18n audit 1217 keys 通过）
- pre-commit 质量门（Go 测试 + 前端检查 + 密钥扫描）全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)