### PR TITLE
fix(phone): 切来源清空地址——从本地 redroid 切「真机」不再带走 localhost:5555

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2476,7 +2476,9 @@ function PhoneSettingsCard() {
       ? [{ label: t('phone.mode.local'), value: 'local' }, { label: t('phone.mode.remote'), value: 'remote' }, { label: t('phone.mode.device'), value: 'device' }]
       : [{ label: t('phone.ios.simulator'), value: 'simulator' }, { label: t('phone.ios.device'), value: 'device' }]
     const opts = (devs[p] || []).map((d: any) => ({ value: d.id, label: `${d.name} (${d.id})${d.kind && d.kind !== 'android' ? ' · ' + d.kind : ''}` }))
-    const changeSrc = (m: string) => patch(p, isA && m === 'local' ? { mode: m, address: 'localhost:5555' } : { mode: m })
+    // 切来源要连地址一起换：每种来源的目标地址各自独立(本地 redroid=loopback / 远程=待填 / 真机=默认设备)。
+    // 否则从「本地 redroid」切到「真机」会把 localhost:5555 带过去，adb 一直连不存在的 loopback，真机被忽略→连不上。
+    const changeSrc = (m: string) => patch(p, isA ? { mode: m, address: m === 'local' ? 'localhost:5555' : '' } : { mode: m, address: '' })
     return (
       <Card size="small" title={
         <Space align="center">


### PR DESCRIPTION
## 问题

设置页手机连接：从「本地 redroid」切到「真机」后连不上手机，来回切也恢复不了。

现场配置自相矛盾：
```json
"android": { "mode": "device", "address": "localhost:5555" }
```
mode 是 **真机(device)**，address 却还是 **本地 redroid** 的 loopback。于是后端把所有 `adb` 命令 `-s localhost:5555` scope 到一个不存在的设备、`Ensure` 里还反复 `adb connect localhost:5555`，而真正插着 USB 的真机（Redmi Note 8）被完全忽略 → 「连不上手机」。

## 根因

`PhoneSettingsCard` 的 `changeSrc` 切换来源(Segmented)时，**只有**切到「本地 redroid」会重置地址；切到「真机」/「远程」把上一来源的地址原样带过去。所以在「本地 redroid」和「真机」之间来回切，`localhost:5555` 一直粘着，真机永远被 scope 掉。

## 修复

`changeSrc` 改为切来源即换目标地址，各来源地址互相独立：
- 本地 redroid → `localhost:5555`
- 远程 redroid → 空（待填 host:port）
- 真机 → 空（用默认单设备，或从下拉选 serial）
- iOS 切 模拟器/真机 → 清 UDID

一行改动，无后端改动。

## 验证

- `npm run typecheck` / i18n 审计 / Go 测试全过（pre-commit 全绿）。
- 手动核对：真机模式下 address 置空后 `adb get-state` = `device`，能正常连到实机（Redmi Note 8, booted）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)