### PR TITLE
fix(term): 久置回前台整链路重同步（只重建渲染器救不了内容坏掉的那类花屏）

### DIFF
--- a/docs/development/web-ui-checklist.md
+++ b/docs/development/web-ui-checklist.md
@@ -50,6 +50,20 @@ chrome goto https://127.0.0.1:13579/ && chrome eval "document.title"
 | 弹层是否被误关 | 触发后等 1.5s 再查节点是否还在 |
 | 布局是否溢出 | `document.documentElement.scrollWidth <= innerWidth` |
 
+## 1.5 「花屏」先分类，再动手
+
+终端花屏有两类，长得一样但修法相反。**别靠截图猜**，用 `__roamTermDiag(true)` 把 xterm 的可视区
+缓冲 dump 出来，跟 `tmux capture-pane -p -t <会话>` 一比：
+
+| 缓冲 vs tmux | 说明 | 修法 |
+|---|---|---|
+| **一致**，但屏幕看着不对 | 本地画错了：WebGL 纹理图集/画布坏了（切后台被回收 GPU、dpr 变化） | 重建渲染器（`rebuildRenderer`）；实在不行整机重建（工具条「重连」） |
+| **不一致** | 内容本身就是坏的：socket 半死、tmux 没重画、TUI 重排留垃圾 | 整链路重同步：关 socket 重连（新 tmux 客户端＝整屏重画）+ 抖尺寸双 SIGWINCH（工具条「重绘」） |
+
+对应的自愈已内置在 `Terminal.tsx`：回前台离开 >1.5s 重建渲染器，>10s 再叠一层关 socket 重连 +
+强制抖动。验证方法：记下 `pgrep -f 'tmux attach -t <会话>'` 的 PID，切后台 30s 再回来，PID 变了
+就说明重新 attach 过。
+
 ## 2. 清单
 
 ### A. 终端页（手机 + 桌面）

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -190,6 +190,8 @@ const Term = forwardRef<TermHandle, {
 
   // 上次 attach 成功时的尺寸，用于判断重连后是否真需要抖动重绘（见 ws.onopen）
   const lastAttach = useRef<{ cols: number; rows: number } | null>(null)
+  // 置位后，下一次 attach 无条件抖动重绘（久置回前台的整链路重同步，见 onVisibility）
+  const forceRepaint = useRef(false)
 
   // 尺寸抖动重绘：cols−1 再复原，两次 SIGWINCH 让 TUI(ink) 整屏重排、清掉错位堆积的垃圾行。
   // 后端 resize 有 cols<20 保护，抖动后一定复原到真实尺寸。
@@ -321,8 +323,10 @@ const Term = forwardRef<TermHandle, {
         const t = termRef.current
         if (!t) return
         const prev = lastAttach.current
+        const forced = forceRepaint.current
+        forceRepaint.current = false
         lastAttach.current = { cols: t.cols, rows: t.rows }
-        if (prev && prev.cols === t.cols && prev.rows === t.rows) return
+        if (!forced && prev && prev.cols === t.cols && prev.rows === t.rows) return
         jiggleResize()
       }, 600)
     }
@@ -434,22 +438,33 @@ const Term = forwardRef<TermHandle, {
     }
     armDprWatch()
 
-    // 切后台再回来（手机上最常见：用一会 → 回桌面/切 App → 过一阵再回来 → 整屏花）。
-    // 后台标签的 GPU 资源会被系统回收，纹理图集/画布随之作废；回到前台时 xterm 不一定收得到
-    // contextlost（安卓上常常是「画布还在、内容是坏的」），于是没人来修，用户只能刷新整页。
-    // 这里在回前台时主动重建一次渲染器再整屏重画。只在真的离开过一会儿才做：短暂切窗口
-    // （<1.5s）画面还好好的，重建纯属浪费还会闪一下。
+    // 切后台再回来（手机上最常见：用一会 → 切出去 → 过一阵回来 → 整屏花）。分两级自愈，
+    // 因为「花屏」其实有两种，修法完全不同（用 __roamTermDiag(true) 把缓冲跟 tmux capture 一比就能分）：
+    //   ① 画布/纹理图集坏了：缓冲内容是对的，只是画错了 → 重建渲染器即可；
+    //   ② 内容本身就是坏的：安卓会把后台页整个冻住，WebSocket 常常「半死」——readyState 还是 1，
+    //      数据其实早就断了；tmux 那头也不会主动重画，于是回来看到的是「旧内容 + 半截新内容」。
+    //      这种只重建渲染器没用（把错的东西再画一遍），必须整条链路重来。
+    // 所以：离开 >1.5s 重建渲染器；离开 >10s 再叠一层——关掉 socket 触发重连（新 tmux 客户端 =
+    // 整屏重画），并置 forceRepaint 让这次 attach 无条件抖一次尺寸，把 TUI 重排的垃圾也清掉。
+    const RESYNC_AFTER_MS = 10000
     let hiddenAt = 0
+    const healAfterAway = (away: number) => {
+      if (away <= 1500) return
+      setTimeout(rebuildRenderer, 60)
+      if (away <= RESYNC_AFTER_MS) return
+      forceRepaint.current = true
+      try { wsRef.current?.close() } catch {} // onclose → 1.2s 后自动重连，走完整 attach 重画
+    }
     const onVisibility = () => {
       if (document.visibilityState === 'hidden') { hiddenAt = performance.now(); return }
       if (!hiddenAt) return
       const away = performance.now() - hiddenAt
       hiddenAt = 0
-      if (away > 1500) setTimeout(rebuildRenderer, 60)
+      healAfterAway(away)
     }
     document.addEventListener('visibilitychange', onVisibility)
