### PR TITLE
fix(worktree): 缺省基准跟随远端主干最新，新 worktree 不再从旧 main 起步

### DIFF
--- a/backend/api/worktree_e2e_test.go
+++ b/backend/api/worktree_e2e_test.go
@@ -321,6 +321,60 @@ func TestRaceLifecycle(t *testing.T) {
 	}
 }
 
+// 缺省基准跟随远端主干最新：本地 main 落后于 origin/main 时，未显式指定 base/remote
+// 建 worktree 应从 origin/main 最新处开分叉（自动 fetch），而非本地旧 main。
+func TestWorktreeCreateAutoBaseFollowsRemote(t *testing.T) {
+	tmp := t.TempDir()
+	h := New(ttmux.New(filepath.Join(tmp, "ttmux-absent")), "", tmp)
+	repo := e2eRepo(t, tmp)
+	gitIn := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(scrubGitEnv(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	origin := filepath.Join(tmp, "origin.git")
+	gitIn(repo, "clone", "--bare", repo, origin)
+	gitIn(repo, "remote", "add", "origin", origin)
+	localHead := gitIn(repo, "rev-parse", "HEAD")
+
+	// 在独立克隆里推进 origin/main 一格：本地 repo 的 main 与 origin 跟踪 ref 都不动，
+	// 从而制造「本地 main 落后于 origin/main」的局面。
+	work := filepath.Join(tmp, "work")
+	gitIn(tmp, "clone", origin, work)
+	if err := os.WriteFile(filepath.Join(work, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(work, "add", ".")
+	gitIn(work, "commit", "-m", "advance main")
+	remoteHead := gitIn(work, "rev-parse", "HEAD")
+	gitIn(work, "push", "-q", "origin", "main")
+	if remoteHead == localHead {
+		t.Fatal("setup: origin/main not advanced")
+	}
+
+	// 不传 base/remote → autoBase 路径应自动 fetch 并从 origin/main 起步。
+	wt, err := h.WT.Create(context.Background(), worktree.CreateReq{Dir: repo, Branch: "roam/auto-base"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := gitIn(wt.Path, "rev-parse", "HEAD")
+	if got != remoteHead {
+		t.Fatalf("auto-base worktree should start from origin/main %s, got %s (local main %s)", remoteHead, got, localHead)
+	}
+	if wt.Base != "main" {
+		t.Fatalf("baseref should stay \"main\", got %q", wt.Base)
+	}
+	if wt.StartOid != remoteHead {
+		t.Fatalf("startOid should be origin/main %s, got %s", remoteHead, wt.StartOid)
+	}
+}
+
 // /git/worktree/sync 路由（10 §3/§4）：本地 bare origin 上「合并」后，sync → list
 // 能看到 mergedInto/mergedKind。不依赖 tmux/CLI（session join 优雅降级为空）。
 func TestWorktreeSyncRoute(t *testing.T) {

--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -269,6 +269,9 @@ func (s *Service) Create(ctx context.Context, req CreateReq) (CreateResp, error)
 	}
 
 	base := strings.TrimSpace(req.Base)
+	// 缺省基准（未显式指定 base/remote）：默认跟随远端主干最新处开分叉，
+	// 避免本地 base 落后于 origin 时新 worktree 从旧提交起步。
+	autoBase := base == "" && req.Remote == ""
 	if base == "" {
 		base = s.defaultBase(ctx, repo)
 		if base == "" {
@@ -282,6 +285,18 @@ func (s *Service) Create(ctx context.Context, req CreateReq) (CreateResp, error)
 			return CreateResp{}, errf("FETCH_FAILED", "%s", out)
 		}
 		startRef = req.Remote + "/" + base
+	} else if autoBase {
+		// 配了 origin 就尽力拉一把最新 origin/<base>（20s 上限，不阻断创建）；
+		// 无远端 / 离线 / fetch 失败一律静默回退本地 base。ahead/behind 与合入
+		// 判定本就优先比对 origin/<base>（见 List），故 baseref 仍记 base 名、口径一致。
+		if _, e := git(ctx, repo.Root, "config", "--get", "remote.origin.url"); e == nil {
+			fctx, fcancel := context.WithTimeout(ctx, 20*time.Second)
+			_, _ = git(fctx, repo.Root, "fetch", "--no-tags", "origin", "+refs/heads/"+base+":refs/remotes/origin/"+base)
+			fcancel()
+		}
+		if _, e := git(ctx, repo.Root, "rev-parse", "--verify", "-q", "refs/remotes/origin/"+base); e == nil {
+			startRef = "origin/" + base
+		}
 	}
 	startOid, e := git(ctx, repo.Root, "rev-parse", "--verify", "--end-of-options", startRef+"^{commit}")
 	if e != nil {


### PR DESCRIPTION
## 背景

用户提问：Roam 建 worktree 的底层机制,是不是也会从「错的/旧的 base」起步?

排查结论:机制**不会**像手动那样从当前 checkout 的功能分支切(它锚定 main/master),但存在一个更隐蔽的缺口 —— 建 worktree 未显式指定 base/remote 时,用的是**本地 main 的 OID**,且**默认不 fetch**。本地 main 若落后于 `origin/main`(没 pull),新 worktree 就从旧提交起步。

## 变更

`worktree.Service.Create` 的**缺省基准路径**(`autoBase = base=="" && remote==""`):
- 若配了 `origin`,先尽力 `git fetch origin <默认分支>`(**20s 上限,不阻断创建**),再从 `origin/<默认分支>` 最新处开分叉;
- **无远端 / 离线 / fetch 失败** → 一律静默回退本地 base(即今日行为),保持离线可用;
- 显式传 `base`/`remote` 的调用方**行为不变**。

## 为什么不会「凭空 ahead」

`roam.baseref` 仍记**分支名**(`main`)而非远端 ref。List 里 ahead/behind 与合入判定**本就优先比对 `origin/<base>`**(`service.go:496`),`StartOid` 又锁定建时分叉点 —— 所以从 `origin/main` 起步后,口径完全一致:新建的空 worktree HEAD==StartOid==origin/main,`rev-list origin/main...HEAD` = 0/0,既不 ahead 也不 behind。

## 测试

新增 `TestWorktreeCreateAutoBaseFollowsRemote`:构造「本地 main 落后于 origin/main 一格」,不传 base/remote 建 worktree,断言其 HEAD / StartOid == origin/main 最新,且 baseref 仍为 `main`。

`scripts/dev/quality/check.sh full` 通过(全 Go 测试 + i18n + typecheck + 构建)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)