### PR TITLE
fix(frontend): 浏览器镜像面板支持中文输入法输入

### DIFF
--- a/frontend/src/BrowserView.tsx
+++ b/frontend/src/BrowserView.tsx
@@ -178,6 +178,13 @@ export default function BrowserView() {
   const touchRef = useRef({ x: 0, y: 0, t: 0, moved: false })
   const lastEmuRef = useRef('')       // 上次已发的 emulate 载荷（去重：载荷没变绝不重发 → 不重设视口 → 不跳）
   const emuTimerRef = useRef(0 as any) // emulate 防抖计时器
+  // 中文等输入法（IME）输入：普通 div 持焦时浏览器不会启动输入法组合，敲拼音只会落下
+  // 原始字母。用一个视觉隐藏的 textarea 承接焦点与组合过程，组合结束后把整段文本经
+  // 现有 char 消息发往远端（后端 Input.insertText 支持多字符）。textarea 定位在最近
+  // 一次点击处，让候选词窗口出现在输入位置附近而不是面板角落。
+  const imeRef = useRef<HTMLTextAreaElement>(null)
+  const composingRef = useRef(false)
+  const [imePos, setImePos] = useState({ x: 8, y: 8 })
 
   // control 开关用 ref 同步，供事件回调读取最新值
   useEffect(() => { controlRef.current = control }, [control])
@@ -468,7 +475,16 @@ export default function BrowserView() {
     if (!controlRef.current) return
     e.preventDefault()
     const pt = mapXY(e)
-    if (sub === 'down') { stageRef.current?.focus(); addRipple(e); dragRef.current = { x: pt.x, y: pt.y, active: true, moved: false } } // 拿焦点 + 涟漪 + 记拖动起点
+    if (sub === 'down') {
+      const st = stageRef.current
+      if (st) {
+        const r = st.getBoundingClientRect()
+        setImePos({ x: e.clientX - r.left, y: e.clientY - r.top })
+      }
+      imeRef.current?.focus({ preventScroll: true }) // 焦点落在隐藏 textarea 上，输入法才会启动组合
+      addRipple(e)
+      dragRef.current = { x: pt.x, y: pt.y, active: true, moved: false } // 记拖动起点
+    } // 拿焦点 + 涟漪 + 记拖动起点
     send({ type: 'mouse', sub, x: pt.x, y: pt.y, button: 'left', buttons: sub === 'down' ? 1 : 0, modifiers: mods(e) })
     if (sub === 'up') {
       const d = dragRef.current
@@ -567,8 +583,19 @@ export default function BrowserView() {
       () => send({ type: 'paste' }),
     )
   }
+  // 组合结束（或非组合的文本插入，如 macOS 长按选音标）后，把 textarea 里攒出的整段
+  // 文本一次发往远端。组合中的退格/选词等按键都由输入法在本地消费，不会到这里。
+  const flushIme = () => {
+    const ta = imeRef.current
+    if (!ta || !ta.value) return
+    send({ type: 'key', sub: 'char', text: ta.value })
+    ta.value = ''
+  }
   const onKey = (e: React.KeyboardEvent) => {
     if (!controlRef.current) return
+    // 输入法组合中：按键属于输入法（key 为 "Process"/keyCode 229），不转发也不
+    // preventDefault，否则组合被打断；组合结果统一由 flushIme 发送。
+    if (composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229) return
     const mod = e.ctrlKey || e.metaKey
     // 复制/粘贴走「跨屏」桥，不把组合键转发给远端：用本机剪贴板，不碰远端那台机器的剪贴板
     if (mod && (e.key === 'v' || e.key === 'V')) { e.preventDefault(); pasteFromClipboard(); return }
@@ -717,6 +744,32 @@ export default function BrowserView() {
             height: rotated ? stage.w : Math.round((stage.w * vp.h) / vp.w),
             objectFit: 'contain',
             transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+          }}
+        />
+        <textarea
+          ref={imeRef}
+          aria-label={t('browser.imeProxyLabel')}
+          tabIndex={-1}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          onCompositionStart={() => { composingRef.current = true }}
+          onCompositionEnd={() => { composingRef.current = false; flushIme() }}
+          onInput={() => {
+            // 组合中的中间态（isComposing 的 input 事件）不发；只有非组合插入
+            //（如 macOS 长按选音标）才在这里落地。
+            if (!composingRef.current) flushIme()
+          }}
+          onBlur={() => {
+            // 失焦时丢弃半截组合，避免残留拼音在下次聚焦时被误发到远端。
+            composingRef.current = false
+            if (imeRef.current) imeRef.current.value = ''
+          }}
+          style={{
+            position: 'absolute', left: imePos.x, top: imePos.y, width: 2, height: 2,
+            opacity: 0, padding: 0, border: 'none', outline: 'none', resize: 'none',
+            overflow: 'hidden', background: 'transparent', caretColor: 'transparent',
+            pointerEvents: 'none',
           }}
         />
         {ripples.map((p) => (

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -362,6 +362,7 @@ const enUS = {
   'browser.quality.ultra': 'Ultra',
   'browser.noDebuggableTab': 'No debuggable tab',
   'browser.rotateTitle': 'Rotate 90° for portrait screens',
+  'browser.imeProxyLabel': 'Keyboard input proxy (captures IME composition)',
   'browser.connected': 'Connected',
   'browser.disconnected': 'Disconnected',
   'browser.launchFailed': 'Cannot reach the mirrored Chrome',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -362,6 +362,7 @@ const zhCN = {
   'browser.quality.ultra': '超清',
   'browser.noDebuggableTab': '没有可调试的标签页',
   'browser.rotateTitle': '旋转画面 90°（手机竖屏看横屏）',
+  'browser.imeProxyLabel': '键盘输入代理（承接输入法组合）',
   'browser.connected': '已连接',
   'browser.disconnected': '未连接',
   'browser.launchFailed': '连不上镜像 Chrome',


### PR DESCRIPTION
## 问题

浏览器镜像面板（BrowserView）里点开远端页面的输入框后，无法输入中文：焦点落在普通
`div` 上，操作系统输入法只在焦点位于可编辑元素（input/textarea/contenteditable）
时才会启动组合（composition），敲拼音要么原样落下字母，要么组合中间态（`key`
为 `"Process"` / keyCode 229）被当特殊键丢弃，选好的词也没有事件把它带出来。

英文直接输入、Ctrl+C/V 走独立的 copy/paste 桥，都不受影响，只有依赖 IME 组合的
输入方式（中/日/韩文等）受阻。

## 方案

在舞台里加一个视觉隐藏的 `<textarea>` 承接焦点与输入法组合过程：

- 鼠标在画面按下时，焦点从 stage 改为落到这个隐藏 textarea 上（同时记录点击坐标，
  用于定位 textarea，让候选词窗口出现在输入位置附近）。
- 组合期间（`isComposing` / keyCode 229）`onKey` 不转发按键，避免打断输入法。
- `compositionend` 时把 textarea 里攒出的整段文本，通过既有的
  `{type:'key', sub:'char', text}` 消息一次性发往远端；后端 `Input.insertText`
  本就支持多字符文本（paste 路径已验证），**后端零改动**。
- 失焦时丢弃半截组合，避免残留拼音被误发。

aria-label 走 i18n（新增 `browser.imeProxyLabel` 键，中英文都补了）。

## 测试

- `npm run typecheck`：通过
- `node scripts/i18n-audit.mjs`：通过（1219 个 locale key）
- `scripts/dev/quality/check.sh quick`：通过

真实输入法组合无法自动化模拟，需人工验证：点击远端输入框 → 切中文输入法敲拼音
选词 → 中文正常上屏、组合中远端页面无字符跳动、英文/回车/Ctrl+C+V 无回归。
