### PR TITLE
fix(project): 会话归属在创建时钉死，cd 走不再掉出项目

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -28,7 +28,7 @@ type API struct {
 }
 
 func New(tt *ttmux.Client, browserHome, dataDir string) *API {
-	return &API{TT: tt, WT: worktree.New(), BrowserHome: browserHome, Football: NewFootballStore(), Speech: NewSpeechStore(dataDir), Prefs: NewPreferencesStore(dataDir), Races: NewRaceStore(dataDir), Projects: project.NewStore(dataDir)}
+	return &API{TT: tt, WT: worktree.New(dataDir), BrowserHome: browserHome, Football: NewFootballStore(), Speech: NewSpeechStore(dataDir), Prefs: NewPreferencesStore(dataDir), Races: NewRaceStore(dataDir), Projects: project.NewStore(dataDir)}
 }
 
 // json 透传 ttmux 的 --json 输出
@@ -123,6 +123,9 @@ func (a *API) NewSession(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
 		return
 	}
+	// 在哪个目录建的，就永远属于那个项目——之后终端里 cd 去哪都不改归属。
+	// （不等轮询采样才钉：新会话头几秒就 cd 走的话会钉错。）
+	a.WT.BindSessionHome(b.Name, strings.TrimSpace(b.Dir))
 	c.JSON(http.StatusOK, gin.H{"data": ttmux.StripANSI(out), "name": b.Name})
 }
 
@@ -151,15 +154,18 @@ func (a *API) RenameSession(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
 		return
 	}
+	a.WT.RenameSessionHome(oldName, newName) // 归属跟着新名字走，改名不掉出项目
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"name": newName}})
 }
 
 // 走 ttmux kill --yes（非交互）：孤儿收养/meta 清理在 CLI 内完成；?cascade=1 级联杀子树。
 func (a *API) KillSession(c *gin.Context) {
-	args := []string{"kill", sessionParam(c), "--yes"}
+	name := sessionParam(c)
+	args := []string{"kill", name, "--yes"}
 	if c.Query("cascade") == "1" {
 		args = append(args, "--cascade")
 	}
+	a.WT.ForgetSessionHome(name) // 同名会话重建不继承旧归属（级联杀掉的子会话由 reconcile 收敛）
 	a.text(c, args...)
 }
 func (a *API) Capture(c *gin.Context) {

--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -97,7 +97,8 @@ func (a *API) ProjectsList(c *gin.Context) {
 	}
 	ann := a.WT.Annotations(ctx)
 
-	// 发现：会话 cwd join 命中的仓库自动记入台账（读路径副作用，无注册流程）
+	// 发现：会话归属目录(home，见 worktree/sessionhome.go)命中的仓库自动记入台账
+	// （读路径副作用，无注册流程）。归属钉死在建会话时的目录，用户 cd 走不改归属。
 	for _, an := range ann {
 		if an.Primary != nil && an.Primary.Repo != "" {
 			a.Projects.Touch(an.Primary.Repo)
@@ -229,7 +230,7 @@ func (a *API) ProjectsList(c *gin.Context) {
 		finish(&p, top)
 	}
 
-	// 非 git 项目：pane cwd 目录前缀认领未归属会话。同一会话归**最深(最长前缀)**
+	// 非 git 项目：按会话 home 目录前缀认领未归属会话。同一会话归**最深(最长前缀)**
 	// 的非 git 项目——嵌套目录(父/子都是非 git 项目，如 /codes 与 /codes/tmp)不能按
 	// map 迭代序抢占，否则父项目先跑就把子目录会话抢走，计数在父/子间随机漂移
 	// （详情页各按自身 dir 认领无此去重，于是子项目外层 0、里层 1）。对齐 worktree

--- a/backend/api/race.go
+++ b/backend/api/race.go
@@ -132,6 +132,7 @@ func (a *API) RaceCreate(c *gin.Context) {
 			fail("session: " + ttmux.StripANSI(out))
 			continue
 		}
+		a.WT.BindSessionHome(ct.Session, b.Dir) // 选手会话归属本仓库；cdInto 之后改钉到各自 worktree
 		wt, err := a.WT.Create(ctx, worktree.CreateReq{Dir: b.Dir, Branch: autoBranch(b.Name) + "-" + letter, Base: b.Base})
 		if err != nil {
 			_, _ = a.TT.Run("kill", ct.Session, "--yes")

--- a/backend/api/worktree.go
+++ b/backend/api/worktree.go
@@ -293,6 +293,9 @@ func shellQuote(s string) string {
 // 键入先于前端随后发送的 agent 启动指令，shell 按序执行，且 cd 留在回滚里可见。
 // pane 目标必须写 =name:（精确会话+缺省窗口）：tmux 3.4 send-keys 对裸 =name 报 can't find pane。
 func (a *API) cdInto(session, path string) error {
+	// 编排层把会话挪进某目录 = 它以后属于那儿（建 worktree 会话/竞赛/派生都走这里）。
+	// 归属钉死后不再随用户在终端里的 cd 漂移。
+	a.WT.BindSessionHome(session, path)
 	if _, err := a.TT.Run("send-keys", "-t", "="+session+":", "-l", "cd "+shellQuote(path)); err != nil {
 		return err
 	}
@@ -322,6 +325,7 @@ func (a *API) WorktreeSessionCreate(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "SESSION_FAILED", "message": ttmux.StripANSI(out)}})
 		return
 	}
+	a.WT.BindSessionHome(b.Name, b.Dir) // 先钉在仓库上；worktree 建成后 cdInto 会改钉到 worktree
 	branch := strings.TrimSpace(b.Branch)
 	if branch == "" {
 		branch = autoBranch(b.Name)
@@ -357,6 +361,12 @@ func (a *API) SessionFork(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "FORK_FAILED", "message": ttmux.StripANSI(out)}})
 		return
+	}
+	// 子会话继承父的归属（fork 缺省就是继承父 cwd）：显式 dir 优先，否则跟父同项目。
+	if d := strings.TrimSpace(b.Dir); d != "" {
+		a.WT.BindSessionHome(b.Child, d)
+	} else if home := a.WT.SessionHome(parent); home != "" {
+		a.WT.BindSessionHome(b.Child, home)
 	}
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"session": b.Child, "parent": parent}, "name": b.Child})
 }
