### PR TITLE
fix(chat): AskUserQuestion 渲染成可读问题卡片

### DIFF
--- a/frontend/src/chat/ClaudeMessage.tsx
+++ b/frontend/src/chat/ClaudeMessage.tsx
@@ -28,11 +28,43 @@ function toolHead(name: string | undefined, o: any, t: (key: string, vars?: Reco
     case 'TodoWrite': return { icon: '☑', title: t('chat.todoCount', { count: (o?.todos || []).length }) }
     case 'WebFetch': return { icon: '🌐', title: clip(s(o?.url)) }
     case 'WebSearch': return { icon: '🌐', title: clip(s(o?.query)) }
+    case 'AskUserQuestion': {
+      const qs = Array.isArray(o?.questions) ? o.questions : []
+      const more = qs.length > 1 ? ` (+${qs.length - 1})` : ''
+      return { icon: '❓', title: clip(s(qs[0]?.question)) + more }
+    }
     default: {
       const key = o && ['command', 'file_path', 'path', 'pattern', 'query', 'prompt', 'description'].find((k) => o[k])
       return { icon: '⚙', title: clip(key ? s(o[key]) : (o ? JSON.stringify(o) : '')) }
     }
   }
+}
+
+// AskUserQuestion：每个问题一张卡片，列出候选项（纯展示，不回传选择）
+function AskQuestions({ questions }: { questions: any[] }) {
+  const { t } = useI18n()
+  return (
+    <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {questions.map((q: any, i: number) => (
+        <div key={i} style={{ border: '1px solid var(--border)', borderRadius: 6, background: 'var(--bg-base)', padding: '6px 8px', fontSize: 12.5, display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, flexWrap: 'wrap' }}>
+            {q?.header && <span style={{ color: 'var(--text-dim)', fontSize: 11 }}>{String(q.header)}</span>}
+            <span style={{ color: 'var(--text-bright)', fontWeight: 600 }}>{String(q?.question || '')}</span>
+            {q?.multiSelect === true && <span style={{ color: 'var(--text-dim)', fontSize: 11 }}>{t('chat.askMultiSelect')}</span>}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {(Array.isArray(q?.options) ? q.options : []).map((op: any, j: number) => (
+              <div key={j} style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <span style={{ color: 'var(--text-bright)', fontWeight: 600 }}>{String(op?.label ?? '')}</span>
+                {op?.description && <span style={{ color: 'var(--text-dim)' }}>{String(op.description)}</span>}
+                {op?.preview && <CodeBox text={String(op.preview)} max={220} />}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 // 工具调用的「详情体」：按工具类型展开有用信息
@@ -61,6 +93,7 @@ function ToolBody({ name, o, raw }: { name?: string; o: any; raw?: string }) {
   }
   if (name === 'Task') return <CodeBox text={o?.prompt || ''} max={260} />
   if (name === 'WebFetch') return <CodeBox text={o?.prompt || o?.url || ''} max={160} />
+  if (name === 'AskUserQuestion' && Array.isArray(o?.questions)) return <AskQuestions questions={o.questions} />
   const pretty = o ? JSON.stringify(o, null, 2) : (raw || '')
   return pretty ? <CodeBox text={pretty} /> : null
 }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -218,6 +218,7 @@ const enUS = {
   'chat.reasoning': 'Reasoning',
   'chat.tool': 'Tool',
   'chat.todoCount': '{count} todo item(s)',
+  'chat.askMultiSelect': 'Multi-select',
   'prompt.confirmRequired': 'Confirmation required',
   'prompt.yes': 'Yes (y)',
   'prompt.no': 'No (n)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -218,6 +218,7 @@ const zhCN = {
   'chat.reasoning': '推理',
   'chat.tool': '工具',
   'chat.todoCount': '{count} 项待办',
+  'chat.askMultiSelect': '多选',
   'prompt.confirmRequired': '需要你确认',
   'prompt.yes': '是 (y)',
   'prompt.no': '否 (n)',


### PR DESCRIPTION
## 问题

前端把 `AskUserQuestion` 当未知工具处理，工具详情体直接把整个 input 打成原始 JSON，用户看不清到底问了什么、有哪些候选项。

Closes #123

## 改动（`frontend/src/chat/ClaudeMessage.tsx`）

- `toolHead()` 增加 `case 'AskUserQuestion'`：图标 `❓`，标题取 `questions[0].question`；问题多于 1 个时末尾追加 ` (+N)`。
- `ToolBody()` 在默认 CodeBox 之前增加 `AskUserQuestion` 分支：每个问题渲染一张卡片
  - 头一行：`header` 小标签（`--text-dim`）+ 问题文本（`--text-bright`），`multiSelect` 为 true 时标注「多选」
  - 下面逐条列出 `options[]`：`label` 加粗（`--text-bright`），`description` 次要色（`--text-dim`）换行
  - `option.preview` 存在时复用现有 `CodeBox` 渲染
- 纯展示，不做点选回传；全部内联样式，沿用文件既有 CSS 变量与字号间距风格。

附带：按仓库 i18n 强制规范，「多选」文案走 `t('chat.askMultiSelect')`，在 `zh-CN.ts` / `en-US.ts` 各补一条词条（硬编码中文会被 `npm run i18n:check` 拦下、build 失败）。

## 验证

- `npm run typecheck` 通过
- `npm run i18n:check` 通过（1275 条词条）
- `npm run build` 通过

未自行合并，留给评审。
