### PR TITLE
fix(term): 关标签/改名整页黑屏；导航栏改用会话 id

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@jvmr/pptx-to-html": "^1.0.1",
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.10.0",
-        "@xterm/addon-webgl": "^0.19.0",
+        "@xterm/addon-webgl": "0.18.0",
         "@xterm/xterm": "^5.5.0",
         "antd": "^5.21.6",
         "docx-preview": "^0.3.7",
@@ -2051,10 +2051,13 @@
       }
     },
     "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmmirror.com/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
-      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
-      "license": "MIT"
+      "version": "0.18.0",
+      "resolved": "https://registry.npmmirror.com/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@jvmr/pptx-to-html": "^1.0.1",
     "@monaco-editor/react": "^4.7.0",
     "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/addon-webgl": "0.18.0",
     "@xterm/xterm": "^5.5.0",
     "antd": "^5.21.6",
     "docx-preview": "^0.3.7",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,6 +86,18 @@ function setHashParams(params: Record<string, string>) {
   if (h !== next) history.replaceState(null, '', next)
 }
 
+// URL 上的终端标签参数（terms=打开的标签、active=当前标签）。
+// 现在写进去的是会话 id；老链接里存的是会话名，两者都能读——还原时按 id 表判别（见 resolveToken）。
+function readTermTokens(): { terms: string[]; active: string } {
+  const p = getHashParams()
+  const t = p.get('terms')
+  const a = p.get('active')
+  return {
+    terms: t ? t.split(',').map(decodeURIComponent).filter(Boolean) : [],
+    active: a ? decodeURIComponent(a) : '',
+  }
+}
+
 // 线性图标（无 emoji，currentColor 描边）
 const svg = (paths: any) => (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -266,15 +278,14 @@ export default function App() {
     }
   }, [])
 
-  // 多终端状态（从 URL 恢复）
-  const [terms, setTerms] = useState<string[]>(() => {
-    const t = getHashParams().get('terms')
-    return t ? t.split(',').map(decodeURIComponent).filter(Boolean) : []
-  })
-  const [active, setActive] = useState<string | null>(() => {
-    const a = getHashParams().get('active')
-    return a ? decodeURIComponent(a) : null
-  })
+  // 多终端状态（从 URL 恢复）。URL 里放的是**会话 id**（见下方 sessIds 注释），
+  // 组件内部一律用会话名——后端 API / WebSocket 收发的都是名字。
+  const [terms, setTerms] = useState<string[]>([])
+  const [active, setActive] = useState<string | null>(null)
+  // URL 上待还原的 id/名字（还没拿到 id 映射前先原样存着）
+  const urlTerms = useRef<string[]>(readTermTokens().terms)
+  const urlActive = useRef<string>(readTermTokens().active)
+  const restored = useRef(false) // 还原完成前不许回写 URL，否则会把待还原的参数抹掉
   const [overlay, setOverlay] = useState(false) // 手机/平板全屏终端
   const [dockOpen, setDockOpen] = useState(true) // 桌面：右侧终端停靠栏是否展开
   const [dockMax, setDockMax] = useState(false)  // 桌面：终端栏向左扩展（遮住会话列表）
@@ -297,13 +308,52 @@ export default function App() {
     }).catch(() => setAuthed(false))
   }, [])
 