@@ -400,6 +410,7 @@ func (a *API) SessionForkWorktree(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "FORK_FAILED", "message": ttmux.StripANSI(out)}})
 		return
 	}
+	a.WT.BindSessionHome(b.Child, dir) // 先钉父仓库，下面 cdInto 改钉到新 worktree
 	var forked map[string]string
 	_ = json.Unmarshal([]byte(out), &forked)
 	branch := strings.TrimSpace(b.Branch)

--- a/backend/worktree/service.go
+++ b/backend/worktree/service.go
@@ -48,6 +48,7 @@ type Service struct {
 	mu     sync.Mutex
 	cache  map[string]listCache   // key: commonDir
 	remote map[string]remoteState // key: commonDir（Sync 的远端观测，进程内缓存）
+	homes  *homeStore             // session → 钉死的归属目录（见 sessionhome.go）
 }
 
 type listCache struct {
@@ -63,8 +64,9 @@ type remoteState struct {
 	heads map[string]bool
 }
 
-func New() *Service {
-	return &Service{cache: map[string]listCache{}, remote: map[string]remoteState{}}
+// New 建服务；dataDir 为空表示不持久化会话归属（测试用），生产由 api.New 传入。
+func New(dataDir string) *Service {
+	return &Service{cache: map[string]listCache{}, remote: map[string]remoteState{}, homes: newHomeStore(dataDir)}
 }
 
 const listCacheTTL = 3 * time.Second
@@ -683,7 +685,8 @@ func underPath(p, root string) bool {
 func (s *Service) joinSessions(ctx context.Context, list []Worktree) []Worktree {
 	out := make([]Worktree, len(list))
 	copy(out, list)
-	panes := tmuxPanes(ctx)
+	// 按会话钉死的 home 目录归属（不是实时 pane cwd）：cd 走了也还挂在原 worktree 下。
+	panes := homePanes(s.sessionHomes(ctx))
 	for i := range out {
 		out[i].Sessions = nil
 	}
@@ -715,9 +718,10 @@ func (s *Service) joinSessions(ctx context.Context, list []Worktree) []Worktree 
 // ── Annotations（跨仓库：session → worktree 归属）─────────
 
 type Annotation struct {
+	Home      string          `json:"home"` // 会话钉死的归属目录（非 git 项目按它做前缀归属）
 	Primary   *AnnotationHit  `json:"primary,omitempty"`
 	Matches   []AnnotationHit `json:"matches"`
-	Ambiguous bool            `json:"ambiguous"`
+	Ambiguous bool            `json:"ambiguous"` // 保留字段：归属已钉死为单一 home，恒 false
 }
 
 type AnnotationHit struct {
@@ -779,12 +783,12 @@ type RepoWorktrees struct {
 	Worktrees []Worktree `json:"worktrees"`
 }
 
-// ListAll 汇总当前全部会话（pane cwd）触达的仓库的 worktree 清单——W4 跨仓库总览。
-// 仓库集合来自 cwd join（5s 缓存），逐仓库 List（3s 缓存），单仓库失败跳过不拖累整体。
+// ListAll 汇总当前全部会话（归属目录）触达的仓库的 worktree 清单——W4 跨仓库总览。
+// 仓库集合来自 home join（5s 缓存），逐仓库 List（3s 缓存），单仓库失败跳过不拖累整体。
 func (s *Service) ListAll(ctx context.Context) []RepoWorktrees {
 	seen := map[string]bool{}
 	var repos []string
-	for _, p := range tmuxPanes(ctx) {
+	for _, p := range homePanes(s.sessionHomes(ctx)) {
 		hit := resolveCwd(ctx, p.Cwd)
 		if hit == nil || hit.Repo == "" || seen[hit.Repo] {
 			continue
@@ -804,50 +808,31 @@ func (s *Service) ListAll(ctx context.Context) []RepoWorktrees {
 	return out
 }
 
-// SessionCwds 全部会话的 pane cwd 快照（canonical）。供非 git 项目按目录
-// 前缀归属会话（08：项目不与 git 绑定，git 只是可选能力）。
+// SessionCwds 全部会话的**归属目录**快照（canonical，每会话一条）。供非 git 项目
+// 按目录前缀归属会话（08：项目不与 git 绑定，git 只是可选能力）。
+// 这里刻意不给实时 pane cwd：会话 cd 出去不该换项目（见 sessionhome.go）。
 func (s *Service) SessionCwds(ctx context.Context) map[string][]string {
 	out := map[string][]string{}
-	for _, p := range tmuxPanes(ctx) {
-		out[p.Session] = append(out[p.Session], canonical(p.Cwd))
+	for sess, home := range s.sessionHomes(ctx) {
+		out[sess] = []string{home}
 	}
 	return out
 }
 
-// Annotations 返回 {session → {primary, matches[], ambiguous}}。
+// Annotations 返回 {session → {home, primary, matches[]}}。
+// 归属按会话钉死的 home 目录现算：分支/worktree 状态实时（home 里切分支照样变），
+// 但「属于哪个仓库/worktree」不随 pane cwd 漂移。非 git 的 home 也会给出条目
+// （只有 home 字段），让非 git 项目也能按前缀认领会话。
 func (s *Service) Annotations(ctx context.Context) map[string]*Annotation {
 	res := map[string]*Annotation{}
-	for _, p := range tmuxPanes(ctx) {
-		hit := resolveCwd(ctx, p.Cwd)
-		if hit == nil {
-			continue
-		}
-		a := res[p.Session]
-		if a == nil {
-			a = &Annotation{}
-			res[p.Session] = a
-		}
-		dup := false
-		for _, m := range a.Matches {
-			if m.Worktree == hit.Worktree {
-				dup = true
-				break
-			}
-		}
-		if !dup {
-			a.Matches = append(a.Matches, *hit)
-		}
-		if p.Active {
+	for sess, home := range s.sessionHomes(ctx) {
+		a := &Annotation{Home: home, Matches: []AnnotationHit{}}
+		if hit := resolveCwd(ctx, home); hit != nil {
 			h := *hit
 			a.Primary = &h
+			a.Matches = append(a.Matches, h)
 		}
-	}
-	for _, a := range res {
-		a.Ambiguous = len(a.Matches) > 1
-		if a.Primary == nil && len(a.Matches) > 0 {
-			h := a.Matches[0]
-			a.Primary = &h
-		}
+		res[sess] = a
 	}
 	return res
 }

--- a/backend/worktree/service_test.go
+++ b/backend/worktree/service_test.go
@@ -55,7 +55,7 @@ func commitFile(t *testing.T, dir, name, content, msg string) {
 // （很多仓库没设 origin/HEAD，旧逻辑会兜底到 HEAD 分支）。
 func TestDefaultBasePrefersMain(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	// 检出到 feature 分支再建 worktree（不传 base）
 	cmd := exec.Command("git", "-C", repo, "checkout", "-q", "-b", "feat/wip")
@@ -74,7 +74,7 @@ func TestDefaultBasePrefersMain(t *testing.T) {
 
 func TestCreateListRemove(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 
 	resp, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/feat-x", Base: "main"})
@@ -143,7 +143,7 @@ func TestCreateListRemove(t *testing.T) {
 
 func TestExternalWorktreeBaseUnknown(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	ext := filepath.Join(repo, ".worktrees", "ext")
 	cmd := exec.Command("git", "-C", repo, "worktree", "add", "-b", "hand-made", ext)
@@ -175,7 +175,7 @@ func TestExternalWorktreeBaseUnknown(t *testing.T) {
 
 func TestMergeSquashAndConflict(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 
 	resp, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/ok", Base: "main"})
@@ -240,7 +240,7 @@ func TestMergeSquashAndConflict(t *testing.T) {
 // 分支名不靠字符串猜），Create 可基于本地不存在、仅远端有的分支建 worktree。
 func TestBranchesAndCreateFromRemote(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	upstream := mkRepo(t)
 	gitIn := func(dir string, args ...string) string {
 		t.Helper()
@@ -304,7 +304,7 @@ func TestBranchesAndCreateFromRemote(t *testing.T) {
 
 func TestExpectedHeadGuard(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	resp, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/drift", Base: "main"})
 	if err != nil {
@@ -321,7 +321,7 @@ func TestExpectedHeadGuard(t *testing.T) {
 // 远端分支被删（branch-gone）只作佐证标记。全程用本地 bare 仓库当 origin，离线可跑。
 func TestMergedDetection(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	gitIn := func(dir string, args ...string) string {
 		t.Helper()
@@ -433,7 +433,7 @@ func TestMergedDetection(t *testing.T) {
 // 后与本地 base ref 是否存在无关，空 worktree 恒不合入。
 func TestMergedEmptyWorktreeRemoteOnlyBase(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	gitIn := func(dir string, args ...string) string {
 		t.Helper()
@@ -480,7 +480,7 @@ func TestMergedEmptyWorktreeRemoteOnlyBase(t *testing.T) {
 // 也无需 Sync 抓任务分支——本测试用本地 bare 当 origin 全程离线验证这条通路。
 func TestPushedDetection(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	gitIn := func(dir string, args ...string) string {
 		t.Helper()
@@ -545,7 +545,7 @@ func TestPushedDetection(t *testing.T) {
 // 还在的卡死状态——Remove(force) 应能从父目录解析仓库并 RemoveAll+prune 收干净。
 func TestRemoveHalfDeadWorktree(t *testing.T) {
 	ctx := context.Background()
-	s := New()
+	s := New("")
 	repo := mkRepo(t)
 	wt, err := s.Create(ctx, CreateReq{Dir: repo, Branch: "roam/half-dead", Base: "main"})
 	if err != nil {

--- a/backend/worktree/sessionhome.go
+++ b/backend/worktree/sessionhome.go
@@ -1,0 +1,199 @@
+// 会话「归属目录」钉死（session home）。
+//
+// 以前 session → worktree/项目 的归属全靠**实时** pane cwd 现算：会话在项目里
+// 建好，用户在终端里 `cd` 去别处（翻日志、看 /tmp、去另一个仓库瞄一眼），归属
+// 立刻跟着漂——项目会话数掉 0、详情页任务流空掉、甚至被别的项目抢走。可 cd 是
+// 终端里的日常动作，不是「换项目」。
+//
+// 现在：会话创建时（Web 建会话/建 worktree 会话/竞赛/fork 都知道目录）就把归属
+// 目录钉死；CLI 直建的会话则第一次被看见时钉死。之后一律只认这个 home 目录，
+// pane cwd 怎么漂都不改归属。分支/worktree 状态仍按 home 目录现算，所以在 home
+// 里切分支照样实时反映。
+//
+// 钉死关系落 <dataDir>/session-homes.json（后端重启不丢），会话消失即收敛；
+// 文件丢了也只是回到「按当前 cwd 重新钉一次」，不影响任何真相源。
+package worktree
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+type homeStore struct {
+	mu   sync.Mutex
+	path string            // 空 = 只在内存里（测试）
+	m    map[string]string // session → canonical 归属目录
+}
+
+func newHomeStore(dataDir string) *homeStore {
+	h := &homeStore{m: map[string]string{}}
+	if dataDir == "" {
+		return h
+	}
+	h.path = filepath.Join(dataDir, "session-homes.json")
+	if b, err := os.ReadFile(h.path); err == nil {
+		_ = json.Unmarshal(b, &h.m)
+	}
+	return h
+}
+
+// save 落盘（调用方须持锁）：tmp + rename 原子替换。写失败只丢钉死关系，下次重钉。
+func (h *homeStore) save() {
+	if h.path == "" {
+		return
+	}
+	b, err := json.MarshalIndent(h.m, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := h.path + ".tmp"
+	if os.WriteFile(tmp, b, 0o644) == nil {
+		_ = os.Rename(tmp, h.path)
+	}
+}
+
+// pin 首次见到即钉死并返回 home；已钉死则原样返回（cwd 漂移不改归属）。
+func (h *homeStore) pin(session, cwd string) string {
+	if session == "" {
+		return ""
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if d := h.m[session]; d != "" {
+		return d
+	}
+	if cwd == "" {
+		return ""
+	}
+	h.m[session] = cwd
+	h.save()
+	return cwd
+}
+
+// bind 显式绑定（创建会话时就知道它属于哪个目录）：覆盖旧值，且早于任何 pane 采样，
+// 免得「建好 5s 内就 cd 走」把归属钉错。
+func (h *homeStore) bind(session, dir string) {
+	if session == "" || dir == "" {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.m[session] == dir {
+		return
+	}
+	h.m[session] = dir
+	h.save()
+}
+
+func (h *homeStore) get(session string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.m[session]
+}
+
+func (h *homeStore) rename(old, neu string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	d := h.m[old]
+	if d == "" {
+		return
+	}
+	delete(h.m, old)
+	h.m[neu] = d
+	h.save()
+}
+
+func (h *homeStore) forget(session string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.m[session]; !ok {
+		return
+	}
+	delete(h.m, session)
+	h.save()
+}
+
+// reconcile 收敛残行：alive 之外的会话删除（裸 tmux kill-session 绕过 API 也能清干净）。
+// alive 为空（tmux 读失败）时不动——宁可留残行，也不能把活会话的归属抹掉。
+func (h *homeStore) reconcile(alive map[string]bool) {
+	if len(alive) == 0 {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	changed := false
+	for s := range h.m {
+		if !alive[s] {
+			delete(h.m, s)
+			changed = true
+		}
+	}
+	if changed {
+		h.save()
+	}
+}
+
+// homePanes 把 {session → home} 拍回 pane 列表，让既有的「按 cwd 最长前缀归属」
+// 逻辑原样复用：每会话一条、Active=true（home 就是它的归属，无歧义）。
+func homePanes(homes map[string]string) []pane {
+	out := make([]pane, 0, len(homes))
+	for sess, dir := range homes {
+		out = append(out, pane{Session: sess, Active: true, Cwd: dir})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Session < out[j].Session })
+	return out
+}
+
+// ── Service 外部接口 ──────────────────────────────────────
+
+// BindSessionHome 显式钉死会话归属目录（建会话的编排方调用）。
+func (s *Service) BindSessionHome(session, dir string) {
+	if dir == "" {
+		return
+	}
+	s.homes.bind(session, canonical(dir))
+}
+
+// SessionHome 返回会话钉死的归属目录（未钉死返回空串）。
+func (s *Service) SessionHome(session string) string { return s.homes.get(session) }
+
+// RenameSessionHome 会话改名时迁移钉死关系。
+func (s *Service) RenameSessionHome(old, neu string) { s.homes.rename(old, neu) }
+
+// ForgetSessionHome 会话被杀时清掉钉死关系（名称复用不继承旧归属）。
+func (s *Service) ForgetSessionHome(session string) { s.homes.forget(session) }
+
+// sessionHomes 返回 {session → home 目录}：已钉死的照旧，没钉过的按当前 pane
+// （活动 pane 优先）钉一次；顺带收敛死会话残行。这是 session 归属的唯一入口，
+// Annotations / SessionCwds / worktree 会话 join 全部走它。
+func (s *Service) sessionHomes(ctx context.Context) map[string]string {
+	panes := tmuxPanes(ctx)
+	alive := make(map[string]bool, len(panes))
+	first := map[string]string{}
+	active := map[string]string{}
+	for _, p := range panes {
+		alive[p.Session] = true
+		if _, ok := first[p.Session]; !ok {
+			first[p.Session] = p.Cwd
+		}
+		if p.Active {
+			active[p.Session] = p.Cwd
+		}
+	}
+	s.homes.reconcile(alive)
+	out := make(map[string]string, len(alive))
+	for sess := range alive {
+		cwd := active[sess]
+		if cwd == "" {
+			cwd = first[sess]
+		}
+		if home := s.homes.pin(sess, cwd); home != "" {
+			out[sess] = home
+		}
+	}
+	return out
+}

--- a/backend/worktree/sessionhome_test.go
+++ b/backend/worktree/sessionhome_test.go
@@ -1,0 +1,154 @@
+package worktree
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeTmux 装一个假 tmux：list-panes 的输出从 panesFile 读，测试中途改文件即可
+// 模拟「用户在会话里 cd 走了」。返回 panesFile 路径。
+func fakeTmux(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	panesFile := filepath.Join(dir, "panes.txt")
+	bin := filepath.Join(dir, "tmux")
+	script := fmt.Sprintf("#!/bin/sh\ncat %q\n", panesFile)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_BIN", bin)
+	return panesFile
+}
+
+func setPanes(t *testing.T, panesFile, content string) {
+	t.Helper()
+	if err := os.WriteFile(panesFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// 端到端语义：会话在仓库里建起来 → cd 去 /tmp → 归属仍是原仓库（annotation.primary）。
+func TestAnnotationsStickToHomeAfterCd(t *testing.T) {
+	ctx := context.Background()
+	repo := mkRepo(t)
+	panesFile := fakeTmux(t)
+	s := New(t.TempDir())
+
+	setPanes(t, panesFile, "work\t1\t"+repo+"\n")
+	if got := s.Annotations(ctx)["work"]; got == nil || got.Primary == nil || got.Primary.Repo != canonical(repo) {
+		t.Fatalf("建会话时归属应为 %s，实得 %+v", repo, got)
+	}
+
+	// 用户 cd 到仓库外（连 git 仓库都不是）——归属不许跟着走
+	away := t.TempDir()
+	setPanes(t, panesFile, "work\t1\t"+away+"\n")
+	ann := s.Annotations(ctx)["work"]
+	if ann == nil || ann.Primary == nil || ann.Primary.Repo != canonical(repo) {
+		t.Fatalf("cd 走之后归属漂了: %+v", ann)
+	}
+	if ann.Home != canonical(repo) {
+		t.Fatalf("home = %q, want %q", ann.Home, canonical(repo))
+	}
+	if cwds := s.SessionCwds(ctx)["work"]; len(cwds) != 1 || cwds[0] != canonical(repo) {
+		t.Fatalf("SessionCwds = %v, want [%s]", cwds, canonical(repo))
+	}
+
+	// 会话没了 → 归属收敛，不留残行
+	setPanes(t, panesFile, "")
+	setPanes(t, panesFile, "other\t1\t"+away+"\n")
+	_ = s.Annotations(ctx)
+	if h := s.SessionHome("work"); h != "" {
+		t.Fatalf("死会话残行未清: %q", h)
+	}
+}
+
+// 归属钉死的核心语义：第一次见到就定下来，之后 cwd 怎么变都不改（用户在终端里
+// cd 出去，不等于换项目）。
+func TestHomePinnedAgainstCwdDrift(t *testing.T) {
+	h := newHomeStore("")
+	if got := h.pin("s1", "/repo/a"); got != "/repo/a" {
+		t.Fatalf("first pin = %q, want /repo/a", got)
+	}
+	if got := h.pin("s1", "/tmp/elsewhere"); got != "/repo/a" {
+		t.Fatalf("cwd 漂移后 home = %q, want /repo/a", got)
+	}
+	if got := h.get("s1"); got != "/repo/a" {
+		t.Fatalf("get = %q, want /repo/a", got)
+	}
+}
+
+// 显式绑定（建会话时就知道目录）覆盖已钉死的值，且不会被后续采样改回去。
+func TestBindOverridesPin(t *testing.T) {
+	h := newHomeStore("")
+	h.pin("s1", "/repo/a")
+	h.bind("s1", "/repo/a/.worktrees/task")
+	if got := h.pin("s1", "/repo/a"); got != "/repo/a/.worktrees/task" {
+		t.Fatalf("home = %q, want worktree 路径", got)
+	}
+}
+
+func TestRenameAndForget(t *testing.T) {
+	h := newHomeStore("")
+	h.bind("old", "/repo/a")
+	h.rename("old", "new")
+	if h.get("old") != "" || h.get("new") != "/repo/a" {
+		t.Fatalf("rename 后 old=%q new=%q", h.get("old"), h.get("new"))
+	}
+	h.forget("new")
+	if h.get("new") != "" {
+		t.Fatalf("forget 后仍有归属: %q", h.get("new"))
+	}
+}
+
+// reconcile 只清死会话；tmux 读失败(alive 空)时一行都不能动。
+func TestReconcileKeepsAliveAndSkipsEmpty(t *testing.T) {
+	h := newHomeStore("")
+	h.bind("alive", "/repo/a")
+	h.bind("dead", "/repo/b")
+	h.reconcile(nil)
+	if h.get("dead") == "" {
+		t.Fatal("alive 集合为空时不应删任何行")
+	}
+	h.reconcile(map[string]bool{"alive": true})
+	if h.get("alive") != "/repo/a" {
+		t.Fatal("活会话归属被误删")
+	}
+	if h.get("dead") != "" {
+		t.Fatal("死会话残行未收敛")
+	}
+}
+
+// 落盘 + 重建：后端重启不丢归属。
+func TestPersistAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	h := newHomeStore(dir)
+	h.bind("s1", "/repo/a")
+	b, err := os.ReadFile(filepath.Join(dir, "session-homes.json"))
+	if err != nil {
+		t.Fatalf("未落盘: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(b, &m); err != nil || m["s1"] != "/repo/a" {
+		t.Fatalf("落盘内容 = %s (%v)", b, err)
+	}
+	if got := newHomeStore(dir).get("s1"); got != "/repo/a" {
+		t.Fatalf("重启后 home = %q, want /repo/a", got)
+	}
+}
+
+// homePanes：每会话一条、Active=true，按会话名稳定排序（供 join 复用老的最长前缀逻辑）。
+func TestHomePanes(t *testing.T) {
+	ps := homePanes(map[string]string{"b": "/repo/b", "a": "/repo/a"})
+	if len(ps) != 2 || ps[0].Session != "a" || ps[1].Session != "b" {
+		t.Fatalf("panes = %+v", ps)
+	}
+	for _, p := range ps {
+		if !p.Active {
+			t.Fatalf("home pane 应为 active: %+v", p)
+		}
+	}
+}

--- a/docs/design/web/07-worktree.md
+++ b/docs/design/web/07-worktree.md
@@ -121,11 +121,14 @@ ttmux 的能力止步于「平坦 tmux session + parent 关系」，**不理解 
 - **ahead/behind 相对已记录的 `roam.baseRef`**，区分 `committedAhead`（未合并到 base 的提交——不是"未推送"）、`dirty`、`untracked` 三个数。
 - **diff 定义**：`mergeBase = git merge-base <baseRef> HEAD`；已提交差异 = `git diff mergeBase..HEAD`；未提交改动**另算** workingTree diff，两个数字不混。文件统计 `--numstat -z`，rename/binary 结构化表达。
 
-### 2.4 session ↔ worktree：cwd join 读模型（上层现算，不写台账）
+### 2.4 session ↔ worktree：home join 读模型（归属钉死，状态现算）
 
-- 上层读 `ttmux ls/inspect` 的**全部 pane cwd**（保留 session+window+pane），与 `git worktree list` 做 join：路径先 canonical（`EvalSymlinks`+clean），按**路径段边界**做「最长 worktree root 前缀」匹配。
-- 返回 `matches[]` + `primary`（active pane）+ `ambiguous` 标记——一个 session 多 pane 可命中多个 worktree，不硬写 session→单对象；UI 对歧义显式标记。
-- Worktree 可无 session（孤儿/外部）；session 可在普通目录；关系随 cd 实时变化，这是特性。
+- **归属目录（home）钉死**：会话创建时就记下它属于哪个目录（Web 建会话/建 worktree 会话/竞赛/fork 都显式绑定；CLI 直建的会话第一次被看见时按 active pane cwd 钉），落 `<dataDir>/session-homes.json`，会话消失即收敛、改名跟着迁移。
+  > 修订（原设计按**实时** pane cwd 现算归属）：cd 是终端里的日常动作，不是「换项目」。实时归属会让会话在用户 `cd /tmp` 看眼日志时就掉出项目——项目会话数掉 0、详情页任务流空、甚至被别的项目抢走。归属改为钉死，**只有编排层的移动（cdInto）才改归属**。
+- join 本身不变：home 路径 canonical（`EvalSymlinks`+clean）后与 `git worktree list` 按**路径段边界**做「最长 worktree root 前缀」匹配。
+- `annotations` 返回 `home` + `primary`（home 命中的 worktree/repo）+ `matches[]`（现为单元素）；`ambiguous` 保留为兼容字段，恒 false。
+- 分支/dirty/worktree 状态仍按 home 目录**现算**——在 home 里切分支照样实时反映；只有「属于谁」不再漂。
+- Worktree 可无 session（孤儿/外部）；session 的 home 可以是普通目录（非 git，则按目录前缀归属非 git 项目）。
 
 生命周期五步，每步都有对应界面（§3）：
 

--- a/docs/design/web/08-project.md
+++ b/docs/design/web/08-project.md
@@ -31,10 +31,11 @@
 
 **不是**「顶层会话 = 项目」：顶层会话可关闭、可多开；目录才是稳定容器。项目**不与 git
 绑定**：任意目录都可以是项目（目录 + 会话）；目录是 git 仓库时归位 canonical 主仓库根，
-并开启 worktree / 编队 / 活动 等 git 能力。非 git 项目的会话归属按 pane cwd 目录前缀
-现算（git 项目按 §2.4 annotation，更精确、优先认领）。
+并开启 worktree / 编队 / 活动 等 git 能力。非 git 项目的会话归属按会话**归属目录
+（home，07 §2.4）**做目录前缀匹配（git 项目按 annotation 的 primary repo，更精确、优先
+认领）。归属在建会话时钉死，用户在终端里 cd 到别处不会让会话掉出项目。
 
-- **发现 = 现算 ∪ 弱台账**：项目列表 = 「全部会话 pane cwd join（07 §2.4）∪ knownRepos
+- **发现 = 现算 ∪ 弱台账**：项目列表 = 「全部会话 home join（07 §2.4）∪ knownRepos
   逐仓库 worktree 扫描」。repo 身份 = canonical common-dir（07 §2.3 规则不变）。
   **不能只靠会话现算**：现有 `GET /git/worktrees/all` 只枚举「当前会话触达的仓库」，
   仓库最后一个会话关掉后，留着未合并提交的孤儿 worktree 就没有任何来源能再发现它——
@@ -45,11 +46,11 @@
     校验并归位主仓库根，非 git 目录拒绝。**永不自动退场**，只能 `DELETE /projects/:key`
     显式移除（纯台账操作，不动目录/worktree/会话）。开 session、建 feature 是进项目
     之后 composer 的事，创建项目本身不建任何会话。
-  - **发现（origin=discovered）**：会话 cwd join 命中即自动记入；移出仅当 **(a)** 仓库
+  - **发现（origin=discovered）**：会话 home join 命中即自动记入；移出仅当 **(a)** 仓库
     目录已不存在，或 **(b)** 不存在任何 roam worktree（clean/已合并未清理的也算存在）
     **且**无会话**且**未置顶。同文件顺带存 UI 偏好（置顶、默认 agent/base、自定显示名）。
   git/session 真相源不变；台账丢失只损失「零会话仓库的可发现性」，活跃仓库下次开会话即重建。
-- cwd 不在任何 git 仓库的会话 → 「散会话」区，保留原会话语义，不强造项目。
+- home 不在任何项目/git 仓库里的会话 → 「散会话」区，保留原会话语义，不强造项目。
 
 ### 2.2 任务 = 会话 ∪ 孤儿 worktree 的统一投影（读模型，非新实体）
 
@@ -131,8 +132,7 @@
     「待集成」，worktree 合并建议走蜂群台集成验收；若在 P3 单独收尾，提示
     「该 worktree 属蜂群 <名>」。跨仓库成员在本项目置灰只留跳转，防双处操作。
 - **worktree × 命令行（P4）**：一个 worktree 下可挂多条命令行——agent 会话与裸 shell 同列
-  （挂靠 = cwd join 实况：cd 走自动离组、cd 进自动入列；多 pane 命中多 worktree 显 ⚠ 歧义
-  标记，hover 列全部 matches）。行内终端尾行预览只读（capture-pane，懒加载）；
+  （挂靠 = 会话 home：在哪建的就挂哪，之后 cd 不改挂靠——见 07 §2.4 归属钉死）。行内终端尾行预览只读（capture-pane，懒加载）；
   「＋ 新开命令行」三选：shell = `ttmux new --dir <worktree>`（命名 `<分支>-sh` 自动后缀），
   Claude/Codex = `POST /worktree-sessions`「已有」档——孤儿复活与外部收编是同一动作的特例。
   「进入」→ 停靠终端（手机全屏），工具栏面包屑 `项目 › ⎇ 分支 › 命令行`；worktree 删除按钮
@@ -143,7 +143,7 @@
 
 | 接口 | 说明 |
 |---|---|
-| `GET /projects` | 聚合：knownRepos（§2.1 台账）逐仓库 worktree 扫描 + `ttmux ls --tree` cwd join（顺带把新命中的仓库记入发现通道）+ races 计数 + 最近活动（worktree HEAD 时间的 max）|
+| `GET /projects` | 聚合：knownRepos（§2.1 台账）逐仓库 worktree 扫描 + `ttmux ls --tree` home join（顺带把新命中的仓库记入发现通道）+ races 计数 + 最近活动（worktree HEAD 时间的 max）|
 | `POST /projects` | 显式创建项目对象（origin=user，永不自动退场）；`{dir, displayName?}`，非 git 目录报 `NOT_GIT_REPO` |
 | `DELETE /projects/:key` | 显式移除（纯台账，不动目录/worktree/会话；有会话的仓库会被发现通道重新记入——列表反映实况）|
 | `GET /projects/:repoKey` | 单仓库详情：任务投影（§2.2）+ worktree 列表 + races + 活动流（各 worktree `git log --since` 汇总 + 收尾留痕，带缓存）|
@@ -165,7 +165,7 @@ action: merged|discarded|cleaned, strategy?, shortstat, at}`），只增不改�
 
 ```
 backend/
-  worktree/service.go     已有：git 领域服务（repo 锁 / 3s list 缓存 / pane cwd join）
+  worktree/service.go     已有：git 领域服务（repo 锁 / 3s list 缓存 / 会话 home join）
   api/worktree.go         已有：handler + 组合编排（worktree-sessions / fork / close-with-worktree）
   api/race.go             已有：RaceStore（<dataDir>/races.json，互斥+整写）+ crown 状态机
   project/service.go      新增：发现聚合 + knownRepos 台账 + 收尾留痕读写

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -580,12 +580,15 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh }
     // 而不是只取 P1 卡片的 top(≤2)——否则该项目的第 3+ 个会话在详情页永远不出现。
     // 已被某 git 仓库认领的会话(annotation 有 primary.repo)排除，避免嵌套 git 子项目
     // 的会话重复挂到非 git 父目录下。
+    // 归属看会话钉死的 home 目录（annotation.home），不是实时 cwd：在会话里 cd 出去
+    // 不该让它掉出项目。后端没给 home（老后端/刚起的会话）才退回 ls 的实时 cwd。
+    const homeOf = (s: any) => ann[s.name]?.home || s.cwd
     const under = (c: string) => !!c && (c === dir || c.startsWith(dir + '/'))
     // 同一会话归最深(最长前缀)的非 git 项目：排除落在更具体的非 git 兄弟项目里的会话，
     // 与后端最长前缀口径一致，否则父项目详情页会把子项目会话重复计入（外层少、里层多）。
     const deeper = allProjects.filter((p) => !p.git && p.dir !== dir && p.dir.startsWith(dir + '/')).map((p) => p.dir)
     const claimedByDeeper = (c: string) => deeper.some((d) => c === d || c.startsWith(d + '/'))
-    return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(s.cwd) && !claimedByDeeper(s.cwd))
+    return sessions.filter((s) => !ann[s.name]?.primary?.repo && under(homeOf(s)) && !claimedByDeeper(homeOf(s)))
   }, [sessions, ann, dir, isGit, allProjects])
   // 蜂群归属（08 §2.2）：两条判据取并集
   //  1) 蜂群自报的工作目录 dir == 本项目目录（swarm new/adopt --dir 落库，CLI 建的群靠这条）


### PR DESCRIPTION
## 问题
在项目里新建的命令行，只要在终端里 `cd` 到别处，它就不算这个项目的会话了：项目卡片会话数掉 0、详情页任务流空掉、甚至被别的项目（或更深的非 git 项目）抢走。

根因：session → 项目/worktree 的归属**全靠实时 pane cwd 现算**（`Annotations` / `SessionCwds` / worktree 会话 join 都读 `tmux list-panes` 的当前路径）。可 `cd` 是终端里的日常动作，不是「换项目」——这个目录 check 本就不该做。

## 改法：归属钉死（session home）
- 新增 `backend/worktree/sessionhome.go`：`session → 归属目录`，落 `<dataDir>/session-homes.json`（后端重启不丢）。会话消失即收敛、改名迁移、被杀即清（同名重建不继承旧归属）。tmux 读失败（alive 集合为空）时一行不动，避免误删活会话归属。
- **建会话时就绑定**，不等轮询采样（新会话头几秒就 cd 走会钉错）：`POST /sessions`、`POST /worktree-sessions`、竞赛选手会话、`fork` / `fork-worktree` 全部显式 bind；编排层 `cdInto`（把会话挪进 worktree）顺带改钉。CLI 直建的会话第一次被看见时按 active pane cwd 钉一次。
- `Annotations` / `SessionCwds` / worktree 会话 join / `ListAll` 一律改走 home，不再读实时 pane cwd。**分支/dirty 等状态仍按 home 现算**——在 home 里切分支照样实时反映，只有「属于谁」不再漂。顺带少了一堆 per-pane 的 git 子进程。
- `annotations` 增 `home` 字段（非 git 的 home 也给条目），前端非 git 项目认领会话改用 `ann.home`，缺省退回 `ls` 的 cwd 兼容老后端；`ambiguous` 归属唯一后恒 false（字段保留，UI 兼容）。
- 同步修订设计文档 07 §2.4（cwd join → home join，含修订理由）与 08 §2.1/§3 相关口径。

## 验证
- 新增 `sessionhome_test.go`：钉死 vs cwd 漂移、显式 bind 覆盖、改名/遗忘、reconcile（空 alive 不动手）、落盘重启，以及**用假 tmux 跑的端到端**——会话建在真仓库里 → 改 pane 输出模拟 `cd /tmp` → `annotations.primary.repo` / `SessionCwds` 不变，会话消失后残行收敛。
- `scripts/dev/quality/check.sh full` 全绿（Go 测试 + i18n audit + typecheck + build）。

## 未覆盖
本 PR 只保证「会话不因 cd 掉出它出生的项目」。若会话本来就在任何项目/仓库之外创建（如在 `~` 起的裸 shell），它仍是「散会话」——没有为这种会话自动造项目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)