### PR TITLE
feat(files): 文件行悬浮显示完整名字，预览悬浮窗加宽

### DIFF
--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -159,7 +159,10 @@ function FileRowBody({ full, name, isDir, size, accent, onInsertPath, onDownload
   return (
     <>
       <span style={{ color: isDir ? accent : 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 22, justifyContent: 'center' }}>{isDir ? <FolderIcon /> : <FileTypeIcon name={name} />}</span>
-      <span style={{ color: 'var(--text-bright)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</span>
+      {/* 面板窄时名字被省略号截断 → 悬浮显示完整名字（长名换行显示，不再被裁掉） */}
+      <Tooltip title={name} placement="topLeft" mouseEnterDelay={0.4} styles={{ root: { maxWidth: 420, wordBreak: 'break-all' } }}>
+        <span style={{ color: 'var(--text-bright)', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</span>
+      </Tooltip>
       {!isDir && <span style={{ color: 'var(--text-dimmer)', fontSize: 11, flex: '0 0 auto' }}>{fmtSize(size)}</span>}
       {onInsertPath && (
         <span data-file-action>
@@ -796,15 +799,17 @@ export default function FileBrowser({
             <>
               {searchTrunc && <div style={{ color: '#d29922', fontSize: 11, padding: '4px 10px' }}>{t('file.searchTruncated')}</div>}
               {(results || []).map((r) => (
-                <div key={r.path} className="cc-filerow" draggable title={r.rel}
+                <div key={r.path} className="cc-filerow" draggable
                   onDragStart={(ev) => startPathDrag(ev, r.path)}
                   onClick={() => openFile(r.path)}
                   style={{ ...rowStyle(), background: r.path === sel ? '#1f6feb22' : undefined }}>
                   <span style={{ color: 'var(--text-dimmer)', flex: '0 0 auto', display: 'inline-flex', width: 25, justifyContent: 'center' }}><FileTypeIcon name={r.name} /></span>
-                  <span style={{ flex: 1, minWidth: 0 }}>
-                    <span style={{ color: 'var(--text-bright)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.name}</span>
-                    <span style={{ color: 'var(--text-dimmer)', fontSize: 11, display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.rel}</span>
-                  </span>
+                  <Tooltip title={<><div>{r.name}</div><div style={{ opacity: .65, fontSize: 11 }}>{r.rel}</div></>} placement="topLeft" mouseEnterDelay={0.4} styles={{ root: { maxWidth: 420, wordBreak: 'break-all' } }}>
+                    <span style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ color: 'var(--text-bright)', display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.name}</span>
+                      <span style={{ color: 'var(--text-dimmer)', fontSize: 11, display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.rel}</span>
+                    </span>
+                  </Tooltip>
                 </div>
               ))}
             </>

--- a/frontend/src/fileview/FileView.tsx
+++ b/frontend/src/fileview/FileView.tsx
@@ -260,7 +260,8 @@ export function FileView({
   }
 
   return (
-    <Modal open onCancel={onClose} footer={null} width="min(900px,94vw)" title={titleNode}>
+    // 弹窗预览：代码/表格/PDF 在窄弹窗里很难看 → 尽量吃满视口宽度（大屏封顶 1440），并上移留出更高正文。
+    <Modal open onCancel={onClose} footer={null} width="min(1440px, 94vw)" style={{ top: 40 }} title={titleNode}>
       <ErrorBoundary>{bodyNode}</ErrorBoundary>
     </Modal>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -188,8 +188,9 @@ body {
   transform: translateZ(0);
   contain: layout paint;
 }
+/* 悬浮抽屉旁的文件/差异预览面板：吃满抽屉左侧剩余宽度（大屏封顶 1440），窄弹窗看代码太挤 */
 .tt-file-detail {
-  width: min(760px, calc(100vw - min(420px, 92vw)));
+  width: min(1440px, calc(100vw - min(420px, 92vw)));
   min-width: 360px;
 }
 .tt-file-drawer .ant-btn,


### PR DESCRIPTION
## 背景
文件管理里名字在窄面板被省略号截断看不全；点开文件的预览悬浮窗只有 900px，看代码/表格/PDF 太挤。

## 改动
- **悬浮显示文件名**：`FileRowBody` 名字列加 antd `Tooltip`（0.4s 延迟，最宽 420px、长名换行）。平铺列表与 VSCode 树共用该组件，两种模式都生效。搜索结果行原来只有原生 `title`，换成同款 Tooltip，第一行文件名、第二行相对路径。
- **预览悬浮窗加宽**：`FileView` 弹窗 `width` `min(900px,94vw)` → `min(1440px,94vw)`，并 `top: 40` 上移留出更高正文。
- **抽屉旁预览面板加宽**：`.tt-file-detail`（sidebar 语境的文件预览，Git diff 面板共用）宽度上限 `760px` → `1440px`，仍是吃满抽屉左侧剩余宽度；`max-width: 760px` 的移动端规则不变。

## 验证
- `tsc --noEmit` 通过，提交钩子的 i18n audit / Go 测试全绿。
- `npm run build` 通过，已部署到本机 dist 实机看过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)