### PR TITLE
feat(project): 项目详情加文件浏览 Tab + 命令行可开多个

### DIFF
--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -14,6 +14,7 @@ import { useI18n } from './i18n'
 import { usePreferences } from './preferences'
 import { detectPrompt } from './prompt'
 import { relTime, taskNameFromPrompt, shq, NewSessionModal, DirPicker, recentDirs, pushRecentDir, CloseWorktreeModal } from './App'
+import FileBrowser from './FileBrowser'
 
 const WorktreePanel = lazy(() => import('./WorktreePanel'))
 const GitPanel = lazy(() => import('./GitPanel'))
@@ -435,7 +436,7 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
   const { t } = useI18n()
   const { message } = AntApp.useApp()
   const [prefs] = usePreferences()
-  const [tab, setTab] = useState<'tasks' | 'wt' | 'race' | 'act'>('tasks')
+  const [tab, setTab] = useState<'tasks' | 'wt' | 'race' | 'act' | 'files'>('tasks')
   const [prompt, setPrompt] = useState('')
   const [wtMode, setWtMode] = useState<'new' | 'repo' | 'existing'>('new')
   const [agent, setAgent] = useState<'claude' | 'codex' | 'none'>('claude')
@@ -727,10 +728,14 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
     } catch (e: any) { message.error(e.message) }
   }
   // 纯命令行：项目目录里开一个裸 shell 会话（同名已存在则直接进入，不重复建）
+  // ＋命令行：每次都开一个新命令行会话（一个项目可有多个）；名字冲突就递增后缀。
+  // 已开的命令行会话 cwd 落在项目根，annotation 归属本项目 → 都列在「任务」活动区，可再进入。
   const newShell = async () => {
     if (!proj) return
-    const name = proj.name + '-sh'
-    if (sessions.some((s) => s.name === name)) { openTerm(name); return }
+    const base = proj.name + '-sh'
+    const taken = new Set(sessions.map((s) => s.name))
+    let name = base
+    for (let i = 2; taken.has(name); i++) name = base + i
     try {
       const res = await api('POST', '/sessions', { name, dir })
       message.success(t('session.created')); openTerm(res.name || name); refresh()
@@ -930,6 +935,7 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
           {isGit && tabBtn('wt', 'Worktree', wts.length)}
           {isGit && tabBtn('race', t('project.tab.race'), races.length + swarms.length)}
           {isGit && tabBtn('act', t('project.tab.activity'))}
+          {tabBtn('files', t('project.tab.files'))}
         </div>
 
         {/* ── 任务流 ── */}
@@ -1233,6 +1239,17 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
             ))}
             {activity.length === 0 && <div className="prj-empty">{t('project.act.empty')}</div>}
             <div style={{ fontSize: 11.5, color: 'var(--text-dimmer)', padding: '8px 12px', borderTop: '1px dashed var(--border-subtle)' }}>{t('project.act.hint')}</div>
+          </div>
+        )}
+
+        {/* ── 文件浏览 ── split 是 height:100% 的组件，需给有界高度的父容器；预留头/Composer/Tab 占位 */}
+        {tab === 'files' && (
+          <div className="prj-panel prj-in" style={{ height: 'calc(100vh - 300px)', minHeight: 420, overflow: 'hidden', padding: 0 }}>
+            <FileBrowser
+              dir={proj.dir}
+              layout="split"
+              onInsertPath={(p) => setPrompt((cur) => (cur ? cur.replace(/\s*$/, ' ') : '') + '@' + p + ' ')}
+            />
           </div>
         )}
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1153,6 +1153,7 @@ const enUS = {
   'project.basedOn': 'Based on {base}',
   'project.tab.race': 'Formations',
   'project.tab.activity': 'Activity',
+  'project.tab.files': 'Files',
   'project.gitPanel': 'Git panel',
   'project.stage.doing': 'Working',
   'project.stage.review': 'Review',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1153,6 +1153,7 @@ const zhCN = {
   'project.basedOn': '基于 {base}',
   'project.tab.race': '编队',
   'project.tab.activity': '活动',
+  'project.tab.files': '文件',
   'project.gitPanel': 'Git 面板',
   'project.stage.doing': '干活中',
   'project.stage.review': 'Review',


### PR DESCRIPTION
## 变更

在**项目详情页**(ProjectHome)补两处能力：

### 1. 「文件」Tab —— 浏览项目文件
- 详情页顶部 Tab 增加 `文件`，对**所有项目**(含非 git)可见。
- 复用现成 `FileBrowser` 组件(`split` 布局：左树/平铺 + 右预览)，作用域为项目根目录 `proj.dir`。
- 浏览时点文件经 `onInsertPath` 以 `@路径` 塞进 Composer，与会话内体验一致。
- **零后端改动**：目录/文件读取走既有 `/api/files`、`/api/file*`。
- `split` 是 `height:100%` 组件，用有界高度父容器包住(`calc(100vh - 300px)`，`minHeight 420`)。

### 2. 「＋ 命令行」可开多个
- 旧逻辑用固定名 `<项目>-sh`，已存在就只是重新进入 —— 「＋」名不副实，一个项目只能有一个命令行。
- 现按全局会话名去重递增(`-sh` / `-sh2` / `-sh3`…)，每点一次都新开一个命令行会话。
- 这些会话 cwd 落在项目根，后端 `Annotations` 按 pane 实际 cwd 解析归属 → 自动列在「任务」活动区可再进入，**无需额外 UI、无后端改动**。

### i18n
- 新增 `project.tab.files`(文件 / Files)，中英双语。

## 验证
- `scripts/dev/quality/check.sh full` 通过(Go 测试 + i18n 审计 1218 keys + typecheck + 构建)。
- 纯前端复用改动，未触碰后端。

🤖 Generated with [Claude Code](https://claude.com/claude-code)