### PR TITLE
feat(cluster): 后端横向扩展数据面（两模式 + yamux 隧道 + Broker 反代）

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -143,6 +143,12 @@ func (a *Auth) verify(tok string) bool {
 // Middleware 校验签名 Cookie；失败返回 401。
 func (a *Auth) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// 来自已认证隧道的进程内请求（云端 Broker 已校验用户会话）直接放行，
+		// 不要求节点本地登录 Cookie。标记走 request context，不可经线缆伪造。见 auth/internal.go。
+		if IsInternal(c.Request) {
+			c.Next()
+			return
+		}
 		tok, err := c.Cookie(CookieName)
 		if err != nil || !a.verify(tok) {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "UNAUTHORIZED"}})

--- a/backend/auth/internal.go
+++ b/backend/auth/internal.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+)
+
+// 隧道内部主体（typed transport principal）。
+//
+// 横向扩展里，浏览器的请求经云端 Broker 校验用户会话后，通过已完成节点认证的隧道
+// 投递到标准节点。节点侧不能再要求浏览器的登录 Cookie（那是 Broker 签发的、节点不认），
+// 但也**绝不能**用某个可由客户端伪造的 HTTP header 来放行——否则公网/局域网都能伪造。
+//
+// 做法：节点在从隧道 Accept 到请求、交给业务 Handler 之前，用 WithInternal 在**进程内**
+// 的 request context 上打一个私有标记。context 值无法经 HTTP 线缆伪造，只有本进程里
+// “已从可信隧道取出该请求”的代码路径才能设置它。Middleware 见到该标记即放行。
+// 见 docs/design/cluster/客户端-服务端横向扩展设计.md §6。
+type internalKey struct{}
+
+// WithInternal 标记该请求来自已认证隧道（仅限进程内调用，不可经线缆伪造）。
+func WithInternal(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), internalKey{}, true))
+}
+
+// IsInternal 判断请求是否来自已认证隧道。
+func IsInternal(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	v, _ := r.Context().Value(internalKey{}).(bool)
+	return v
+}

--- a/backend/cluster/broker/broker.go
+++ b/backend/cluster/broker/broker.go
@@ -1,0 +1,173 @@
+package broker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"ttmux-web/cluster/tunnel"
+)
+
+// Broker 组合注册表 + 隧道服务端 + 反代，暴露一组 gin.HandlerFunc。
+type Broker struct {
+	reg *Registry
+	up  websocket.Upgrader
+}
+
+// New 从 dir 加载注册表（nodes.json）。
+func New(dir string) *Broker {
+	return &Broker{
+		reg: NewRegistry(dir),
+		// 节点接入靠 token 鉴权（见 HandleTunnel），来源不是浏览器，放开 Origin 校验。
+		up: websocket.Upgrader{ReadBufferSize: 4096, WriteBufferSize: 4096, CheckOrigin: func(*http.Request) bool { return true }},
+	}
+}
+
+// 隧道接入 / 心跳协议里用到的头。
+const (
+	hdrEnroll = "X-Roam-Enroll"     // 一次性接入令牌（首次注册）
+	hdrNodeID = "X-Roam-Node-Id"    // 长期节点 id（重连）
+	hdrToken  = "X-Roam-Node-Token" // 长期节点凭证（重连；注册成功时经 101 响应头下发一次）
+	hdrName   = "X-Roam-Node-Name"
+	hdrGroup  = "X-Roam-Node-Group"
+	hdrMeta   = "X-Roam-Node-Meta" // JSON(NodeMeta)
+)
+
+// HandleTunnel 是节点出站拨号的落点：先按 token 鉴权（enrollment 或长期凭证），
+// 再升级为 WebSocket、包成 yamux 会话并登记。**不走用户会话鉴权**——它是节点在连，
+// 不是浏览器。鉴权在 Upgrade 之前完成，避免给未授权连接升级协议。
+func (b *Broker) HandleTunnel(c *gin.Context) {
+	var meta NodeMeta
+	if s := c.GetHeader(hdrMeta); s != "" {
+		_ = json.Unmarshal([]byte(s), &meta)
+	}
+
+	var id, plainToken string
+	respHeader := http.Header{}
+	if enroll := c.GetHeader(hdrEnroll); enroll != "" {
+		var ok bool
+		id, plainToken, ok = b.reg.ConsumeEnrollment(enroll, c.GetHeader(hdrName), c.GetHeader(hdrGroup), meta)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "ENROLL_INVALID"}})
+			return
+		}
+		// 长期凭证经 101 响应头下发一次；节点收到后落盘 node.json，之后用它重连。
+		respHeader.Set(hdrNodeID, id)
+		respHeader.Set(hdrToken, plainToken)
+	} else {
+		id = c.GetHeader(hdrNodeID)
+		if id == "" || !b.reg.AuthNode(id, c.GetHeader(hdrToken)) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "NODE_UNAUTHORIZED"}})
+			return
+		}
+	}
+
+	ws, err := b.up.Upgrade(c.Writer, c.Request, respHeader)
+	if err != nil {
+		return // Upgrade 内部已写响应
+	}
+	sess, err := tunnel.Server(ws)
+	if err != nil {
+		_ = ws.Close()
+		return
+	}
+	b.reg.Attach(id, sess, meta)
+	defer func() {
+		b.reg.Detach(id, sess)
+		_ = sess.Close()
+	}()
+
+	// 节点主动开的流是控制流（心跳）；前端请求走 Broker 主动 Open 的流（见 proxyNode）。
+	for {
+		st, err := sess.Accept()
+		if err != nil {
+			return // 会话断开
+		}
+		go b.readControl(id, st)
+	}
+}
+
+// readControl 读一条控制流上换行分隔的心跳 JSON：{"sessionCount":n,"load":f}。
+func (b *Broker) readControl(id string, conn net.Conn) {
+	defer conn.Close()
+	sc := bufio.NewScanner(conn)
+	for sc.Scan() {
+		var hb struct {
+			SessionCount int     `json:"sessionCount"`
+			Load         float64 `json:"load"`
+		}
+		if json.Unmarshal(sc.Bytes(), &hb) == nil {
+			b.reg.Heartbeat(id, hb.SessionCount, hb.Load)
+		}
+	}
+}
+
+// Nodes 返回节点列表（/api/broker/nodes）。
+func (b *Broker) Nodes(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"data": b.reg.List()})
+}
+
+// Bootstrap 返回控制台启动所需的最小信息（/api/broker/bootstrap）：可访问节点 +
+// 推荐节点。**Broker 本地处理，不依赖 current node**，消除前端 currentNode 启动循环。
+// 见 docs/design/cluster/多机切换交互设计.md §9.1。
+func (b *Broker) Bootstrap(c *gin.Context) {
+	nodes := b.reg.List()
+	recommended := ""
+	for _, n := range nodes {
+		if n.Online {
+			recommended = n.ID
+			break
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"nodes": nodes, "recommended": recommended}})
+}
+
+// Enroll 签发一次性接入令牌并给出接入命令（POST /api/broker/enroll）。
+func (b *Broker) Enroll(c *gin.Context) {
+	var body struct{ Name, Group string }
+	_ = c.ShouldBindJSON(&body)
+	e := b.reg.CreateEnrollment(body.Name, body.Group, 0)
+	scheme := "https"
+	if c.Request.TLS == nil && c.GetHeader("X-Forwarded-Proto") != "https" {
+		scheme = "http"
+	}
+	base := scheme + "://" + c.Request.Host
+	cmd := "curl -fsSL " + base + "/install.sh | bash -s -- --broker " + base + " --token " + e.Token
+	if body.Name != "" {
+		cmd += " --name " + strconv.Quote(body.Name)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"token": e.Token, "expiresAt": e.ExpiresAt, "command": cmd}})
+}
+
+// ProxyNode 把 /n/:nodeId/*path 反代进目标节点的隧道流（REST + WebSocket 升级）。
+// 转发本体是 httputil.ReverseProxy（同 backend/browser/devtools.go），只是把底层连接
+// 换成该节点隧道上 Open() 出来的 yamux 流。见架构文档 §7.2。
+func (b *Broker) ProxyNode(c *gin.Context) {
+	id := c.Param("nodeId")
+	sess := b.reg.Session(id)
+	if sess == nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"code": "NODE_OFFLINE"}})
+		return
+	}
+	target := &url.URL{Scheme: "http", Host: "node"}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	rp.Transport = &http.Transport{
+		DialContext:           func(context.Context, string, string) (net.Conn, error) { return sess.Open() },
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
+	rp.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, _ error) {
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	// 剥掉 /n/<id> 前缀，节点业务 Handler 只认 /api/...。
+	c.Request.URL.Path = c.Param("path")
+	c.Request.URL.RawPath = ""
+	rp.ServeHTTP(c.Writer, c.Request)
+}

