### PR TITLE
fix(project): 嵌套非 git 项目任务数外层 0 里层 1——认领改最长前缀去随机漂移

### DIFF
--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -229,28 +229,36 @@ func (a *API) ProjectsList(c *gin.Context) {
 		finish(&p, top)
 	}
 
-	// 非 git 项目：pane cwd 目录前缀认领未归属会话
-	for _, ng := range nonGit {
+	// 非 git 项目：pane cwd 目录前缀认领未归属会话。同一会话归**最深(最长前缀)**
+	// 的非 git 项目——嵌套目录(父/子都是非 git 项目，如 /codes 与 /codes/tmp)不能按
+	// map 迭代序抢占，否则父项目先跑就把子目录会话抢走，计数在父/子间随机漂移
+	// （详情页各按自身 dir 认领无此去重，于是子项目外层 0、里层 1）。对齐 worktree
+	// joinSessions 的「最长前缀命中」口径。
+	if len(nonGit) > 0 {
 		if cwds == nil {
 			cwds = a.WT.SessionCwds(ctx)
 		}
-		var top []projectSession
+		tops := make([][]projectSession, len(nonGit))
 		for _, s := range sessions {
 			if claimed[s.Name] {
 				continue
 			}
-			under := false
-			for _, c := range cwds[s.Name] {
-				if c == ng.e.Dir || strings.HasPrefix(c, ng.e.Dir+string(filepath.Separator)) {
-					under = true
-					break
+			best, bestLen := -1, -1
+			for i, ng := range nonGit {
+				for _, c := range cwds[s.Name] {
+					if (c == ng.e.Dir || strings.HasPrefix(c, ng.e.Dir+string(filepath.Separator))) && len(ng.e.Dir) > bestLen {
+						best, bestLen = i, len(ng.e.Dir)
+					}
 				}
 			}
-			if under {
-				addSession(ng.p, &top, s.Name, rawInt(s.Attached) > 0, rawInt(s.LastActivity), "", false)
+			if best >= 0 {
+				ng := nonGit[best]
+				addSession(ng.p, &tops[best], s.Name, rawInt(s.Attached) > 0, rawInt(s.LastActivity), "", false)
 			}
 		}
-		finish(ng.p, top)
+		for i, ng := range nonGit {
+			finish(ng.p, tops[i])
+		}
 	}
 
 	for _, s := range sessions {

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -149,7 +149,7 @@ export default function Projects({ openTerm, closeTerm, initialKey }: { openTerm
     <>
       <style>{PRJ_CSS}</style>
       {initialKey
-        ? <ProjectHome proj={data.projects.find((x) => x.key === initialKey)} loaded={loaded} openTerm={openTerm} closeTerm={closeTerm} refresh={load} />
+        ? <ProjectHome proj={data.projects.find((x) => x.key === initialKey)} allProjects={data.projects} loaded={loaded} openTerm={openTerm} closeTerm={closeTerm} refresh={load} />
         : <ProjectList data={data} loaded={loaded} openTerm={openTerm} refresh={load} />}
     </>
   )
@@ -429,8 +429,8 @@ function tailLine(raw: string): string {
 }
 
 // ── P2 项目主页：头部 + composer(hero) + 任务流/Worktree/编队/活动 ──
-function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
-  proj?: Proj; loaded: boolean; openTerm: (n: string) => void; closeTerm: (n: string) => void; refresh: () => void
+function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }: {
+  proj?: Proj; allProjects: Proj[]; loaded: boolean; openTerm: (n: string) => void; closeTerm: (n: string) => void; refresh: () => void
 }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
@@ -572,8 +572,12 @@ function ProjectHome({ proj, loaded, openTerm, closeTerm, refresh }: {
     // 已被某 git 仓库认领的会话(annotation 有 primary.repo)排除，避免嵌套 git 子项目
     // 的会话重复挂到非 git 父目录下。
     const under = (c: string) => !!c && (c === dir || c.startsWith(dir + '/'))
-    return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(s.cwd))
-  }, [sessions, ann, dir, isGit])
+    // 同一会话归最深(最长前缀)的非 git 项目：排除落在更具体的非 git 兄弟项目里的会话，
+    // 与后端最长前缀口径一致，否则父项目详情页会把子项目会话重复计入（外层少、里层多）。
+    const deeper = allProjects.filter((p) => !p.git && p.dir !== dir && p.dir.startsWith(dir + '/')).map((p) => p.dir)
+    const claimedByDeeper = (c: string) => deeper.some((d) => c === d || c.startsWith(d + '/'))
+    return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(s.cwd) && !claimedByDeeper(s.cwd))
+  }, [sessions, ann, dir, isGit, allProjects])
   // 蜂群归属（08 §2.2）：swarm ls 无 dir 字段——按「指挥/成员会话 ∈ 本项目会话」现算
   const mineKey = useMemo(() => mine.map((s) => s.name).sort().join('\n'), [mine])
   useEffect(() => {


### PR DESCRIPTION
## 问题

嵌套的两个非 git 项目（例：`临时`=`/home/ai/codes/tmp` 落在 `线上问题排查`=`/home/ai/codes` 内），项目列表卡片显示 **0 任务**，进详情页却显示 **1 任务**。

## 根因

`ProjectsList` 给非 git 项目按 pane cwd 前缀认领会话时，遍历的是 `a.Projects.Entries()`（Go map，**每次请求顺序随机**）并用共享 `claimed` 集合先到先得。父/子目录都命中同一会话时，谁先被 map 迭代到谁就抢走 → 外层计数在父/子间**随机漂移**（实测同一实例连续刷新在 0/1 间跳变）。

详情页 `ProjectHome` 各自按本项目 dir 独立认领、无跨项目去重，于是子项目**恒**把该会话算进来 → 外层 0 / 里层 1。

## 修复

同一会话归**最深（最长前缀）**的非 git 项目，对齐 `worktree.joinSessions` 的「最长前缀命中」口径：

- `backend/api/project.go`：对每个未归属会话遍历所有非 git 项目取最长匹配 dir，确定唯一归属（去掉 map 顺序依赖）。
- `frontend/src/Projects.tsx`：详情页排除落在更具体非 git 兄弟项目里的会话，避免父项目详情页重复计入子项目会话。

## 验证

- 后端：编译补丁二进制对当前 tmux 实况连刷 5 次，`临时=1` 稳定不再漂移；父项目 `线上=3`（gateway/supabase/横向可扩展机制），`https` 正确归入更深的 `临时`。
- 前端：`tsc --noEmit` 通过，`vite build` 通过。
- 提交通过仓库 pre-commit 质量门（go test + i18n + typecheck + secret scan）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)