### PR TITLE
fix(swarm): 给蜂群持久化工作目录 dir，修 CLI 建的群在项目视图不显示

### DIFF
--- a/cli/ttmux-cli-go/internal/command/swarm/members.go
+++ b/cli/ttmux-cli-go/internal/command/swarm/members.go
@@ -66,6 +66,11 @@ func adopt(rt runtime.Runtime, st *swarmcore.Store, swarm, cc, dir, prompt strin
 	if cc == "" {
 		cc = "cc-" + st.Name(swarm)
 	}
+	// 显式给了 --dir 就记进 meta：Web 项目视图按 dir 把蜂群归到项目(issue #125)。
+	// 没给就保持原值不动，避免 adopt 一次把建群时记的目录抹掉。
+	if abs := absDir(dir); abs != "" {
+		_ = st.MetaSet(swarm, "dir", abs)
+	}
 	if dir == "" {
 		dir = "."
 	}
@@ -110,7 +115,9 @@ func cmdAdopt(rt runtime.Runtime, st *swarmcore.Store, args []string, w io.Write
 		return fmt.Errorf("usage: ttmux swarm adopt <name> [--by <session>] [--dir <dir>] [--prompt <text>]")
 	}
 	swarm := args[0]
-	cc, dir, prompt := "", ".", ""
+	// dir 留空表示「没给 --dir」（adopt 内部再退回 "."），这样才分得清
+	// 「显式指定目录」和「沿用默认」，只有前者才写进 meta.dir
+	cc, dir, prompt := "", "", ""
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
 		case "--by":
@@ -131,6 +138,7 @@ type swarmListItem struct {
 	Status     string `json:"status"`
 	Supervisor string `json:"supervisor"`
 	Created    string `json:"created"`
+	Dir        string `json:"dir"` // 工作目录(绝对路径, 可空)：Web 按它把蜂群归到项目
 	Total      int    `json:"total"`
 	Alive      int    `json:"alive"`
 	Pending    int    `json:"pending"`
@@ -148,7 +156,7 @@ func cmdList(rt runtime.Runtime, st *swarmcore.Store, args []string, w io.Writer
 			total, alive := groupCounts(rt, s.Name)
 			items = append(items, swarmListItem{
 				ID: s.ID, Name: s.Name, Goal: s.Goal, Status: s.Status,
-				Supervisor: s.Supervisor, Created: s.Created,
+				Supervisor: s.Supervisor, Created: s.Created, Dir: s.Dir,
 				Total: total, Alive: alive, Pending: st.PendingCount(s.Name),
 			})
 		}

--- a/cli/ttmux-cli-go/internal/command/swarm/status.go
+++ b/cli/ttmux-cli-go/internal/command/swarm/status.go
@@ -29,6 +29,9 @@ func cmdStatusText(rt runtime.Runtime, st *swarmcore.Store, name string, w io.Wr
 	if stt.Goal != "" {
 		fmt.Fprintf(w, "    %s目标:%s %s\n", p.Dim, p.Reset, stt.Goal)
 	}
+	if stt.Dir != "" {
+		fmt.Fprintf(w, "    %s目录:%s %s\n", p.Dim, p.Reset, stt.Dir)
+	}
 	if stt.Supervisor != "" {
 		fmt.Fprintf(w, "    %s指挥:%s %s%s%s\n", p.Dim, p.Reset, p.Magenta, stt.Supervisor, p.Reset)
 	}

--- a/cli/ttmux-cli-go/internal/command/swarm/swarm.go
+++ b/cli/ttmux-cli-go/internal/command/swarm/swarm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"ttmux-cli-go/internal/command/group"
@@ -136,7 +137,16 @@ func cmdNew(rt runtime.Runtime, st *swarmcore.Store, args []string, w io.Writer)
 	if dir != "" {
 		_ = os.MkdirAll(dir, 0o755)
 	}
-	id, err := st.NewSwarm(name, goal)
+	// 绝对路径入库：Web 项目视图按 dir 归属蜂群(issue #125)，相对路径跨进程无意义
+	dirAbs := absDir(dir)
+	if dirAbs == "" && stdinIsTTY() {
+		// 人(或终端里的 agent)直接 `swarm new` 没给 --dir：Leader 就地在当前目录
+		// 起，那当前目录就是这个蜂群的工作目录，记下来 Web 才归得了项目。
+		// 后端(web)调 CLI 时 stdin 是管道，不走这条——否则会把服务进程的 cwd
+		// 当成蜂群目录，归到一个八竿子打不着的项目上。
+		dirAbs, _ = os.Getwd()
+	}
+	id, err := st.NewSwarm(name, goal, dirAbs)
 	if err != nil {
 		return err
 	}
@@ -355,6 +365,26 @@ func cmdRemove(rt runtime.Runtime, st *swarmcore.Store, args []string, w io.Writ
 	}
 	ui.Ok(w, "蜂群 %s 已删除", ui.Bold(name))
 	return nil
+}
+
+// absDir 把 --dir 规整成绝对路径（空值/"." 视为未指定，返回 ""）——落库的目录
+// 要能被 Web 端跟项目目录直接比对，相对路径取决于 CLI 当时的 cwd，没法比。
+func absDir(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" || dir == "." {
+		return ""
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return dir
+	}
+	return abs
+}
+
+// stdinIsTTY 判断 CLI 是不是人在终端里跑（后端转发时 stdin 是管道）。
+func stdinIsTTY() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func next(args []string, i int) (string, int) {

--- a/cli/ttmux-cli-go/internal/swarm/dir_test.go
+++ b/cli/ttmux-cli-go/internal/swarm/dir_test.go
@@ -1,0 +1,86 @@
+package swarm
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func testOpts(t *testing.T) Options {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "h")
+	return Options{HomeDir: home, DataDir: filepath.Join(home, "data"), Now: func() time.Time { return time.Unix(100, 0) }}
+}
+
+// 建群时记下的工作目录要能从 swarm ls / swarm status 两条路读回来——
+// Web 项目视图就是靠它归属蜂群的(issue #125)。
+func TestSwarmDirRoundTrip(t *testing.T) {
+	opt := testOpts(t)
+	st := NewStore(opt)
+	if _, err := st.NewSwarm("sw", "goal", "/tmp/proj-a"); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := st.ListSwarms()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Dir != "/tmp/proj-a" {
+		t.Fatalf("ListSwarms dir=%+v want /tmp/proj-a", rows)
+	}
+	stt, err := Status("sw", opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stt.Dir != "/tmp/proj-a" {
+		t.Errorf("Status dir=%q want /tmp/proj-a", stt.Dir)
+	}
+	// adopt --dir 走 MetaSet 改目录
+	if err := st.MetaSet("sw", "dir", "/tmp/proj-b"); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.MetaGet("sw", "dir"); got != "/tmp/proj-b" {
+		t.Errorf("MetaGet dir=%q want /tmp/proj-b", got)
+	}
+}
+
+// 老库(没有 dir 列)打开时应就地补列，且补两次不报错。
+func TestMetaDirMigrationIdempotent(t *testing.T) {
+	opt := testOpts(t)
+	if err := os.MkdirAll(opt.HomeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(opt.HomeDir, "meta.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE swarms(id TEXT PRIMARY KEY, name TEXT UNIQUE, goal TEXT, status TEXT, supervisor TEXT, created TEXT);
+		INSERT INTO swarms(id,name,goal,status,supervisor,created) VALUES('sw1','old','g','running','','2026-06-22 10:00:00');`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	st := NewStore(opt)
+	for i := 0; i < 2; i++ {
+		if err := st.MetaInit(); err != nil {
+			t.Fatalf("MetaInit #%d: %v", i+1, err)
+		}
+	}
+	rows, err := st.ListSwarms()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Name != "old" || rows[0].Dir != "" {
+		t.Fatalf("ListSwarms=%+v want one row 'old' with empty dir", rows)
+	}
+	if err := st.MetaSet("old", "dir", "/tmp/legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if got := st.MetaGet("old", "dir"); got != "/tmp/legacy" {
+		t.Errorf("MetaGet dir=%q want /tmp/legacy", got)
+	}
+}

--- a/cli/ttmux-cli-go/internal/swarm/store.go
+++ b/cli/ttmux-cli-go/internal/swarm/store.go
@@ -56,10 +56,12 @@ func (s *Store) MetaInit() error {
 		return err
 	}
 	defer db.Close()
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS swarms(
+	if _, err = db.Exec(`CREATE TABLE IF NOT EXISTS swarms(
 		id TEXT PRIMARY KEY, name TEXT UNIQUE, goal TEXT,
-		status TEXT, supervisor TEXT, created TEXT)`)
-	return err
+		status TEXT, supervisor TEXT, created TEXT, dir TEXT)`); err != nil {
+		return err
+	}
+	return migrateMetaDB(db)
 }
 
 // ResolveID maps a name-or-id to its id ("" if unknown).
@@ -122,7 +124,7 @@ func (s *Store) MetaSet(nameOrID, col, val string) error {
 // metaCol whitelists the swarm columns to keep MetaGet/Set injection-safe.
 func metaCol(col string) string {
 	switch col {
-	case "goal", "status", "supervisor", "created", "name", "id":
+	case "goal", "status", "supervisor", "created", "name", "id", "dir":
 		return col
 	}
 	return "status"

--- a/cli/ttmux-cli-go/internal/swarm/subrole_test.go
+++ b/cli/ttmux-cli-go/internal/swarm/subrole_test.go
@@ -24,7 +24,7 @@ func TestSubroleDutyRoundTrip(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "h")
 	opt := Options{HomeDir: home, DataDir: filepath.Join(home, "data"), Now: func() time.Time { return time.Unix(100, 0) }}
 	st := NewStore(opt)
-	if _, err := st.NewSwarm("sw", "goal"); err != nil {
+	if _, err := st.NewSwarm("sw", "goal", ""); err != nil {
 		t.Fatal(err)
 	}
 	// 细分角色用别名写入，应被 SubroleNorm 归一为 frontend

--- a/cli/ttmux-cli-go/internal/swarm/swarm.go
+++ b/cli/ttmux-cli-go/internal/swarm/swarm.go
@@ -28,6 +28,7 @@ type SwarmStatus struct {
 	Status         string         `json:"status"`
 	Supervisor     string         `json:"supervisor"`
 	Created        string         `json:"created"`
+	Dir            string         `json:"dir"` // 工作目录(绝对路径, 可空)：Web 按它把蜂群归到项目
 	LeaderLastPost int64          `json:"leader_last_post"`
 	Members        []SwarmMember  `json:"members"`
 	Pending        []SwarmPending `json:"pending"`
@@ -60,6 +61,7 @@ type swarmMeta struct {
 	Status     string
 	Supervisor string
 	Created    string
+	Dir        string
 }
 
 func DefaultOptions() Options {
@@ -214,6 +216,10 @@ func Status(name string, opt Options) (*SwarmStatus, error) {
 		return nil, err
 	}
 	defer metaDB.Close()
+	// 老库没有 dir 列：读之前补一次(幂等)，否则 findSwarm 的 SELECT 会整条失败
+	if err := migrateMetaDB(metaDB); err != nil {
+		return nil, err
+	}
 
 	meta, err := findSwarm(metaDB, name)
 	if err != nil {
@@ -234,6 +240,7 @@ func Status(name string, opt Options) (*SwarmStatus, error) {
 		Status:         meta.Status,
 		Supervisor:     meta.Supervisor,
 		Created:        meta.Created,
+		Dir:            meta.Dir,
 		LeaderLastPost: readLeaderLastPost(opt.HomeDir, meta.ID),
 		Members:        []SwarmMember{},
 		Pending:        []SwarmPending{},
@@ -312,13 +319,32 @@ func openSQLite(path string) (*sql.DB, error) {
 
 func findSwarm(db *sql.DB, name string) (swarmMeta, error) {
 	var m swarmMeta
-	err := db.QueryRow(`SELECT id, name, IFNULL(goal,''), IFNULL(status,''), IFNULL(supervisor,''), IFNULL(created,'')
+	err := db.QueryRow(`SELECT id, name, IFNULL(goal,''), IFNULL(status,''), IFNULL(supervisor,''), IFNULL(created,''), IFNULL(dir,'')
 		FROM swarms WHERE name=? OR id=? LIMIT 1`, name, name).
-		Scan(&m.ID, &m.Name, &m.Goal, &m.Status, &m.Supervisor, &m.Created)
+		Scan(&m.ID, &m.Name, &m.Goal, &m.Status, &m.Supervisor, &m.Created, &m.Dir)
 	if errors.Is(err, sql.ErrNoRows) {
 		return m, fmt.Errorf("swarm not found: %s", name)
 	}
 	return m, err
+}
+
+// migrateMetaDB brings an existing meta.db up to the current swarms schema.
+// Only additive column migrations live here, so it is idempotent and safe to
+// run on every open: a column that already exists is simply skipped, and a
+// failing ALTER (read-only db, racing writer) degrades to the old behaviour
+// instead of breaking the read path.
+func migrateMetaDB(db *sql.DB) error {
+	cols, err := tableColumns(db, "swarms")
+	if err != nil {
+		return err
+	}
+	if !cols["dir"] {
+		if _, err := db.Exec(`ALTER TABLE swarms ADD COLUMN dir TEXT`); err != nil &&
+			!strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+			return err
+		}
+	}
+	return nil
 }
 
 func migrateSwarmDB(db *sql.DB) error {

--- a/cli/ttmux-cli-go/internal/swarm/write.go
+++ b/cli/ttmux-cli-go/internal/swarm/write.go
@@ -23,11 +23,13 @@ type MemberSpec struct {
 
 // SwarmRow is one swarm in the registry listing.
 type SwarmRow struct {
-	ID, Name, Goal, Status, Supervisor, Created string
+	ID, Name, Goal, Status, Supervisor, Created, Dir string
 }
 
 // NewSwarm inserts a planning swarm and initializes its db. Returns the id.
-func (s *Store) NewSwarm(name, goal string) (string, error) {
+// dir 是蜂群的工作目录(绝对路径, 可空)——Web 项目视图按它把蜂群归到项目，
+// 不能只靠成员会话名(ls --json 会把蜂群会话过滤掉，见 issue #125)。
+func (s *Store) NewSwarm(name, goal, dir string) (string, error) {
 	if err := s.MetaInit(); err != nil {
 		return "", err
 	}
@@ -37,8 +39,8 @@ func (s *Store) NewSwarm(name, goal string) (string, error) {
 	}
 	defer db.Close()
 	id := s.NewID()
-	_, err = db.Exec(`INSERT INTO swarms(id,name,goal,status,supervisor,created)
-		VALUES(?,?,?,'planning','',?)`, id, name, goal, s.opt.Now().Format("2006-01-02 15:04:05"))
+	_, err = db.Exec(`INSERT INTO swarms(id,name,goal,status,supervisor,created,dir)
+		VALUES(?,?,?,'planning','',?,?)`, id, name, goal, s.opt.Now().Format("2006-01-02 15:04:05"), dir)
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +62,7 @@ func (s *Store) ListSwarms() ([]SwarmRow, error) {
 		return nil, err
 	}
 	defer db.Close()
-	rows, err := db.Query(`SELECT id,name,IFNULL(goal,''),IFNULL(status,''),IFNULL(supervisor,''),IFNULL(created,'') FROM swarms ORDER BY created`)
+	rows, err := db.Query(`SELECT id,name,IFNULL(goal,''),IFNULL(status,''),IFNULL(supervisor,''),IFNULL(created,''),IFNULL(dir,'') FROM swarms ORDER BY created`)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +70,7 @@ func (s *Store) ListSwarms() ([]SwarmRow, error) {
 	var out []SwarmRow
 	for rows.Next() {
 		var r SwarmRow
-		if err := rows.Scan(&r.ID, &r.Name, &r.Goal, &r.Status, &r.Supervisor, &r.Created); err != nil {
+		if err := rows.Scan(&r.ID, &r.Name, &r.Goal, &r.Status, &r.Supervisor, &r.Created, &r.Dir); err != nil {
 			return nil, err
 		}
 		out = append(out, r)

--- a/docs/design/swarm/蜂群 Web 接入设计.md
+++ b/docs/design/swarm/蜂群 Web 接入设计.md
@@ -93,19 +93,21 @@ swarm task rm     <群> <卡id>
 ### 4.2 给 `swarm ls` / `swarm status` 加 `--json`
 
 现 `_swarm_ls` / `_swarm_status` 只有彩色文本；web 列表/详情需要结构化。新增：
-- `swarm ls --json` → `[{name,id,goal,status,supervisor,created,total,alive,pending}]`
-- `swarm status <群> --json` → `{name,goal,status,supervisor,created, members:[{name,type,task,status,done,pending,deps}], pending:[...], done_marked:[...]}`
+- `swarm ls --json` → `[{name,id,goal,status,supervisor,created,dir,total,alive,pending}]`
+- `swarm status <群> --json` → `{name,goal,status,supervisor,created,dir, members:[{name,type,task,status,done,pending,deps}], pending:[...], done_marked:[...]}`
   成员存活/状态复用既有 `_status_json`（`status.sh`）或 `_group_sessions` + `_session_exists` 拼装。
+  `dir` = 蜂群工作目录（绝对路径，可空），`swarm new/adopt --dir` 落库。项目视图按它把蜂群
+  归到项目——不能只靠成员会话名，因为 `ttmux ls --json` 按设计会过滤掉所有蜂群会话（issue #125）。
 
 ### 4.3 JSON 契约（前后端共识，字段名定死）
 
 ```jsonc
 // GET /api/swarms            ← swarm ls --json
 [{"name":"login","id":"2026-0616-1356-aqzq","goal":"加登录","status":"running",
-  "supervisor":"cc-login","total":3,"alive":2,"pending":1}]
+  "supervisor":"cc-login","dir":"/home/me/codes/app","total":3,"alive":2,"pending":1}]
 
 // GET /api/swarms/:n         ← swarm status :n --json
-{"name":"login","goal":"...","status":"running","supervisor":"cc-login",
+{"name":"login","goal":"...","status":"running","supervisor":"cc-login","dir":"/home/me/codes/app",
  "members":[{"name":"api","type":"agent","task":"实现登录API","status":"running","done":0,"deps":""}],
  "pending":[{"name":"web","deps":"api"}], "done_marked":["api"]}
 

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -429,6 +429,12 @@ function tailLine(raw: string): string {
   return (lines[lines.length - 1] || '').slice(0, 90)
 }
 
+// 目录规整：去尾斜杠 + 折叠重复斜杠，用于蜂群 dir 与项目 dir 的等值比较
+function normDir(p: string): string {
+  const s = String(p || '').trim().replace(/\/{2,}/g, '/').replace(/\/+$/, '')
+  return s
+}
+
 // ── P2 项目主页：头部 + composer(hero) + 任务流/Worktree/编队/活动 ──
 function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }: {
   proj?: Proj; allProjects: Proj[]; loaded: boolean; openTerm: (n: string) => void; closeTerm: (n: string) => void; refresh: () => void
@@ -581,7 +587,11 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
     const claimedByDeeper = (c: string) => deeper.some((d) => c === d || c.startsWith(d + '/'))
     return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(s.cwd) && !claimedByDeeper(s.cwd))
   }, [sessions, ann, dir, isGit, allProjects])
-  // 蜂群归属（08 §2.2）：swarm ls 无 dir 字段——按「指挥/成员会话 ∈ 本项目会话」现算
+  // 蜂群归属（08 §2.2）：两条判据取并集
+  //  1) 蜂群自报的工作目录 dir == 本项目目录（swarm new/adopt --dir 落库，CLI 建的群靠这条）
+  //  2) 「指挥/成员会话 ∈ 本项目会话」现算（老蜂群没有 dir，保留兼容）
+  // 光靠 2) 不够：项目会话来自 ttmux ls --json，而它按设计过滤掉所有蜂群会话，
+  // 于是 CLI 建的群 inProj 恒为 0、永远不显示（issue #125）。
   const mineKey = useMemo(() => mine.map((s) => s.name).sort().join('\n'), [mine])
   useEffect(() => {
     if (!isGit) return
@@ -590,6 +600,7 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
       try {
         const list = await api('GET', '/swarms')
         const names = new Set(mineKey.split('\n').filter(Boolean))
+        const here = normDir(dir)
         const active = (Array.isArray(list) ? list : []).filter((s: any) => s.status !== 'archived')
         const out: any[] = []
         await Promise.all(active.map(async (sw: any) => {
@@ -597,7 +608,12 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
             const st = await api('GET', `/swarms/${encodeURIComponent(sw.name)}`)
             const members = (st?.members || []) as any[]
             const inProj = members.filter((m: any) => names.has(m.session)).length + (st?.supervisor && names.has(st.supervisor) ? 1 : 0)
-            if (inProj > 0) out.push({ ...sw, inProj, roster: members.length + (st?.supervisor ? 1 : 0), supervisor: st?.supervisor || '', members })
+            const swDir = normDir(sw.dir || st?.dir || '')
+            const byDir = !!here && !!swDir && swDir === here
+            const roster = members.length + (st?.supervisor ? 1 : 0)
+            // 认了 dir 的群，整支班子都算本项目的：它的会话本来就被 ls 过滤掉了，
+            // 按会话数算会显示成 0/N 且每行都标「跨项目」。
+            if (inProj > 0 || byDir) out.push({ ...sw, inProj: byDir ? roster : inProj, byDir, roster, supervisor: st?.supervisor || '', members })
           } catch {}
         }))
         if (!stop) setSwarms(out.sort((a, b) => String(a.name).localeCompare(String(b.name))))
@@ -606,7 +622,7 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
     loadSwarms()
     const i = setInterval(loadSwarms, 10000)
     return () => { stop = true; clearInterval(i) }
-  }, [isGit, mineKey])
+  }, [isGit, mineKey, dir])
   // Agent 运行标注 + 待输入检测（仅本项目会话，量小）
   useEffect(() => {
     let stop = false
@@ -1151,7 +1167,8 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
             const ex = swarmExtras[sw.name]
             const mineNames = new Set(mine.map((x) => x.name))
             const memberRow = (session: string, role: string, subrole?: string, done?: boolean, status?: string) => {
-              const inProj = mineNames.has(session)
+              // 按 dir 认领的群：成员会话不在 ls 清单里（被蜂群过滤挡掉），但确实属于本项目
+              const inProj = mineNames.has(session) || !!sw.byDir
               const running = cc[session] || cx[session] || status === 'running'
               return (
                 <div key={session} className="prj-subrow" style={{ opacity: inProj ? 1 : 0.45 }}


### PR DESCRIPTION
## 问题

CLI 创建的蜂群在 Web 项目视图里永远不显示。

## 根因

项目视图判定蜂群归属，此前唯一依据是「指挥/成员会话名 ∈ 本项目会话集合」（`frontend/src/Projects.tsx`），而项目会话集合来自 `ttmux ls --json`（`backend/api/project.go`）——它按设计过滤掉全部蜂群会话（`cli/ttmux-cli-go/internal/app/app.go` 的 `swarmSessions()`）。

归属所需的会话恰好是被过滤掉的那些，于是 `inProj` 恒为 0，蜂群永远进不了项目视图。

## 方案（治本）

给蜂群持久化工作目录 `dir`，前端改为按目录归属。

- **建表/迁移**：`swarms` 表加 `dir` 文本列；老库打开时幂等补列（`ALTER TABLE swarms ADD COLUMN dir TEXT`，已有则跳过，duplicate column 类报错忽略）。读路径 `Status` 也先补一次，否则老库上 `SELECT dir` 会整条失败。
- **写入**：`swarm new --dir` / `swarm adopt --dir` 把目录规整成绝对路径写进 `dir` 列。`adopt` 只在显式给了 `--dir` 时才写，免得一次接管把建群时记的目录抹掉。`swarm new` 在终端里没给 `--dir` 时记录 cwd（Leader 本来就在 cwd 起）；后端转发 CLI 时 stdin 是管道，不走这条，避免把服务进程的 cwd 当成蜂群目录。
- **输出**：`swarm ls --json`、`swarm status --json` 输出 `dir`；`swarm status` 文本视图也显示「目录」。后端 `/api/swarms` 原样透传 CLI JSON，无字段白名单，无需改动。
- **前端**：归属改为两条判据取并集——`dir` 相等（路径规整后比较）**或**原有会话启发式（保留，老蜂群没有 `dir`，向后兼容）。按 `dir` 认领的群，成员行不再全标「跨项目」且可点进会话。
- 同步更新设计文档里的 JSON 契约。

## 验证

- `go build ./...` + `go test ./...`（cli 与 backend）通过；新增 `internal/swarm/dir_test.go` 覆盖 dir 往返与老库幂等迁移，既有 `TestStatusJSONCompat` 本身就用无 `dir` 列的老 schema，顺带覆盖迁移读路径。
- 前端 `tsc --noEmit` + `npm run build`（含 i18n audit）通过。
- 隔离 `ROAM_HOME` 下实测（未碰线上库、未起/杀任何会话）：`swarm new demo --dir /tmp/proj-x --no-master` 后，`swarm ls --json` 与 `swarm status demo --json` 均带 `"dir":"/tmp/proj-x"`。

Closes #125