-    // 从 bfcache 恢复（安卓返回键、iOS 侧滑返回）不一定走 visibilitychange，单独兜一次
-    const onPageShow = (e: PageTransitionEvent) => { if (e.persisted) setTimeout(rebuildRenderer, 60) }
+    // 从 bfcache 恢复（安卓返回键、iOS 侧滑返回）不一定走 visibilitychange：一律按「久置」处理
+    const onPageShow = (e: PageTransitionEvent) => { if (e.persisted) healAfterAway(RESYNC_AFTER_MS + 1) }
     window.addEventListener('pageshow', onPageShow)
 
     setTimeout(() => { try { fit.fit() } catch {} }, 0)
@@ -838,7 +853,16 @@ const Term = forwardRef<TermHandle, {
 
 // 渲染故障排查用：终端画糊/画空时在浏览器控制台执行 __roamTermDiag()，把每个终端的渲染状态
 // （渲染器类型、dpr、单元格与画布尺寸、行列数、字形是否还在图集里）打出来。纯调试接口，无 UI 文案。
-;(window as any).__roamTermDiag = () => [...liveTerms].map(({ name, term, el, webgl }) => {
+// 传 true 额外 dump 可视区的缓冲文本：拿它跟 `tmux capture-pane -p` 一比，就能分清「花屏」是
+// **本地画错了**（缓冲和 tmux 一致、只有像素不对 → 渲染器问题）还是**内容本来就是坏的**
+// （缓冲里就有错位/残行 → 重绘/数据流问题）。这两类的修法完全不同，别靠肉眼猜。
+;(window as any).__roamTermDiag = (dumpText = false) => [...liveTerms].map(({ name, term, el, webgl }) => {
+  const bufferText = () => {
+    const b = term.buffer.active
+    const out: string[] = []
+    for (let i = 0; i < term.rows; i++) out.push(b.getLine(b.viewportY + i)?.translateToString(true) ?? '')
+    return out
+  }
   const core: any = (term as any)._core
   const dims = core?._renderService?.dimensions
   const canvases = el ? [...el.querySelectorAll('canvas')].map((c) => `${c.width}x${c.height} css ${c.style.width}x${c.style.height}`) : []
@@ -856,6 +880,7 @@ const Term = forwardRef<TermHandle, {
     clientSize: el ? `${el.clientWidth}x${el.clientHeight}` : '',
     viewportY: term.buffer.active.viewportY,
     baseY: term.buffer.active.baseY,
+    ...(dumpText ? { lines: bufferText() } : {}),
   }
 })
 


### PR DESCRIPTION
承接 #134：那一版在回前台时重建渲染器，但用户反馈「久置后重新用网页访问还是花屏」。

## 花屏有两类，长得一样、修法相反

| xterm 缓冲 vs `tmux capture-pane` | 说明 | 修法 |
|---|---|---|
| **一致**，但屏幕看着不对 | 本地画错了：WebGL 纹理图集/画布坏了（后台被回收 GPU、dpr 变化） | 重建渲染器 |
| **不一致** | 内容本身就是坏的：socket 半死、tmux 不主动重画、TUI 重排留垃圾 | 整链路重同步 |

第二类里 socket 是「半死」的：`readyState` 还是 1，数据其实早断了。安卓把后台页整个冻住时就是这个状态，回来看到的是「旧内容 + 半截新内容」。**这种重建渲染器完全没用**，等于把错的东西再画一遍 —— 正是用户说的「还是花」。

## 改动

回前台按离开时长分两级自愈：

- `>1.5s`：重建渲染器（原逻辑）。
- `>10s`：再叠一层 —— 主动 `close()` 掉 WebSocket 触发重连。后端每条 WebSocket 都是一个独立的 `tmux attach` pty（见 `backend/pty/pty.go:Handler`），断开即杀、重连即新客户端，**新客户端 = tmux 整屏重画**；同时置 `forceRepaint` 让这次 attach 无条件抖一次尺寸（双 SIGWINCH），把 TUI 重排残留的垃圾一并清掉。
- bfcache 恢复（安卓返回键/iOS 侧滑）一律按「久置」处理。

配套：`__roamTermDiag(true)` 加上可视区缓冲 dump，拿它跟 `tmux capture-pane -p` 一比就能当场分清是上面哪一类，不用靠肉眼猜；`docs/development/web-ui-checklist.md` 补了这张分类表和验证手法。

## 真机验证（Redmi Note 8 · adb + CDP）

- 切后台 30s 再回前台：`tmux attach` 进程 PID 确实换了（1457607→1459086），状态回到「已连接」，xterm 缓冲与 tmux capture 内容一致，离线期间产生的输出也都在。
- 另外 4 种场景压过当前版本，均**未**复现花屏：断网 90s / 后台 45s 带持续输出 / 后台 10 分钟带持续输出 / 窗口从 216x74 缩到 47x38。

本地：`tsc --noEmit` 干净，`vitest` 41 项全过，提交钩子完整质量门（Go 全量测试、i18n 审计 1416 键、密钥扫描）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)