-  // 终端状态同步到 URL，刷新后可恢复
+  // ── 会话身份映射（id ↔ 名字）──
+  // 会话名可以随时改，用它当 URL 里的 handle 会让分享/收藏的链接一改名就指空。id 由后端按
+  // tmux session_id 派生、改名不变，所以 URL 只写 id。名字仍是 API/WS 的 handle，只在这里换算。
+  const [sessIds, setSessIds] = useState<{ byId: Record<string, string>; byName: Record<string, string> } | null>(null)
   useEffect(() => {
-    setHashParams({
-      terms: terms.map(encodeURIComponent).join(','),
-      active: active ? encodeURIComponent(active) : '',
+    if (!authed) return
+    let stop = false
+    const load = () => api('GET', '/sessions').then((list) => {
+      if (stop) return
+      const byId: Record<string, string> = {}
+      const byName: Record<string, string> = {}
+      for (const s of Array.isArray(list) ? list : []) {
+        if (s?.id && s?.name) { byId[s.id] = s.name; byName[s.name] = s.id }
+      }
+      setSessIds({ byId, byName })
+    }).catch(() => { if (!stop) setSessIds((m) => m || { byId: {}, byName: {} }) }) // 拉不到也要放行还原，别把标签卡在空白
+    load()
+    const t = setInterval(load, 5000)
+    return () => { stop = true; clearInterval(t) }
+  }, [authed])
+
+  // 从 URL 还原标签：拿到 id 表后做一次。老链接里存的是名字，id 表里查不到就按名字用。
+  useEffect(() => {
+    if (!sessIds || restored.current) return
+    restored.current = true
+    const toName = (tok: string) => sessIds.byId[tok] || tok
+    const names = Array.from(new Set(urlTerms.current.map(toName)))
+    if (!names.length) return
+    // 用户在 id 表回来之前就点开了标签 → 以他的操作为准，别被 URL 还原顶掉
+    setTerms((cur) => (cur.length ? cur : names))
+    setActive((cur) => {
+      if (cur) return cur
+      const a = urlActive.current ? toName(urlActive.current) : ''
+      return a && names.includes(a) ? a : names[names.length - 1]
     })
-  }, [terms, active])
+  }, [sessIds])
+
+  // 终端状态同步到 URL，刷新后可恢复。写 id；还没有 id 的（刚建、列表未刷新）先退回写名字。
+  useEffect(() => {
+    if (!restored.current) return
+    const toTok = (n: string) => sessIds?.byName[n] || n
+    setHashParams({
+      terms: terms.map((n) => encodeURIComponent(toTok(n))).join(','),
+      active: active ? encodeURIComponent(toTok(active)) : '',
+    })
+  }, [terms, active, sessIds])
 
   // hash 路由：URL #/xxx 与当前页同步（支持前进/后退、刷新保持、收藏分享）
   useEffect(() => {
@@ -382,6 +432,13 @@ export default function App() {
       termRefs.current[newName] = termRefs.current[oldName]
       delete termRefs.current[oldName]
     }
+    // id 表 5 秒才轮询一次，这里先就地改名，免得 URL 上的 id 短暂退化成名字再跳回来
+    setSessIds((m) => {
+      const id = m?.byName[oldName]
+      if (!m || !id) return m
+      const { [oldName]: _drop, ...rest } = m.byName
+      return { byId: { ...m.byId, [id]: newName }, byName: { ...rest, [newName]: id } }
+    })
   }
   const closeTerm = (name: string) => {
     setTerms((ts) => {

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -2,6 +2,9 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 're
 import type { CSSProperties, TouchEvent as RTouchEvent } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+// 版本必须与 @xterm/xterm 主版本配对（本仓库 xterm 5.5 → addon-webgl 0.18.x，peerDeps 写的 ^5）。
+// 0.19+ 是给 xterm 6 内核的：卸载时读 `_core._store._isDisposed` 判断内核有没有拆，
+// 5.5 内核根本没有 `_store` → 每次拆终端必抛 TypeError（升级前先确认这个字段还在）。
 import { WebglAddon } from '@xterm/addon-webgl'
 import '@xterm/xterm/css/xterm.css'
 // 终端符号补字集（约 46KB，仅覆盖框线/箭头/技术符号等区段）：见 FONT_FAMILY 的说明
@@ -355,10 +358,12 @@ const Term = forwardRef<TermHandle, {
     // WebGL 渲染器：默认的 DOM 渲染器每格一个 span，单元格宽是分数像素，手机 dpr 常为 2.625/3
     // 这类非整数，亚像素误差累积会裁字/叠字，整屏重绘也更容易看到闪烁。WebGL 按纹理网格绘制，
     // 顺带让 rescaleOverlappingGlyphs 生效。上下文丢失（后台切回/GPU 回收）时 dispose 退回 DOM。
+    let webglAddon: WebglAddon | undefined
     try {
       const webgl = new WebglAddon()
       webgl.onContextLoss(() => { try { webgl.dispose() } catch {} })
       term.loadAddon(webgl)
+      webglAddon = webgl
     } catch { /* 不支持 WebGL 的浏览器继续用 DOM 渲染器 */ }
 
     setTimeout(() => { try { fit.fit() } catch {} }, 0)
@@ -679,7 +684,12 @@ const Term = forwardRef<TermHandle, {
       }
       dataDisp.dispose()
       try { wsRef.current?.close() } catch {}
-      term.dispose()
+      // 拆终端务必吞异常：这里是 React 的 effect cleanup，抛出去会顺着卸载流程把整棵树炸掉
+      // （整页黑屏，而不只是这一个标签坏掉）。xterm 的 WebGL addon 就踩过——它按新版内核的
+      // 私有字段做卸载判断，配到旧内核上必抛 TypeError，于是「关一个会话/改一次名」就黑屏。
+      // 先单独拆 WebGL addon，再拆终端本体，各自兜住，任一步失败都不影响另一步和其他标签。
+      try { webglAddon?.dispose() } catch {}
+      try { term.dispose() } catch {}
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name])

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { App as AntApp } from 'antd'
 import App from './App'
+import ErrorBoundary from './ErrorBoundary'
 import { ThemeProvider } from './theme'
 import { I18nProvider } from './i18n'
 import { spike, verify } from './p2p/download'
@@ -35,12 +36,16 @@ try {
 } catch { /* 不支持的浏览器忽略 */ }
 
 // 主题(黑/白)统一收敛到 ThemeProvider：它内部按 mode 渲染 ConfigProvider + 写 data-theme。
+// 根上再套一层错误边界：React 里任何未捕获的渲染/卸载异常都会把整棵树卸掉 → 整页黑屏，
+// 连重试入口都没有。兜住后至少显示「出错·重试」，点一下重挂应用，不必手动刷新。
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <I18nProvider>
       <ThemeProvider>
         <AntApp>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </AntApp>
       </ThemeProvider>
     </I18nProvider>


### PR DESCRIPTION
## 黑屏根因

headless Chrome 复现拿到真实堆栈：

```
TypeError: Cannot read properties of undefined (reading '_isDisposed')
  at ... WebglAddon dispose → _wrappedAddonDispose → Terminal.dispose
```

对应上游代码 `if (this._terminal._core._store._isDisposed) return`。

eae28f9 上 WebGL 渲染器时装的 `@xterm/addon-webgl@0.19.0` 是给 xterm **6** 内核的版本（0.18.0 才声明 `peerDependencies: @xterm/xterm ^5.0.0`），而本仓库用的是 `@xterm/xterm@5.5.0`，内核里根本没有 `_store` → **每一次拆终端都必抛 TypeError**。

拆终端发生在 React 的 effect cleanup 里，异常从卸载流程逃出去就把整棵树卸掉。叉掉标签是卸载，改名（React key 变）也是卸载，所以两个操作都整页全黑。

## 改动

- `@xterm/addon-webgl` 钉到 `0.18.0`，import 处写清配对规则，防止下次升级再踩
- `Terminal.tsx` cleanup 先单独拆 WebGL addon 再拆终端本体，各自 try/catch —— effect cleanup 里绝不能让异常逃出去
- 根节点套上 `ErrorBoundary`（此前只在 FileView 用），以后任何未捕获异常显示「出错·重试」而不是黑屏

## 顺带：导航栏 handle 从会话名换成会话 id

名字可以随时改，拿它当 URL 里的 handle 会让分享/收藏的链接一改名就指空。登录后轮询 `/api/sessions` 维护 id↔名字双向表，URL 只写 id，组件内部仍全程用名字（后端 API / WebSocket 的 handle 没动）。老链接里存的是名字，查不到 id 就按名字走，已分享出去的链接照常能开，并会被就地换写成 id。

## 验证（headless Chrome 打真实实例）

| | 结果 |
|---|---|
| ① 老名字链接还原 | 3 个标签正常，URL 自动换写成 `terms=2026-0722-1528-0063,...` |
| ② 叉掉一个标签 | 剩余标签存活，canvas 仍在，无异常（修复前此处整页黑） |
| ③ 改名 | 标签更名，**URL 完全不变**，无异常 |
| ④ 用 id 链接刷新 | 标签正确还原 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)