### PR TITLE
fix(chat): 语音开关联动对话页 + 麦克风不再压住发送 + 提问弹框点不没

### DIFF
--- a/docs/development/web-ui-checklist.md
+++ b/docs/development/web-ui-checklist.md
@@ -1,0 +1,122 @@
+# Web UI 验收清单（Chrome CLI / 手机 ADB）
+
+前端改动**不能只靠肉眼和 typecheck 收工**——Roam 的坑大多在真实浏览器里才现形：层叠上下文、
+触摸事件命中、软键盘、tmux attach 尺寸。本清单给出一套可复现的跑法：桌面走 `chrome` CLI 或
+CDP，手机走 adb + 手机 Chrome 的 DevTools（同一套 CDP 脚本两端复用）。
+
+> 已经踩过的真事：xterm 的透明画布层（`.xterm-link-layer`）带正 z-index，会「逃」出 `position:
+> relative` 的终端容器，压在 Claude/Codex 对话面板之上——**看得见、点不着**，表现为「聊天区滑
+> 不动、发送/停止按不动」。这类问题只有做**命中测试**（`document.elementFromPoint`）或真手势才
+> 能发现，截图和 typecheck 一律看不出来。
+
+## 0. 接上被测端
+
+### 手机（推荐，触摸相关的问题只在这儿现形）
+
+```bash
+adb devices -l                                   # 认到设备
+adb shell svc power stayon true                  # 别让屏灭：Chrome 进后台会被冻，CDP 直接失联
+adb shell am start -a android.intent.action.VIEW -d "https://<LAN_IP>:13579/" com.android.chrome
+adb forward tcp:9555 localabstract:chrome_devtools_remote
+curl -s http://127.0.0.1:9555/json/list          # 看到目标页 = 通了
+```
+
+- 自签证书拦截页：CDP 里点 `#details-button` → `#proceed-link`。
+- 登录页只有口令框，**两步验证码框是提交口令后才出现的**，脚本要分两步填。
+- **改完前端一定要硬刷**：`Page.navigate` 到 `#/xxx` 是同文档导航，不重新加载文档，页面会一直跑
+  老包（页面上那条「🔄 有新版本 / 刷新」横幅就是提示）。脚本里跟一句
+  `Page.reload({ ignoreCache: true })`，否则你验的是上一版代码——这一条踩过两次。
+- 真手势用 `Input.synthesizeScrollGesture`（走合成器，等价手指滑动）；点按用
+  `Input.dispatchMouseEvent`。**不要**用 `el.click()` 做「点得到吗」的验收——它绕过命中测试，
+  被透明层盖住也照样触发。
+
+### 桌面
+
+```bash
+chrome goto https://127.0.0.1:13579/ && chrome eval "document.title"
+```
+
+`chrome` CLI 接的是 9222 上那台全局 Chrome（与 Web 镜像同一台）。若 `navigate` 超时且日志有
+`Failed global descriptor lookup`，说明这台机器的 Chrome 网络进程起不来（代理/沙箱环境问题），
+先修环境或直接改用手机端跑。
+
+## 1. 通用断言姿势
+
+| 要验的东西 | 怎么验（别只看截图） |
+|---|---|
+| 元素是否**真的可点** | `document.elementFromPoint(x, y)` 命中的是不是它自己 |
+| 区域是否**真的可滚** | 记 `scrollTop` → `Input.synthesizeScrollGesture` → 再读 `scrollTop` |
+| 覆盖层是否吃事件 | `getComputedStyle(el).pointerEvents`；window 上挂 capture 监听看 `e.target` |
+| 弹层是否被误关 | 触发后等 1.5s 再查节点是否还在 |
+| 布局是否溢出 | `document.documentElement.scrollWidth <= innerWidth` |
+
+## 2. 清单
+
+### A. 终端页（手机 + 桌面）
+
+- [ ] 会话列表点进去能开终端，`.xterm` 出现且 `已连接`。
+- [ ] 终端能上下滑看历史（`Input.synthesizeScrollGesture` 后画面变化）。
+- [ ] 底部输入条打字 + 「Enter」能送进 PTY；快捷键丝带横向可滑。
+- [ ] 工具条各钮命中测试通过（尤其被浮层覆盖的右侧分组）。
+- [ ] 单击终端移光标只发 ←→（备用屏），不误发 ↑↓。
+
+### B. Claude / Codex 专业渲染模式（重灾区）
+
+- [ ] 切进对话页：`textarea[placeholder]` 存在，历史消息渲染出来。
+- [ ] **聊天区能滑动看历史**：`scrollTop` 真的变小（不是只有滚动条能拖）。
+- [ ] **命中测试**：聊天区中心、发送钮中心、停止钮中心 `elementFromPoint` 都不能是
+      `CANVAS.xterm-*`——命中终端画布就是层叠上下文又漏了。
+- [ ] 「发送」能把消息送进会话；生成中「停止」能打断。
+- [ ] 悬浮麦克风不压住发送/停止/选择框（量 rect 交集）。
+- [ ] 工具条「语音输入」开关能同时管住终端页与对话页的麦克风。
+- [ ] 「回到底部 ↓」在上滚后出现、点了回底。
+- [ ] 「切回终端」回到终端且连接不断。
+
+### C. 提问弹框（PromptDialog）
+
+- [ ] 会话里出现 TUI 选择框时弹框自动弹出。**手机上尤其要验**：手机 attach 后窗格只剩 40 多列，
+      选项被折成五六行，`detectPrompt` 的分组一旦按行距卡死就一条都认不出来（见
+      `src/prompt.test.ts` 的窄屏用例）。
+- [ ] 测这一条前先确认偏好里「弹框提醒」是开的（`promptPopupOff=false`），否则弹框本来就不该出现；
+      脚本里临时改完记得还原。
+- [ ] **点终端空白处：弹框不消失**，且这一下点击落到终端（命中测试）。
+- [ ] 点选项能把按键注入会话；点右上角 × 只关这一条。
+- [ ] `.ant-modal-wrap` 的 `pointer-events` 必须是 `none`（否则整页点击被吃）。
+
+### D. 手机专属
+
+- [ ] 底部导航栏不挡住会话覆盖层（覆盖层 z-index 高于 nav）。
+- [ ] 软键盘弹起后输入框与发送钮仍可达（`interactive-widget=overlays-content`，键盘只盖不顶）。
+- [ ] 页面不出现横向滚动（`scrollWidth <= innerWidth`）。
+- [ ] 竖屏/横屏切换后终端重新 fit，不留花屏。
+
+## 3. 脚本骨架
+
+`scripts/` 下没有常驻脚本（测试环境一次性），临时脚本写法见下——两端只差 CDP 端口与目标页选择：
+
+```js
+// connect(port, targetId) → { eval, clickAt, shot, send }
+const cdp = await connect(9555, targetId)               // 手机；桌面用 9222
+const box = () => cdp.eval(`(() => { const d = [...document.querySelectorAll('div')]
+  .filter((x) => /auto|scroll/.test(getComputedStyle(x).overflowY) && x.scrollHeight > x.clientHeight + 40)
+  .sort((a, b) => b.scrollHeight - a.scrollHeight)[0]
+  const r = d.getBoundingClientRect()
+  return JSON.stringify({ top: d.scrollTop, x: r.left + r.width / 2, y: r.top + r.height / 2 }) })()`)
+
+const b0 = JSON.parse(await box())
+await cdp.send('Input.synthesizeScrollGesture', { x: b0.x, y: b0.y, yDistance: 300, gestureSourceType: 'touch', speed: 800 })
+const b1 = JSON.parse(await box())
+console.assert(b1.top < b0.top, '聊天区滑不动')
+```
+
+## 4. 造测试数据（别拿用户的会话做实验）
+
+```bash
+# 独立会话 + 真实转录：起一个 claude（不发消息=不花钱），再把一份历史 jsonl 拷进它的 project 目录
+tmux new-session -d -s roam-uitest -x 200 -y 45 -c /tmp/uitest 'claude'
+cp <某个较小的>.jsonl ~/.claude/projects/-tmp-uitest/aaaa1111-....jsonl
+```
+
+- 转录别拿几十 MB 的大文件，前端一次性拉全量会把手机拖死（那是测试数据问题，不是 bug）。
+- 要真选择框：在测试会话里发 `/model`，那就是一个标准的 Claude Code 选择框。
+- 收尾：`tmux kill-session -t roam-uitest`，删掉拷进去的 jsonl。

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -724,7 +724,12 @@ const Term = forwardRef<TermHandle, {
     borderRadius: which === 'start' ? '50% 0 50% 50%' : '0 50% 50% 50%',
   })
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%', WebkitTouchCallout: 'none' } as CSSProperties}>
+    // isolation:isolate —— 必须有。xterm 内部的画布层(.xterm-link-layer 等)带正 z-index，而本容器
+    // 只是 position:relative（z-index:auto 不成层叠上下文），那些画布就会「逃」到外层去，压在同级
+    // 后面的兄弟节点之上：Claude/Codex 对话面板正是这样被一层**透明**画布盖住的——看得见、点不着，
+    // 表现为对话区滑不动历史、发送/停止按不动（画布吃掉了所有 pointer/touch）。isolate 把这些
+    // z-index 关回终端自己这一层，覆盖层就能正常接事件。真机 CDP 命中测试可复现/回归。
+    <div style={{ position: 'relative', width: '100%', height: '100%', isolation: 'isolate', WebkitTouchCallout: 'none' } as CSSProperties}>
       <div ref={elRef} style={{ width: '100%', height: '100%' }} />
       {handles && (['start', 'end'] as const).map((which) => (
         <div key={which} onTouchStart={dragHandle(which)} style={handleStyle(which)} />

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -6,6 +6,7 @@ import { api, upload, makeClipboardImageFile } from '../api'
 import FileBrowser from '../FileBrowser'
 import FloatingFileDrawer from '../FloatingFileDrawer'
 import { PromptPanel, detectPrompt } from '../prompt'
+import { usePreferences } from '../preferences'
 import { useI18n } from '../i18n'
 import { VoiceInput } from './VoiceInput'
 import type { Msg } from './types'
@@ -40,6 +41,11 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
   const { t } = useI18n()
   const screens = Grid.useBreakpoint()
   const isMobile = !screens.md // 手机窄屏：输入区换成「文本框独占一行 + 按钮行」竖排，避免挤成一坨
+  // 语音按钮的显隐跟终端工具条那颗「语音输入」开关是同一个偏好：关了就整个页面都不出现麦克风。
+  const [prefs] = usePreferences()
+  const showVoice = prefs.showVoiceButton !== false
+  // 触屏上点按钮不夺走文本框焦点 → 软键盘不收起 → 布局不回弹，click 不会落空（同 App 的 noBlur）。
+  const noBlur = (e: React.MouseEvent) => { if (isMobile) e.preventDefault() }
 
   // 把文本追加进输入框末尾（语音识别结果 / 路径插入共用）
   const appendText = (s: string) => setInput((v) => (v ? v.replace(/\s*$/, ' ') : '') + s + ' ')
@@ -185,6 +191,11 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
               ↓
             </button>
           )}
+          {/* 桌面端悬浮语音按钮（长按说话，识别回填输入框）：挂在消息区这层而不是整页外壳——
+              它是 bottom:54 的绝对定位，挂外层时会压住底部输入行的「停止/发送」（输入框一涨到
+              两行以上尤其明显，点上去变成录音）和上方的选择框面板。挂这层就永远浮在输入区之上，
+              与 bottom:12 的「回到底部」钮天然错开。手机端不走这里，已内联到按钮行。 */}
+          {!isMobile && showVoice && <VoiceInput accent={accent} onResult={appendText} />}
         </div>
         {/* 交互式选择框（权限确认/选项菜单）：检测到才显示，可点选 */}
         <PromptPanel name={name} accent={accent} />
@@ -202,11 +213,11 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
                 onPaste={onPaste}
               />
               <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                <Button shape="circle" title={t('chat.uploadToCwd')} loading={uploading} onClick={() => fileRef.current?.click()}>📎</Button>
-                <VoiceInput inline accent={accent} onResult={appendText} />
+                <Button shape="circle" title={t('chat.uploadToCwd')} loading={uploading} onMouseDown={noBlur} onClick={() => fileRef.current?.click()}>📎</Button>
+                {showVoice && <VoiceInput inline accent={accent} onResult={appendText} />}
                 <span style={{ flex: 1 }} />
-                {busy && <Button danger title={t('chat.stopTitle')} onClick={stop}>{t('chat.stop')}</Button>}
-                <Button type="primary" loading={sending} onClick={send} style={{ background: accent, borderColor: accent }}>{t('common.send')}</Button>
+                {busy && <Button danger title={t('chat.stopTitle')} onMouseDown={noBlur} onClick={stop}>{t('chat.stop')}</Button>}
+                <Button type="primary" loading={sending} onMouseDown={noBlur} onClick={send} style={{ background: accent, borderColor: accent }}>{t('common.send')}</Button>
               </div>
             </>
           ) : (
@@ -223,8 +234,6 @@ export function ChatShell({ name, dir, accent, title, placeholder, onBack, onRef
             </>
           )}
         </div>
-        {/* 桌面端右下角悬浮语音按钮（长按说话，识别回填输入框）；手机端已内联到按钮行。 */}
-        {!isMobile && <VoiceInput accent={accent} onResult={appendText} />}
       </div>
       <FloatingFileDrawer open={showFiles}>
         <FileBrowser dir={dir} accent={accent} onClose={() => setShowFiles(false)} onInsertPath={insertPath} />

--- a/frontend/src/prompt.test.ts
+++ b/frontend/src/prompt.test.ts
@@ -1,0 +1,74 @@
+// detectPrompt 的回归用例。重点是**窄屏**：手机 attach 后 tmux 窗格常只剩 40 多列，
+// Claude 的选项会折成五六行，早期按「行距 ≤3」分组会把每个选项拆成孤岛 → 手机上根本不弹提问框。
+import { describe, it, expect } from 'vitest'
+import { detectPrompt } from './prompt'
+
+// 宽屏：选项彼此紧挨
+const WIDE = `
+   Select model
+   Switch between Claude models. Your pick becomes the default for new sessions.
+     1. Default (recommended)  Opus 5 with 1M context · Best for everyday tasks
+   ❯ 2. Opus (1M context) ✔    Opus 5 with 1M context · Best for everyday tasks
+     3. Fable                  Fable 5 · Most capable for your hardest tasks
+   Enter to set as default · Esc to cancel
+`
+
+// 窄屏（47 列，真机抓的）：每个选项后面跟 4 行续行，选项之间隔 5 行
+const NARROW = `
+   Select model
+   Switch between Claude models. Your pick
+   becomes the default for new sessions. For
+   other/previous model names, specify with
+   --model.
+
+     1. Default (recommende…  Opus 5 with 1M
+                              context ·
+                              Best for
+                              everyday,
+                              complex tasks
+   ❯ 2. Opus (1M context) ✔   Opus 5 with 1M
+                              context ·
+                              Best for
+                              everyday,
+                              complex tasks
+     3. Fable                 Fable 5 · Most
+                              capable for
+                              your hardest   ↓
+`
+
+// 普通编号列表：没有游标、也没有确认类关键词，不该误判成选择框
+const PLAIN_LIST = `
+   Here is what I changed:
+     1. renamed the helper
+     2. added a test
+     3. updated the docs
+   Done.
+`
+
+describe('detectPrompt', () => {
+  it('宽屏选择框：识别出全部选项与当前游标', () => {
+    const p = detectPrompt(WIDE)
+    expect(p?.kind).toBe('select')
+    expect(p?.choices.map((c) => c.num)).toEqual([1, 2, 3])
+    expect(p?.choices.find((c) => c.selected)?.num).toBe(2)
+  })
+
+  it('窄屏折行选择框：选项隔了 5 行也要认出来（手机回归）', () => {
+    const p = detectPrompt(NARROW)
+    expect(p?.kind).toBe('select')
+    expect(p?.choices.map((c) => c.num)).toEqual([1, 2, 3])
+    expect(p?.choices.find((c) => c.selected)?.num).toBe(2)
+  })
+
+  it('y/n 提示走兜底分支', () => {
+    expect(detectPrompt('Overwrite existing file? (y/n)')?.kind).toBe('yesno')
+  })
+
+  it('普通编号列表不误判', () => {
+    expect(detectPrompt(PLAIN_LIST)).toBeNull()
+  })
+
+  it('空屏返回 null', () => {
+    expect(detectPrompt('')).toBeNull()
+  })
+})

--- a/frontend/src/prompt.tsx
+++ b/frontend/src/prompt.tsx
@@ -173,9 +173,16 @@ export function PromptDialog({ name, accent, enabled = true }: { name: string; a
       closable
       onCancel={() => setDismissedKey(promptKey)}
       mask={false}
+      // 这是「浮在终端上的提示」，不是模态框：
+      //   maskClosable=false —— 点别处不再算「取消」。默认 true 时 rc-dialog 见点击落在 wrap 上就
+      //     onCancel，于是随手点一下终端这条提问就被 dismissedKey 记死、再也不弹（用户报的「点鼠标就没了」）。
+      //   wrapper 透传 —— antd 的 .ant-modal-wrap 不论 mask 真假都是 fixed+inset:0 且可点，会把整页点击
+      //     全吃掉（点不到底下的终端）。置 pointerEvents:none 让它透传；弹框本体 .ant-modal-content
+      //     自带 pointer-events:auto，照常可点。关闭只走右上角 × 或答完题。
+      maskClosable={false}
       width={520}
       centered
-      styles={{ header: { textAlign: 'center' }, body: { paddingTop: 12 } }}
+      styles={{ wrapper: { pointerEvents: 'none' }, header: { textAlign: 'center' }, body: { paddingTop: 12 } }}
     >
       <PromptActions p={p} accent={accent} busy={busy} choose={choose} press={press} />
     </Modal>

--- a/frontend/src/prompt.tsx
+++ b/frontend/src/prompt.tsx
@@ -30,11 +30,13 @@ export function detectPrompt(capture: string): Prompt | null {
     const m = clean(raw).match(OPT)
     if (m) opts.push({ num: Number(m[1]), label: m[2].trim(), selected: CURSOR.test(raw), idx })
   })
-  // 取最后一组相邻选项（允许 ≤3 行间隔，兼容 Codex 长选项换行）
+  // 取最后一组选项。绑定条件是「编号正好接上」而不是单纯挨得近：手机 attach 后 tmux 窗格常只有
+  // 40 多列，Claude 的选项被折成五六行，按行距卡 ≤3 会把每个选项都拆成孤岛 → 一条都识别不出来
+  // （表现为手机上根本不弹提问框）。编号连续性本身就足够防误判，行距只留一个宽松上限兜底。
   const g: P[] = []
   for (let i = opts.length - 1; i >= 0; i--) {
-    if (!g.length) g.unshift(opts[i])
-    else if (g[0].idx - opts[i].idx <= 3) g.unshift(opts[i])
+    if (!g.length) { g.unshift(opts[i]); continue }
+    if (opts[i].num === g[0].num - 1 && g[0].idx - opts[i].idx <= 12) g.unshift(opts[i])
     else break
   }
   // 必须是从 1 起的连续编号、至少两项 —— 否则当普通编号列表，不误判


### PR DESCRIPTION
真机（Redmi Note 8 · adb + CDP 驱动手机 Chrome）跑完验收清单，共 5 个问题，全部已修并在真机上验过。

## 1. 对话面板被 xterm 的透明画布盖住 —— 滑不动、点不着（根因）

xterm 内部画布层（`.xterm-link-layer` 等）带正 z-index，而终端容器只是 `position: relative`（`z-index: auto` 不成层叠上下文），画布因此「逃」到外层，压在同级后面的 Claude/Codex 对话面板之上。那层画布是**透明**的：面板看得见、但所有 pointer/touch 都被它吃掉 —— 聊天区滑不动历史、发送/停止按不动。

修法：终端容器加 `isolation: isolate`，把这些 z-index 关回终端自己那一层。

真机命中测试（`document.elementFromPoint`）：
- 修前：聊天区中心命中 `CANVAS.xterm-link-layer`
- 修后：命中对话内容；手势滚动 `scrollTop` 2180 → 1898 → 2153；发送钮命中自身

## 2. 窄屏下提问框根本识别不出来

`detectPrompt` 按「行距 ≤3」给选项分组。手机 attach 后 tmux 窗格只剩 40 多列，Claude 的选项被折成五六行、彼此隔 5 行，于是每个选项都成孤岛，一条都识别不出 —— 手机上根本不弹提问框。改成用「编号正好接上」绑定（行距只留 ≤12 兜底），新增 `src/prompt.test.ts` 覆盖宽屏 / 窄屏折行 / 普通编号列表不误判 / y-n 兜底。

## 3. 提问弹框：鼠标点一下就永久消失

`PromptDialog` 用 antd `Modal mask={false}` 做浮层，但 `.ant-modal-wrap` 不论 mask 真假都是 `fixed + inset:0` 且可点，`maskClosable` 默认 true。随手点一下终端：① 点击被这层看不见的罩子吃掉（点不到终端）；② 触发 `onCancel` → `dismissedKey` 把该提问记死、再也不弹。

改 `maskClosable={false}` + `styles.wrapper` 置 `pointerEvents: 'none'` 让罩子透传；弹框本体 `.ant-modal-content` 自带 `pointer-events: auto` 不受影响，关闭只走右上角 × 或答完题。

## 4. 工具条「语音输入」开关不联动对话页

开关只写偏好 `showVoiceButton`，终端视图按它渲染，`ChatShell` 却无条件渲染麦克风。改为同走 `usePreferences()`，桌面悬浮钮与手机内联钮一并受控。

## 5. 悬浮麦克风压住「停止 / 发送」

桌面悬浮麦克风原挂在最外层列容器（`absolute bottom:54`、54px 高、`z-index:25`），输入框一涨到两行以上就盖住发送/停止的上半截。改挂进消息滚动区那层定位上下文，与 `bottom:12` 的「回到底部」钮天然错开。手机端 📎/停止/发送 补 `onMouseDown` 阻止默认（同 `App.tsx` 的 `noBlur`），点按钮不夺走文本框焦点。

## 验收

新增 `docs/development/web-ui-checklist.md`：Chrome CLI + 安卓 ADB 的 Web UI 验收清单。核心是「别只看截图」——可点性用 `elementFromPoint` 命中测试，可滚性用 `Input.synthesizeScrollGesture` 前后比 `scrollTop`；并记下「改完前端必须 `Page.reload({ignoreCache: true})`」（hash 路由跳转是同文档导航，不重新加载文档，本次踩了两次，验的都是上一版代码）。

真机按清单跑：**终端/对话 16/16 + 提问弹框 6/6 全绿**（会话打开、连接、无横向滚动、历史渲染、手势滚动双向、命中测试、发送成功、切回终端、语音开关双向联动、弹框自动弹出、点外部不消失 ×2、× 可关）。

本地：`tsc --noEmit` 干净，`vitest` 41 项全过，提交钩子完整质量门（Go 全量测试、i18n 审计 1415 键、密钥扫描）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)