--- a/backend/cluster/broker/integration_test.go
+++ b/backend/cluster/broker/integration_test.go
@@ -1,0 +1,117 @@
+package broker_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"ttmux-web/cluster/broker"
+	"ttmux-web/cluster/node"
+)
+
+// TestTunnelProxyEndToEnd 拉起一个 Broker（gin + httptest），让一个节点经隧道注册进来，
+// 再通过 /n/<id>/api/ping 把请求反代到节点的业务 Handler，验证整条数据面打通：
+// enrollment → yamux over ws 隧道 → 反代 → 节点响应回传。
+func TestTunnelProxyEndToEnd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	brk := broker.New(t.TempDir())
+
+	r := gin.New()
+	r.GET("/cluster/tunnel", brk.HandleTunnel)
+	r.POST("/api/broker/enroll", brk.Enroll)
+	r.GET("/api/broker/nodes", brk.Nodes)
+	r.Any("/n/:nodeId/*path", brk.ProxyNode)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// 1) 签发接入令牌
+	token := enroll(t, srv.URL)
+
+	// 2) 节点：业务 Handler 只回 pong
+	biz := http.NewServeMux()
+	biz.HandleFunc("/api/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "pong")
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cl := &node.Client{
+		Broker:   srv.URL,
+		Token:    token,
+		Name:     "test-node",
+		Version:  "test",
+		CredPath: filepath.Join(t.TempDir(), "node.json"),
+		Handler:  biz,
+	}
+	go cl.Run(ctx)
+
+	// 3) 等节点上线，取 nodeId
+	id := waitOnline(t, srv.URL)
+
+	// 4) 经 Broker 反代打到节点业务 Handler
+	got := ""
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(srv.URL + "/n/" + id + "/api/ping")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			got = string(b)
+			break
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got != "pong" {
+		t.Fatalf("反代结果 = %q，期望 %q", got, "pong")
+	}
+}
+
+func enroll(t *testing.T, base string) string {
+	t.Helper()
+	resp, err := http.Post(base+"/api/broker/enroll", "application/json", nil)
+	if err != nil {
+		t.Fatalf("enroll 失败: %v", err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Data struct{ Token string } `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil || out.Data.Token == "" {
+		t.Fatalf("解析 enroll 响应失败: %v (token=%q)", err, out.Data.Token)
+	}
+	return out.Data.Token
+}
+
+func waitOnline(t *testing.T, base string) string {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/api/broker/nodes")
+		if err == nil {
+			var out struct {
+				Data []struct {
+					ID     string `json:"id"`
+					Online bool   `json:"online"`
+				} `json:"data"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&out)
+			resp.Body.Close()
+			for _, n := range out.Data {
+				if n.Online {
+					return n.ID
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("节点未在超时内上线")
+	return ""
+}

--- a/backend/cluster/broker/registry.go
+++ b/backend/cluster/broker/registry.go
@@ -1,0 +1,238 @@
+// Package broker 是云端 Broker 的数据面 + 控制面：节点注册表、enrollment 签发、
+// 隧道服务端、以及把带 nodeId 的前端请求反代进目标节点隧道。它只做路由 + 注册，
+// 不重实现任何业务能力。见 docs/design/cluster/客户端-服务端横向扩展设计.md §2.3 / §7。
+package broker
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/yamux"
+)
+
+// heartbeatTimeout 超过这个时长没收到心跳即判该节点离线（前端灰显）。
+const heartbeatTimeout = 30 * time.Second
+
+// Node 是注册表里一条节点记录。凭证本身不明文入库，只存 token 的哈希。
+type Node struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Hostname      string    `json:"hostname"`
+	OS            string    `json:"os"`
+	Version       string    `json:"version"`
+	Capabilities  []string  `json:"capabilities"`
+	Group         string    `json:"group"`
+	Tags          []string  `json:"tags,omitempty"`
+	SessionCount  int       `json:"sessionCount"`
+	Load          float64   `json:"load"`
+	LastHeartbeat time.Time `json:"lastHeartbeat"`
+	TokenHash     string    `json:"tokenHash"` // sha256(nodeToken)，用于重连鉴权
+}
+
+// Online 依据最后心跳时间判活。
+func (n *Node) Online() bool { return time.Since(n.LastHeartbeat) < heartbeatTimeout }
+
+// enrollment 是一次性接入令牌。
+type enrollment struct {
+	Token     string
+	ExpiresAt time.Time
+	Used      bool
+	Name      string
+	Group     string
+}
+
+// Registry 维护节点元数据（落盘）、在线隧道会话（内存）与 enrollment 令牌（内存）。
+type Registry struct {
+	mu       sync.RWMutex
+	nodes    map[string]*Node
+	sessions map[string]*yamux.Session // nodeId -> 当前在线隧道
+	enroll   map[string]*enrollment
+	path     string // nodes.json 落盘路径
+}
+
+// NewRegistry 从 dir/nodes.json 加载已知节点（缺失则空）。
+func NewRegistry(dir string) *Registry {
+	r := &Registry{
+		nodes:    map[string]*Node{},
+		sessions: map[string]*yamux.Session{},
+		enroll:   map[string]*enrollment{},
+		path:     filepath.Join(dir, "nodes.json"),
+	}
+	if b, err := os.ReadFile(r.path); err == nil {
+		var list []*Node
+		if json.Unmarshal(b, &list) == nil {
+			for _, n := range list {
+				r.nodes[n.ID] = n
+			}
+		}
+	}
+	return r
+}
+
+func (r *Registry) persistLocked() {
+	list := make([]*Node, 0, len(r.nodes))
+	for _, n := range r.nodes {
+		list = append(list, n)
+	}
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(r.path), 0o700)
+	_ = os.WriteFile(r.path, b, 0o600)
+}
+
+// CreateEnrollment 生成一次性接入令牌（默认 30 分钟过期）。
+func (r *Registry) CreateEnrollment(name, group string, ttl time.Duration) *enrollment {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	e := &enrollment{Token: randToken(), ExpiresAt: time.Now().Add(ttl), Name: name, Group: group}
+	r.mu.Lock()
+	r.enroll[e.Token] = e
+	r.mu.Unlock()
+	return e
+}
+
+// ConsumeEnrollment 校验并消费接入令牌，创建/复用节点并换发长期节点凭证。
+// 返回 nodeID、明文 nodeToken（仅此一次返回，之后只存哈希）。
+func (r *Registry) ConsumeEnrollment(token, name, group string, meta NodeMeta) (id, nodeToken string, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.enroll[token]
+	if e == nil || e.Used || time.Now().After(e.ExpiresAt) {
+		return "", "", false
+	}
+	e.Used = true
+	id = "n_" + randID()
+	nodeToken = randToken()
+	if name == "" {
+		name = firstNonEmpty(e.Name, meta.Hostname, id)
+	}
+	if group == "" {
+		group = e.Group
+	}
+	r.nodes[id] = &Node{
+		ID: id, Name: name, Group: group,
+		Hostname: meta.Hostname, OS: meta.OS, Version: meta.Version, Capabilities: meta.Capabilities,
+		TokenHash: hashToken(nodeToken), LastHeartbeat: time.Now(),
+	}
+	r.persistLocked()
+	return id, nodeToken, true
+}
+
+// AuthNode 校验已注册节点的长期凭证（重连时用）。
+func (r *Registry) AuthNode(id, token string) bool {
+	r.mu.RLock()
+	n := r.nodes[id]
+	r.mu.RUnlock()
+	if n == nil || n.TokenHash == "" {
+		return false
+	}
+	want, _ := hex.DecodeString(n.TokenHash)
+	got := sha256.Sum256([]byte(token))
+	return subtle.ConstantTimeCompare(want, got[:]) == 1
+}
+
+// Attach 绑定一条在线隧道会话；同一节点已有旧会话则关闭它。
+func (r *Registry) Attach(id string, sess *yamux.Session, meta NodeMeta) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if old := r.sessions[id]; old != nil {
+		_ = old.Close()
+	}
+	r.sessions[id] = sess
+	if n := r.nodes[id]; n != nil {
+		n.LastHeartbeat = time.Now()
+		if meta.Hostname != "" {
+			n.Hostname, n.OS, n.Version, n.Capabilities = meta.Hostname, meta.OS, meta.Version, meta.Capabilities
+		}
+		r.persistLocked()
+	}
+}
+
+// Detach 解绑会话（隧道断开时）。
+func (r *Registry) Detach(id string, sess *yamux.Session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sessions[id] == sess {
+		delete(r.sessions, id)
+	}
+}
+
+// Heartbeat 更新节点的心跳时间与上报的会话数 / 负载。
+func (r *Registry) Heartbeat(id string, sessionCount int, load float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n := r.nodes[id]; n != nil {
+		n.LastHeartbeat = time.Now()
+		n.SessionCount = sessionCount
+		n.Load = load
+	}
+}
+
+// Session 返回节点当前在线隧道会话（不在线返回 nil）。
+func (r *Registry) Session(id string) *yamux.Session {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.sessions[id]
+}
+
+// List 返回节点快照（含在线状态）。
+func (r *Registry) List() []NodeView {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]NodeView, 0, len(r.nodes))
+	for _, n := range r.nodes {
+		_, online := r.sessions[n.ID]
+		out = append(out, NodeView{Node: *n, Online: online && n.Online()})
+	}
+	return out
+}
+
+// NodeMeta 是节点接入 / 心跳时上报的自身信息。
+type NodeMeta struct {
+	Hostname     string   `json:"hostname"`
+	OS           string   `json:"os"`
+	Version      string   `json:"version"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// NodeView 是给前端的节点视图（元数据 + 实时在线状态）。
+type NodeView struct {
+	Node
+	Online bool `json:"online"`
+}
+
+func randToken() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func randID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func hashToken(t string) string {
+	sum := sha256.Sum256([]byte(t))
+	return hex.EncodeToString(sum[:])
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/backend/cluster/node/creds.go
+++ b/backend/cluster/node/creds.go
@@ -1,0 +1,50 @@
+package node
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+var errNoToken = errors.New("cluster: 未提供 enrollment token（cluster.token 为空），无法首次注册")
+
+// creds2 是落盘的长期节点凭证（node.json）。
+type creds2 struct {
+	ID    string `json:"id"`
+	Token string `json:"token"`
+}
+
+// loadCreds 读取长期节点凭证；不存在 / 不完整都返回 nil（视为未注册，走 enrollment）。
+func loadCreds(path string) (*creds2, error) {
+	if path == "" {
+		return nil, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil
+	}
+	var c creds2
+	if json.Unmarshal(b, &c) != nil || c.ID == "" || c.Token == "" {
+		return nil, nil
+	}
+	return &c, nil
+}
+
+// saveCreds 把长期节点凭证落盘（0600）。
+func saveCreds(path string, c *creds2) error {
+	if path == "" {
+		return nil
+	}
+	b, _ := json.MarshalIndent(c, "", "  ")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// sessionOpener 是 heartbeat 需要的最小接口（*yamux.Session 满足）。
+type sessionOpener interface {
+	Open() (net.Conn, error)
+}

--- a/backend/cluster/node/node.go
+++ b/backend/cluster/node/node.go
@@ -1,0 +1,168 @@
+// Package node 是标准节点的出站隧道客户端：拨号云端 Broker、注册 / 重连、把 Broker
+// 转发进来的业务请求交给本机业务 Handler、并定期上报心跳。对现有业务 handler 零改动
+// ——只是把「本机 loopback」换成「隧道」。见 docs/design/cluster/客户端-服务端横向扩展设计.md §4。
+package node
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"ttmux-web/auth"
+	"ttmux-web/cluster/tunnel"
+)
+
+// 与 broker 侧约定的接入头（见 cluster/broker/broker.go）。
+const (
+	hdrEnroll = "X-Roam-Enroll"
+	hdrNodeID = "X-Roam-Node-Id"
+	hdrToken  = "X-Roam-Node-Token"
+	hdrName   = "X-Roam-Node-Name"
+	hdrGroup  = "X-Roam-Node-Group"
+	hdrMeta   = "X-Roam-Node-Meta"
+)
+
+// Client 是节点侧隧道客户端。
+type Client struct {
+	Broker   string       // 云端 Broker 地址，如 https://broker:443
+	Token    string       // 一次性 enrollment token（首次注册用）
+	Name     string       // 节点显示名
+	Group    string       // 分组
+	Insecure bool         // 跳过 Broker TLS 校验（自签调试）
+	Version  string       // 本机 Roam 版本
+	CredPath string       // node.json 落盘路径
+	Handler  http.Handler // 本机业务 Handler（server.New 返回的引擎）
+}
+
+func (cl *Client) meta() map[string]any {
+	host, _ := os.Hostname()
+	return map[string]any{
+		"hostname":     host,
+		"os":           runtime.GOOS,
+		"version":      cl.Version,
+		"capabilities": []string{"term", "files", "git", "browser", "phone", "swarm"},
+	}
+}
+
+// Run 持续维持到 Broker 的隧道：断线指数退避重连，直到 ctx 取消。
+func (cl *Client) Run(ctx context.Context) {
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := cl.connectOnce(ctx); err != nil {
+			log.Printf("[cluster] 连接 Broker 失败: %v（%s 后重试）", err, backoff)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// connectOnce 建立一次隧道并服务，直到会话断开才返回。
+func (cl *Client) connectOnce(ctx context.Context) error {
+	u, err := url.Parse(cl.Broker)
+	if err != nil {
+		return err
+	}
+	switch u.Scheme {
+	case "https", "wss":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
+	u.Path = "/cluster/tunnel"
+
+	metaJSON, _ := json.Marshal(cl.meta())
+	header := http.Header{}
+	header.Set(hdrMeta, string(metaJSON))
+	if cl.Name != "" {
+		header.Set(hdrName, cl.Name)
+	}
+	if cl.Group != "" {
+		header.Set(hdrGroup, cl.Group)
+	}
+	creds, _ := loadCreds(cl.CredPath)
+	enrolling := creds == nil
+	if enrolling {
+		if cl.Token == "" {
+			return errNoToken
+		}
+		header.Set(hdrEnroll, cl.Token)
+	} else {
+		header.Set(hdrNodeID, creds.ID)
+		header.Set(hdrToken, creds.Token)
+	}
+
+	d := websocket.Dialer{HandshakeTimeout: 15 * time.Second}
+	if cl.Insecure {
+		d.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 —— 仅自签调试
+	}
+	ws, resp, err := d.Dial(u.String(), header)
+	if err != nil {
+		return err
+	}
+	if enrolling && resp != nil {
+		// 注册成功：从 101 响应头取长期节点凭证并落盘，之后用它重连。
+		id, tok := resp.Header.Get(hdrNodeID), resp.Header.Get(hdrToken)
+		if id != "" && tok != "" {
+			if err := saveCreds(cl.CredPath, &creds2{ID: id, Token: tok}); err != nil {
+				log.Printf("[cluster] 保存节点凭证失败: %v", err)
+			}
+			log.Printf("[cluster] 已注册为节点 %s", id)
+		}
+	}
+
+	sess, err := tunnel.Client(ws)
+	if err != nil {
+		_ = ws.Close()
+		return err
+	}
+	defer sess.Close()
+	log.Printf("[cluster] 已连上 Broker %s", cl.Broker)
+
+	go cl.heartbeat(ctx, sess)
+
+	// Broker 主动 Open 的流是转发进来的前端业务请求；用本机业务 Handler 服务它们。
+	// 隧道流已由 Broker 完成用户会话校验，标记为内部主体（进程内、不可伪造）后放行本地鉴权。
+	internal := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cl.Handler.ServeHTTP(w, auth.WithInternal(r))
+	})
+	return http.Serve(sess, internal) // 会话断开即返回
+}
+
+// heartbeat 开一条控制流，定期上报换行分隔的心跳 JSON。
+func (cl *Client) heartbeat(ctx context.Context, sess sessionOpener) {
+	st, err := sess.Open()
+	if err != nil {
+		return
+	}
+	defer st.Close()
+	enc := json.NewEncoder(st)
+	t := time.NewTicker(15 * time.Second)
+	defer t.Stop()
+	for {
+		// TODO(P2): 上报真实会话数 / 负载（现从 ttmux 查）。
+		if err := enc.Encode(map[string]any{"sessionCount": 0, "load": 0.0}); err != nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
+}

--- a/backend/cluster/tunnel/tunnel.go
+++ b/backend/cluster/tunnel/tunnel.go
@@ -1,0 +1,89 @@
+// Package tunnel 把一条 WebSocket 连接包成可多路复用的双向隧道（yamux over wss），
+// 供云端 Broker 与标准节点共用。一条隧道里能并发开多条逻辑流：一条终端会话、一次
+// 文件下载、一次 CDP 反代各占一条流，互不阻塞；心跳走单独的控制流。
+//
+// 载体用项目已有的 gorilla/websocket（走 443/wss 对企业防火墙最友好），多路复用用
+// hashicorp/yamux。见 docs/design/cluster/客户端-服务端横向扩展设计.md §7.1。
+package tunnel
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/hashicorp/yamux"
+)
+
+// wsConn 把 *websocket.Conn 适配成 net.Conn，让 yamux 能在其上跑。
+// gorilla 允许「一个并发读 + 一个并发写」，正好匹配 yamux 的单读单写循环。
+type wsConn struct {
+	ws *websocket.Conn
+	r  io.Reader // 当前 binary message 的 reader（跨 Read 调用续读）
+}
+
+func (c *wsConn) Read(p []byte) (int, error) {
+	for {
+		if c.r == nil {
+			mt, r, err := c.ws.NextReader()
+			if err != nil {
+				return 0, err
+			}
+			if mt != websocket.BinaryMessage {
+				continue // 忽略非二进制帧（如对端的 ping/close 由 gorilla 内部处理）
+			}
+			c.r = r
+		}
+		n, err := c.r.Read(p)
+		if err == io.EOF {
+			c.r = nil // 当前 message 读完，等下一帧
+			if n > 0 {
+				return n, nil
+			}
+			continue
+		}
+		return n, err
+	}
+}
+
+func (c *wsConn) Write(p []byte) (int, error) {
+	if err := c.ws.WriteMessage(websocket.BinaryMessage, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *wsConn) Close() error                       { return c.ws.Close() }
+func (c *wsConn) LocalAddr() net.Addr                { return c.ws.LocalAddr() }
+func (c *wsConn) RemoteAddr() net.Addr               { return c.ws.RemoteAddr() }
+func (c *wsConn) SetReadDeadline(t time.Time) error  { return c.ws.SetReadDeadline(t) }
+func (c *wsConn) SetWriteDeadline(t time.Time) error { return c.ws.SetWriteDeadline(t) }
+
+func (c *wsConn) SetDeadline(t time.Time) error {
+	if err := c.ws.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return c.ws.SetWriteDeadline(t)
+}
+
+func yamuxCfg() *yamux.Config {
+	cfg := yamux.DefaultConfig()
+	cfg.EnableKeepAlive = true
+	cfg.KeepAliveInterval = 15 * time.Second
+	cfg.ConnectionWriteTimeout = 20 * time.Second
+	cfg.LogOutput = io.Discard
+	return cfg
+}
+
+// Server 在 Broker 侧把接受到的节点长连包成 yamux 会话（server 端）。
+// 返回的 *yamux.Session 既能 Open() 出流（转发前端请求给节点），也实现 net.Listener
+// 接口，Accept() 出节点主动开的控制流（心跳）。
+func Server(ws *websocket.Conn) (*yamux.Session, error) {
+	return yamux.Server(&wsConn{ws: ws}, yamuxCfg())
+}
+
+// Client 在节点侧把出站长连包成 yamux 会话（client 端）。节点用它 Accept() 出
+// Broker 转发进来的业务请求流（交给本机业务 Handler），并 Open() 控制流上报心跳。
+func Client(ws *websocket.Conn) (*yamux.Session, error) {
+	return yamux.Client(&wsConn{ws: ws}, yamuxCfg())
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"net"
@@ -12,7 +13,9 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/gin-gonic/gin"
 	"ttmux-web/browser"
+	"ttmux-web/cluster/node"
 	"ttmux-web/config"
 	"ttmux-web/internal/clibin"
 	"ttmux-web/internal/webui"
@@ -110,7 +113,30 @@ func main() {
 		Version: version,
 	}
 
-	r := server.New(cfg)
+	// 横向扩展模式分流（见 docs/design/cluster/客户端-服务端横向扩展设计.md §4）：
+	//   - cloud：云端 Broker，只做路由 + 注册表 + 控制台，不构造业务 runtime；
+	//   - standard（默认）：现在的单机 Roam；若配了 cluster.broker，则额外出站注册进云端。
+	var r *gin.Engine
+	if conf.Cluster.Mode == "cloud" {
+		log.Printf("以云端 Broker 模式启动（只做路由 + 注册表 + 控制台，不跑本机业务）")
+		r = server.NewBroker(cfg)
+	} else {
+		r = server.New(cfg)
+		if conf.Cluster.Broker != "" {
+			cl := &node.Client{
+				Broker:   conf.Cluster.Broker,
+				Token:    conf.Cluster.Token,
+				Name:     conf.Cluster.Name,
+				Group:    conf.Cluster.Group,
+				Insecure: conf.Cluster.Insecure,
+				Version:  version,
+				CredPath: filepath.Join(dataDir(), "cluster", "node.json"),
+				Handler:  r, // 业务 Handler 不变，隧道请求经内部主体放行本地鉴权
+			}
+			go cl.Run(context.Background())
+			log.Printf("标准模式：出站注册到云端 Broker %s", conf.Cluster.Broker)
+		}
+	}
 
 	// 退出时回收本进程拉起的 Chrome（含其子进程组），避免泄漏孤儿进程
 	sig := make(chan os.Signal, 1)

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -31,10 +31,24 @@ type Web struct {
 	LockSecs   int      `yaml:"lock_secs"`
 }
 
+// Cluster 对应 config.yaml 里的 cluster: 段（横向扩展：标准节点 / 云端 Broker）。
+// mode=standard（默认）为现在的单机 Roam，填了 broker 就额外出站注册进云端；
+// mode=cloud 是云端 Broker，只做路由 + 注册表 + 控制台，不跑业务。见
+// docs/design/cluster/客户端-服务端横向扩展设计.md。
+type Cluster struct {
+	Mode     string `yaml:"mode"`     // standard（默认）| cloud
+	Broker   string `yaml:"broker"`   // 云端 Broker 地址，如 https://broker:443（standard 模式填了才上云）
+	Token    string `yaml:"token"`    // 一次性 enrollment token（首次注册用，之后换长期节点凭证）
+	Name     string `yaml:"name"`     // 节点显示名（默认 hostname）
+	Group    string `yaml:"group"`    // 分组（可选）
+	Insecure bool   `yaml:"insecure"` // 跳过 Broker TLS 校验（自签证书调试用，生产勿开）
+}
+
 // Config 是解析后的配置（env 覆盖已叠加，默认值已填充）。
 type Config struct {
-	Web  Web
-	Path string // 实际配置文件路径（供 SavePassword 落盘）
+	Web     Web
+	Cluster Cluster
+	Path    string // 实际配置文件路径（供 SavePassword 落盘）
 }
 
 // Home 返回 Roam 主目录（数据/配置根）。优先 ROAM_HOME，兼容旧 TTMUX_HOME。
@@ -73,12 +87,13 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 	var file struct {
-		Web Web `yaml:"web"`
+		Web     Web     `yaml:"web"`
+		Cluster Cluster `yaml:"cluster"`
 	}
 	if err := yaml.Unmarshal(b, &file); err != nil {
 		return nil, err
 	}
-	c := &Config{Web: file.Web, Path: path}
+	c := &Config{Web: file.Web, Cluster: file.Cluster, Path: path}
 	c.applyDefaults()
 	c.applyEnv()
 	return c, nil
@@ -93,6 +108,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Web.LockSecs <= 0 {
 		c.Web.LockSecs = 30
+	}
+	if c.Cluster.Mode == "" {
+		c.Cluster.Mode = "standard"
 	}
 }
 
@@ -125,6 +143,25 @@ func (c *Config) applyEnv() {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			c.Web.LockSecs = n
 		}
+	}
+	// cluster 段的环境变量覆盖（横向扩展）。
+	if v := firstEnv("ROAM_CLUSTER_MODE"); v != "" {
+		c.Cluster.Mode = v
+	}
+	if v := firstEnv("ROAM_CLUSTER_BROKER"); v != "" {
+		c.Cluster.Broker = v
+	}
+	if v := firstEnv("ROAM_CLUSTER_TOKEN"); v != "" {
+		c.Cluster.Token = v
+	}
+	if v := firstEnv("ROAM_CLUSTER_NAME"); v != "" {
+		c.Cluster.Name = v
+	}
+	if v := firstEnv("ROAM_CLUSTER_GROUP"); v != "" {
+		c.Cluster.Group = v
+	}
+	if v := firstEnv("ROAM_CLUSTER_INSECURE"); v != "" {
+		c.Cluster.Insecure = truthy(v)
 	}
 }
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -32,6 +32,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/backend/server/broker.go
+++ b/backend/server/broker.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+	"ttmux-web/auth"
+	"ttmux-web/cluster/broker"
+)
+
+// NewBroker 装配**云端 Broker** 的 Gin 引擎。它**不复用 New()**——不构造业务 runtime、
+// 不启动 SyncLoop、不初始化 browser / phone / pty，只做：用户认证入口、静态资源（控制台）、
+// 节点隧道接入、Broker-local API（/api/broker/*）、以及把 /n/:nodeId/* 反代进目标节点。
+// 见 docs/design/cluster/客户端-服务端横向扩展设计.md §4。
+func NewBroker(cfg Config) *gin.Engine {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.UseRawPath = true
+	r.Use(gin.Recovery())
+
+	a := auth.New(cfg.Password, cfg.TOTPSecret, cfg.TOTPState, cfg.LockAfter, cfg.LockSecs, cfg.SavePassword)
+	brk := broker.New(filepath.Join(cfg.DataDir, "cluster"))
+
+	// 公开端点（与单机一致：登录 / 首次设置 / 版本 / 证书 / 导航页）
+	mountPublic(r, a, cfg)
+
+	// 节点出站隧道接入（token 鉴权，非用户会话）。
+	r.GET("/cluster/tunnel", brk.HandleTunnel)
+
+	// 用户会话下的最小 /api（控制台探活用；业务 API 一律经 /n/<id> 代理到节点）。
+	g := r.Group("/api", a.Middleware())
+	g.Use(func(c *gin.Context) { c.Header("Cache-Control", "no-store") })
+	g.GET("/me", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}}) })
+
+	// Broker-local API：节点列表 / bootstrap / 接入签发（用户会话鉴权）。
+	bg := r.Group("/api/broker", a.Middleware())
+	bg.Use(func(c *gin.Context) { c.Header("Cache-Control", "no-store") })
+	bg.GET("/nodes", brk.Nodes)
+	bg.GET("/bootstrap", brk.Bootstrap)
+	bg.POST("/enroll", brk.Enroll)
+
+	// 节点反代：/n/:nodeId/*path（用户会话鉴权后转发进目标节点隧道）。
+	ng := r.Group("/n/:nodeId", a.Middleware())
+	ng.Any("/*path", brk.ProxyNode)
+
+	mountWeb(r, cfg.FrontendDir)
+	return r
+}

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -62,43 +62,8 @@ func New(cfg Config) *gin.Engine {
 	phone.InitConfig(cfg.DataDir)   // 手机后端配置（本地/远程 redroid/真机）持久化到 dataDir
 	hub := stream.New(tt, cfg.LogsDir)
 
-	// 公开端点
-	r.POST("/api/login", a.Login)
-	r.POST("/api/logout", a.Logout)
-	r.POST("/api/setup", a.Setup)                // 首次设置口令（仅当尚未设置口令时可用），成功即发会话
-	r.GET("/api/pubconfig", a.PubConfig)         // 登录页据此决定是否要动态码 / 是否需首次设置
-	r.GET("/api/version", func(c *gin.Context) { // roam 版本 + 仓库（关于页/检测更新，免登录）
-		c.JSON(http.StatusOK, gin.H{"data": gin.H{"version": cfg.Version, "repo": roamRepo}})
-	})
-	// 检测更新：后端查 GitHub Releases（带缓存 + 优雅降级），避免浏览器直连 GitHub API
-	// 遇到的限流/跨域/网络不通问题。无论成功与否都返回 releases 页地址供手动前往。
-	r.GET("/api/update-check", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"data": checkUpdate(cfg.Version)})
-	})
-
-	// 下载自签证书（免登录）：手机装为受信任证书后即把本站当安全上下文，
-	// 可装成全屏 PWA、麦克风/剪贴板可用。TLS 关闭或证书不存在时返回 404。
-	r.GET("/cert.crt", func(c *gin.Context) {
-		if cfg.TLSCertPath == "" {
-			c.String(404, "TLS 未启用，无证书可下载")
-			return
-		}
-		pem, err := os.ReadFile(cfg.TLSCertPath)
-		if err != nil {
-			c.String(404, "证书不存在")
-			return
-		}
-		// application/x-x509-ca-cert：安卓据此弹出「安装 CA 证书」流程。
-		c.Header("Content-Type", "application/x-x509-ca-cert")
-		c.Header("Content-Disposition", `attachment; filename="ttmux-ca.crt"`)
-		c.Data(200, "application/x-x509-ca-cert", pem)
-	})
-
-	// 导航起始页（免登录）：供被投屏的 Chrome 当默认主页，因此不能挂在认证组里
-	hm := home.New(cfg.DataDir)
-	r.GET("/home", hm.Page)
-	r.GET("/home/sites", hm.GetSites)
-	r.PUT("/home/sites", hm.PutSites)
+	// 公开端点（登录 / 首次设置 / 版本 / 证书 / 导航页）——与云端 Broker 共用
+	mountPublic(r, a, cfg)
 
 	// 受保护端点
 	g := r.Group("/api", a.Middleware())
@@ -374,6 +339,47 @@ func firstNonEmptyStr(a, b string) string {
 		return a
 	}
 	return b
+}
+
+// mountPublic 注册免登录的公开端点（登录 / 首次设置 / 版本 / 检测更新 / 下载证书 /
+// 导航起始页）。单机（New）与云端 Broker（NewBroker）共用同一套入口。
+func mountPublic(r *gin.Engine, a *auth.Auth, cfg Config) {
+	r.POST("/api/login", a.Login)
+	r.POST("/api/logout", a.Logout)
+	r.POST("/api/setup", a.Setup)                // 首次设置口令（仅当尚未设置口令时可用），成功即发会话
+	r.GET("/api/pubconfig", a.PubConfig)         // 登录页据此决定是否要动态码 / 是否需首次设置
+	r.GET("/api/version", func(c *gin.Context) { // roam 版本 + 仓库（关于页/检测更新，免登录）
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"version": cfg.Version, "repo": roamRepo}})
+	})
+	// 检测更新：后端查 GitHub Releases（带缓存 + 优雅降级），避免浏览器直连 GitHub API
+	// 遇到的限流/跨域/网络不通问题。无论成功与否都返回 releases 页地址供手动前往。
+	r.GET("/api/update-check", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": checkUpdate(cfg.Version)})
+	})
+
+	// 下载自签证书（免登录）：手机装为受信任证书后即把本站当安全上下文，
+	// 可装成全屏 PWA、麦克风/剪贴板可用。TLS 关闭或证书不存在时返回 404。
+	r.GET("/cert.crt", func(c *gin.Context) {
+		if cfg.TLSCertPath == "" {
+			c.String(404, "TLS 未启用，无证书可下载")
+			return
+		}
+		pem, err := os.ReadFile(cfg.TLSCertPath)
+		if err != nil {
+			c.String(404, "证书不存在")
+			return
+		}
+		// application/x-x509-ca-cert：安卓据此弹出「安装 CA 证书」流程。
+		c.Header("Content-Type", "application/x-x509-ca-cert")
+		c.Header("Content-Disposition", `attachment; filename="ttmux-ca.crt"`)
+		c.Data(200, "application/x-x509-ca-cert", pem)
+	})
+
+	// 导航起始页（免登录）：供被投屏的 Chrome 当默认主页，因此不能挂在认证组里
+	hm := home.New(cfg.DataDir)
+	r.GET("/home", hm.Page)
+	r.GET("/home/sites", hm.GetSites)
+	r.PUT("/home/sites", hm.PutSites)
 }
 
 func mountWeb(r *gin.Engine, frontendDir string) {


### PR DESCRIPTION
## 概要

多机横向扩展 **P1 后端数据面**（Client/Server ≈ frpc/frps）。设计见 `docs/design/cluster/`（PR #113）。现有业务 handler 零改动。

## 内容

- **config**：新增 `cluster` 段（`mode=standard` 默认 / `cloud`）+ `ROAM_CLUSTER_*` 环境变量。
- **cluster/tunnel**：yamux over gorilla/ws 双向隧道（`net.Conn` 适配 + 多路复用）。
- **cluster/broker**：节点注册表 + enrollment 签发 + 隧道服务端 + `/n/<id>` 反代（`httputil.ReverseProxy` over yamux）。
- **cluster/node**：出站拨号 / 注册 / 重连 / 心跳，把隧道请求交给本机业务 Handler。
- **auth**：内部主体（typed transport principal，进程内不可伪造）放行隧道流量，**禁 header 绕过**（设计 §6）。
- **server**：拆出 `NewBroker` + `mountPublic`，cloud 模式不构造业务 runtime（不启 SyncLoop/browser/phone）。
- **cmd/main**：按 `cluster.mode` 两路分流。

## 测试

- `cluster/broker` 端到端集成测试：enrollment → yamux 隧道 → 反代 → 节点响应，`go test` 通过。
- `scripts/dev/quality/check.sh quick` 全绿（build/test、i18n、typecheck、secret scan）。

## 说明

前端节点切换器 / `/nodes` 页为后续增量。此分支是把误直推 main 的提交撤回后（main 上 revert `71cad89`）重新走 PR review。

🤖 Generated with [Claude Code](https://claude.com/claude-code)