### PR TITLE
fix(phone): 真机脏配置自愈——不再带 redroid 地址/平板分辨率致连不上+物理屏错乱

### DIFF
--- a/backend/phone/android.go
+++ b/backend/phone/android.go
@@ -148,6 +148,11 @@ func (d *androidDevice) Ensure() error {
 		}
 	}
 	d.keepAwake() // 连上即设常亮，镜像不因锁屏黑屏
+	if androidCfg().Mode == "device" {
+		// 真机恒原生：清掉可能残留的 redroid 平板档 override，自愈物理屏尺寸/密度。
+		_, _ = d.shell(6*time.Second, "wm", "size", "reset")
+		_, _ = d.shell(6*time.Second, "wm", "density", "reset")
+	}
 	return nil
 }
 

--- a/backend/phone/config.go
+++ b/backend/phone/config.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -68,6 +69,8 @@ func defaultConfig() Config {
 func InitConfig(dataDir string) {
 	cfgStore.mu.Lock()
 	defer cfgStore.mu.Unlock()
+	// 无论走哪条分支(新结构/旧迁移/默认)，落定前都自愈一遍脏配置。
+	defer func() { cfgStore.cur.Android = sanitizeAndroid(cfgStore.cur.Android) }()
 	cfgStore.cur = defaultConfig()
 	if dataDir == "" {
 		return
@@ -109,6 +112,24 @@ func InitConfig(dataDir string) {
 	}
 }
 
+// sanitizeAndroid 归一化 Android 子配置，消除模式/地址/分辨率互相串档导致的连不上或分辨率错乱。
+// 幂等：加载(InitConfig)与保存(setConfig)都调，脏配置无需任何 UI 操作即自愈。
+//   - 全字段去空白："localhost:5555  " 这类尾随空格会让 adb connect / adb -s 失败。
+//   - 真机(device)：地址必须是 USB serial(无冒号)或空；带 host:port 是 redroid 残留 → 丢弃回落默认设备。
+//   - 真机(device)：不套平板分辨率档(会把物理屏改成怪比例) → 恒原生。
+func sanitizeAndroid(a AndroidCfg) AndroidCfg {
+	a.Mode = strings.TrimSpace(a.Mode)
+	a.Address = strings.TrimSpace(a.Address)
+	a.Resolution = strings.TrimSpace(a.Resolution)
+	if a.Mode == "device" {
+		if strings.Contains(a.Address, ":") {
+			a.Address = ""
+		}
+		a.Resolution = ""
+	}
+	return a
+}
+
 func getConfig() Config {
 	cfgStore.mu.Lock()
 	defer cfgStore.mu.Unlock()
@@ -126,6 +147,7 @@ func setConfig(c Config) {
 	if c.IOS.Mode == "" {
 		c.IOS.Mode = "simulator"
 	}
+	c.Android = sanitizeAndroid(c.Android)
 	cfgStore.mu.Lock()
 	cfgStore.cur = c
 	f := cfgStore.file

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2504,7 +2504,7 @@ function PhoneSettingsCard() {
               <span style={dim}>{isA ? (c.mode === 'remote' ? t('phone.addrHelpRemote') : t('phone.addrHelpDevice')) : t('phone.addrHelpIOS')}</span>
             </Space>
           )}
-          {isA && (
+          {isA && c.mode !== 'device' && (
             <Space direction="vertical" size={4} style={{ width: '100%' }}>
               <span style={dim}>{t('phone.resolution')}</span>
               <Segmented value={c.resolution || 'phone'} onChange={(v) => patch(p, { resolution: (v as string) === 'phone' ? '' : v })}


### PR DESCRIPTION
## 问题

真机(device)模式下手机**连不上**,且**物理屏分辨率错乱**——两个毛病同一个根:redroid 的「地址 + 分辨率档」串档到了真机。

现场脏配置 `phone-config.json`:
```json
"android": { "mode": "device", "address": "localhost:5555  ", "resolution": "tablet" }
```
- `target()` 只要 address 非空就用 → 后端执行 `adb -s "localhost:5555  "`,连一台不存在的 loopback 设备,真正在线的 USB 真机被忽略 → **连不上**。
- 保存时把平板档 `wm size 1200x1920 / wm density 240` 推给了物理真机(原生 1080x2340/440)→ 尺寸、挖孔、比例全乱 → **分辨率错乱**。

根因:切来源没清干净(旧数据)+ 后端对模式/地址/分辨率的一致性零校验。

## 自愈方案(后端兜底,不靠前端)

- **`backend/phone/config.go`** — 新增 `sanitizeAndroid`,加载(`InitConfig`)与保存(`setConfig`)都归一化,幂等:
  - 全字段去空白(`"localhost:5555  "` 这类尾随空格会让 `adb connect`/`adb -s` 失败);
  - 真机丢弃 `host:port` 地址 → 回落默认设备;
  - 真机清空分辨率档。

  → 脏配置**无需任何 UI 操作,进程启动即自愈**。
- **`backend/phone/android.go`** — `Ensure()` 连真机时 `wm size/density reset`,自愈已被改脏的物理屏(每次连接/推流都兜)。
- **`frontend/src/App.tsx`** — 真机模式隐藏分辨率档(平板档只对 redroid 模拟设备开放),从源头堵住串档。

## 验证

- pre-commit 质量门全过:`go test ./...` 全绿(含 `phone` 6.7s)、`tsc --noEmit`、i18n audit(1217 keys)。
- 线上真机已手动 `wm size/density reset` 复原为原生 1080x2340/440。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
