### PR TITLE
fix(web): 消除终端闪屏与后台状态误报

### DIFF
--- a/backend/api/waiting.go
+++ b/backend/api/waiting.go
@@ -11,14 +11,15 @@ import (
 // 等待用户输入的交互框（Claude/Codex 的权限确认 / 编号选择菜单 / y-n）。列表绿点
 // 语义（设计 W2）里的「黄=待输入」用它，务必与前端解析口径一致，避免列表/详情打架。
 var (
-	waitANSI   = regexp.MustCompile("\x1b\\[[0-?]*[ -/]*[@-~]")
-	waitCtrl   = regexp.MustCompile("[\x00-\x08\x0b-\x1f\x7f]")
-	waitCursor = regexp.MustCompile(`[❯➤▶►▸→›»☞◉●>]`)
-	waitLead   = regexp.MustCompile(`^[\s│┃|╎┆┊╭╰├╞┝─━═]+`)
-	waitTail   = regexp.MustCompile(`[\s│┃|╎┆┊╮╯┤╡┥─━═]+$`)
-	waitOpt    = regexp.MustCompile(`^(?:[❯➤▶►▸→›»☞◉●>]\s*)?(\d+)[.)]\s+(\S.*)$`)
-	waitKW     = regexp.MustCompile(`(?i)(would you like|proceed|allow|continue|overwrite|apply|approve|trust|run|command|是否|确认|继续|允许|要不要|执行|命令)`)
-	waitYesNo  = regexp.MustCompile(`(?i)\((?:y/n|yes/no)\)|\[y/n\]`)
+	waitANSI         = regexp.MustCompile("\x1b\\[[0-?]*[ -/]*[@-~]")
+	waitCtrl         = regexp.MustCompile("[\x00-\x08\x0b-\x1f\x7f]")
+	waitCursorPrefix = regexp.MustCompile(`^[❯➤▶►▸→›»☞◉●>]\s*`)
+	waitLead         = regexp.MustCompile(`^[\s│┃|╎┆┊╭╰├╞┝─━═]+`)
+	waitTail         = regexp.MustCompile(`[\s│┃|╎┆┊╮╯┤╡┥─━═]+$`)
+	waitOpt          = regexp.MustCompile(`^(?:[❯➤▶►▸→›»☞◉●>]\s*)?(\d+)[.)]\s+(\S.*)$`)
+	waitQuestion     = regexp.MustCompile(`(?i)(would you like|do you want|are you sure|should (we|i)|(proceed|allow|continue|overwrite|approve|trust).*[?？]|是否(继续|允许|确认|执行)|(继续|允许|确认|执行).*[?？])`)
+	waitAction       = regexp.MustCompile(`(?i)((enter|return).*(select|confirm|continue|submit|accept)|(esc|escape).*(cancel|back)|(回车|enter).*(选择|确认|继续)|(按|press).*(y|n|yes|no).*(确认|confirm))`)
+	waitYesNo        = regexp.MustCompile(`(?i)\((?:y/n|yes/no)\)|\[y/n\]`)
 )
 
 func waitStripCtl(s string) string {
@@ -52,13 +53,13 @@ func sessionWaiting(capture string) bool {
 	for idx, raw := range lines {
 		if m := waitOpt.FindStringSubmatch(waitClean(raw)); m != nil {
 			n, _ := strconv.Atoi(m[1])
-			opts = append(opts, opt{num: n, idx: idx, selected: waitCursor.MatchString(raw)})
+			opts = append(opts, opt{num: n, idx: idx, selected: waitCursorPrefix.MatchString(waitClean(raw))})
 		}
 	}
-	// 取最后一组相邻选项（允许 ≤3 行间隔，兼容 Codex 长选项换行）
+	// 取最后一组连续编号选项。窄屏下单个选项可能折成多行，与前端统一放宽到 ≤12 行。
 	var g []opt
 	for i := len(opts) - 1; i >= 0; i-- {
-		if len(g) == 0 || g[0].idx-opts[i].idx <= 3 {
+		if len(g) == 0 || g[0].idx-opts[i].idx <= 12 {
 			g = append([]opt{opts[i]}, g...)
 		} else {
 			break
@@ -104,22 +105,26 @@ func sessionWaiting(capture string) bool {
 			win = append(win, waitClean(l))
 		}
 		windowText := strings.Join(win, " ")
-		anySel := false
+		selectedCount := 0
 		for _, o := range g {
 			if o.selected {
-				anySel = true
-				break
+				selectedCount++
 			}
 		}
-		if anySel || waitKW.MatchString(question) || waitKW.MatchString(windowText) {
+		if selectedCount == 1 || (waitQuestion.MatchString(question) && waitAction.MatchString(windowText)) {
 			return true
 		}
 	}
 	// y/n 兜底
 	for i := len(lines) - 1; i >= 0 && len(lines)-i <= 12; i-- {
-		if waitYesNo.MatchString(waitClean(lines[i])) {
+		line := waitClean(lines[i])
+		if line == "" {
+			continue
+		}
+		if waitYesNo.MatchString(line) {
 			return true
 		}
+		break
 	}
 	return false
 }

--- a/backend/api/waiting_test.go
+++ b/backend/api/waiting_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+func TestSessionWaitingRejectsAgentCommandList(t *testing.T) {
+	capture := `Running implementation work…
+  1. Run the formatter command
+  2. Continue with the typecheck
+  3. Write the result > report.txt
+Working…`
+	if sessionWaiting(capture) {
+		t.Fatal("normal agent command list must not be treated as waiting for confirmation")
+	}
+}
+
+func TestSessionWaitingRejectsQuotedListAndHistoricalYesNo(t *testing.T) {
+	capture := `Documentation example:
+> 1. Run the command
+> 2. Continue editing
+Answer prompts with (y/n).
+Done.`
+	if sessionWaiting(capture) {
+		t.Fatal("quoted list or historical y/n text must not be treated as a current prompt")
+	}
+}
+
+func TestSessionWaitingAcceptsCursorMenu(t *testing.T) {
+	capture := `Select model
+  1. Default
+❯ 2. Opus
+  3. Fable
+Enter to select · Esc to cancel`
+	if !sessionWaiting(capture) {
+		t.Fatal("menu with an option cursor must be treated as waiting for confirmation")
+	}
+}
+
+func TestSessionWaitingAcceptsExplicitPromptWithoutCursor(t *testing.T) {
+	capture := `Are you sure you want to proceed?
+  1. Yes, continue
+  2. No, go back
+Enter to confirm · Esc to cancel`
+	if !sessionWaiting(capture) {
+		t.Fatal("explicit question with action hints must be treated as waiting for confirmation")
+	}
+}

--- a/backend/pty/pty.go
+++ b/backend/pty/pty.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	creackpty "github.com/creack/pty"
 	"github.com/gin-gonic/gin"
@@ -335,6 +336,14 @@ func Handler(c *gin.Context) {
 		_, _ = cmd.Process.Wait()
 	}()
 	lastSize := *sz
+	// pty 输出和控制消息 pong 可能同时写 WebSocket。gorilla 只允许一个并发 writer，
+	// 所有连接级写入必须从这个小闸门经过，否则后台恢复探测会偶发 concurrent write panic。
+	var writeMu sync.Mutex
+	writeMessage := func(messageType int, data []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteMessage(messageType, data)
+	}
 
 	// pty → ws
 	go func() {
@@ -342,12 +351,12 @@ func Handler(c *gin.Context) {
 		for {
 			n, err := ptmx.Read(buf)
 			if n > 0 {
-				if werr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); werr != nil {
+				if werr := writeMessage(websocket.BinaryMessage, buf[:n]); werr != nil {
 					return
 				}
 			}
 			if err != nil {
-				conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				_ = writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 				conn.Close()
 				return
 			}
@@ -374,9 +383,21 @@ func Handler(c *gin.Context) {
 				Lines int    `json:"lines"`
 				Col   int    `json:"col"`
 				Row   int    `json:"row"`
+				ID    string `json:"id"`
 			}
 			if json.Unmarshal(data, &ctrl) == nil && ctrl.Type != "" {
 				switch ctrl.Type {
+				case "ping":
+					// 浏览器从长时间后台恢复时先探测连接，不再无条件 close 全部终端。
+					// pong 只证明这条 WS/PTY 桥仍可双向通信，不触碰 tmux 尺寸和屏幕内容。
+					pong, _ := json.Marshal(struct {
+						Type string `json:"type"`
+						ID   string `json:"id"`
+					}{Type: "pong", ID: ctrl.ID})
+					if err := writeMessage(websocket.TextMessage, pong); err != nil {
+						return
+					}
+					continue
 				case "resize":
 					// 防御异常尺寸：前端布局未就绪 / 面板折叠 / 离屏挂载时可能发来极窄的 cols(如 2)。
 					// 因 window-size=latest，这会把共享会话挤成「窄条」，且客户端断开后仍卡住——

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,8 @@ import { useThemeMode } from './theme'
 import { useI18n } from './i18n'
 import { usePwaInstall } from './install'
 import { usePreferences, savePreferences, loadPreferences } from './preferences'
-import { PromptDialog, detectPrompt } from './prompt'
+import { PromptDialog, advancePromptSignal, detectPrompt } from './prompt'
+import type { PromptSignal } from './prompt'
 import { copyText } from './chat/blocks'
 import { SessionTitle, setSessionLabels, updateSessionLabel, useSessionLabel, sessionLabel, sessionDisplay } from './session-label'
 import { VoiceInput } from './chat/VoiceInput'
@@ -458,9 +459,12 @@ export default function App() {
   }
   const anyClaude = terms.some((t) => claudeMap[t]?.running || codexMap[t]?.running)
   const docked = hasSider && terms.length > 0 && dockOpen // 桌面停靠栏已展开
-  const dockResizesPage = docked && tab !== 'browser'
+  // 停靠终端的几何必须跨页面稳定。旧逻辑给 browser 单独走 flex 布局、其它页面又按各自的
+  // 默认宽度布局，切一次导航就会改变终端列数 → tmux 收到 SIGWINCH 后整屏重排，肉眼就是闪屏。
+  // IDE 的停靠面板应独立于主页面类型，因此所有桌面页面统一保留同一块主内容宽度。
+  const dockResizesPage = docked
   const filesDefaultWidth = typeof window === 'undefined' ? 640 : Math.round((window.innerWidth - (collapsed ? 64 : 208) - 18) * 0.5)
-  const defaultDockWidth = tab === 'files' ? Math.max(520, Math.min(900, filesDefaultWidth)) : tab === 'sessions' || tab === 'overview' || tab === 'swarm' || tab === 'settings' || tab === 'phone' ? 420 : 300
+  const defaultDockWidth = Math.max(520, Math.min(900, filesDefaultWidth))
   const dockPageWidth = customDockWidth ?? defaultDockWidth
   const setStatus = (name: string, s: TermStatus) => setStatusMap((m) => ({ ...m, [name]: s }))
   const sendKey = (seq: string) => active && termRefs.current[active]?.send(seq)
@@ -533,7 +537,8 @@ export default function App() {
   return (
     <Layout style={{ height: '100dvh', overflow: 'hidden', background: 'var(--bg-base)' }}>
       <UpdateBanner />
-      {/* 拖动时只移动引导线，松手才提交布局，避免 HTML iframe 在每个指针事件上完整重排。 */}
+      {/* 拖动停靠分隔栏时只移动引导线，松手才提交一次布局。若持续改变页面/终端宽度，
+          HTML iframe 会高频重排，ResizeObserver 也会反复 fit → SIGWINCH → tmux 整屏重排。 */}
       <div ref={dockGuideRef} data-dock-resize-guide style={{
         display: 'none', position: 'fixed', top: 0, bottom: 0, width: 2, zIndex: 1000,
         pointerEvents: 'none', background: '#58a6ff', boxShadow: '0 0 0 1px rgba(88,166,255,.18)',
@@ -647,7 +652,11 @@ export default function App() {
                       if (guide) guide.style.display = 'none'
                       const next = pendingDockWidth.current
                       pendingDockWidth.current = null
-                      if (next != null && next !== startW) setCustomDockWidth(next)
+                      if (next != null && next !== startW) {
+                        // 在 React 提交新几何之前冻结当前帧；Terminal 会等新尺寸内容画好后自行交接。
+                        if (active) termRefs.current[active]?.beginVisualHandoff()
+                        setCustomDockWidth(next)
+                      }
                     },
                   })
                 }}
@@ -846,6 +855,7 @@ function TerminalPane(props: {
   const { t } = useI18n()
   const st = active ? statusMap[active] : undefined
   const [termNeedsInput, setTermNeedsInput] = useState<Record<string, boolean>>({})
+  const promptSignals = useRef<Record<string, PromptSignal>>({})
   const activeNeedsInput = !!(active && termNeedsInput[active])
   const dot = activeNeedsInput ? '#d29922' : st === 'connected' ? '#3fb950' : st === 'connecting' ? '#d29922' : '#f85149'
   // 当前标签是否在 Claude/Codex 对话视图：此时聊天 UI 自带输入框，
@@ -981,7 +991,11 @@ function TerminalPane(props: {
   }, [active, claudeMap, codexMap])
 
   useEffect(() => {
-    if (!terms.length) { setTermNeedsInput({}); return }
+    if (!terms.length) {
+      promptSignals.current = {}
+      setTermNeedsInput((previous) => Object.keys(previous).length ? {} : previous)
+      return
+    }
     let stop = false
     const checkPrompts = async () => {
       const entries = await Promise.all(terms.map(async (name) => {
@@ -992,7 +1006,21 @@ function TerminalPane(props: {
           return [name, false] as const
         }
       }))
-      if (!stop) setTermNeedsInput(Object.fromEntries(entries))
+      if (stop) return
+      const nextSignals: Record<string, PromptSignal> = {}
+      const nextState: Record<string, boolean> = {}
+      entries.forEach(([name, candidate]) => {
+        const signal = advancePromptSignal(promptSignals.current[name], candidate)
+        nextSignals[name] = signal
+        nextState[name] = signal.stable
+      })
+      promptSignals.current = nextSignals
+      // 未发生语义变化时复用旧对象，避免后台抓屏每 4 秒让整个终端区无意义重渲染。
+      setTermNeedsInput((previous) => {
+        const keys = Object.keys(nextState)
+        const unchanged = keys.length === Object.keys(previous).length && keys.every((name) => previous[name] === nextState[name])
+        return unchanged ? previous : nextState
+      })
     }
     checkPrompts()
     const t = setInterval(checkPrompts, 4000)
@@ -1221,7 +1249,15 @@ function TerminalPane(props: {
       )}
       <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
         {terms.map((termName) => (
-          <div key={termName} style={{ position: 'absolute', inset: 0, display: termName === active ? 'block' : 'none', padding: 6 }}>
+          // 非当前终端不能用 display:none：xterm 会暂停渲染且容器尺寸归零，切换或关闭当前标签时
+          // 下一张 WebGL 画布要经过“重新量尺寸 → 清画布 → 重画”，中间会露出 1~2 帧黑屏。
+          // visibility:hidden 保留真实尺寸并让后台画布保持就绪；pointerEvents/zIndex 隔离交互与层叠。
+          <div key={termName} style={{
+            position: 'absolute', inset: 0, padding: 6,
+            visibility: termName === active ? 'visible' : 'hidden',
+            pointerEvents: termName === active ? 'auto' : 'none',
+            zIndex: termName === active ? 1 : 0,
+          }}>
             <Term ref={(h) => { termRefs.current[termName] = h }} name={termName} fontSize={fontSize} active={termName === active} onStatus={(s) => setStatus(termName, s)}
               onContextMenu={({ x, y, selection }) => { setActive(termName); setCtx({ x, y, session: termName, selection }) }}
               onSelectionMenu={({ selection }) => { setActive(termName); setCtx(null); if (selection.trim()) { copyText(selection); message.success(t('common.copied')) } }}

--- a/frontend/src/Terminal.tsx
+++ b/frontend/src/Terminal.tsx
@@ -9,6 +9,9 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import '@xterm/xterm/css/xterm.css'
 // 终端符号补字集（约 46KB，仅覆盖框线/箭头/技术符号等区段）：见 FONT_FAMILY 的说明
 import './assets/fonts/roam-symbols.css'
+import { shouldJiggleAfterAttach } from './terminal-resize'
+import type { TerminalDimensions } from './terminal-resize'
+import { parseTerminalPong } from './terminal-lifecycle'
 
 export type TermStatus = 'connecting' | 'connected' | 'closed'
 export interface TermHandle {
@@ -26,6 +29,8 @@ export interface TermHandle {
   // 尺寸抖动(cols−1→cols)触发两次 SIGWINCH，逼全屏 TUI 整屏重排重绘。
   // 窄屏(手机)下 Claude Code 等 ink TUI 折行重绘错位会满屏堆叠垃圾行，等价于「拖一下窗口就好了」。
   redraw: () => void
+  // 外层布局即将一次性提交新尺寸时，先冻结当前终端帧；新尺寸完成绘制后组件会自动交接。
+  beginVisualHandoff: () => void
 }
 
 // ── 渲染器坏掉时的自救 ─────────────────────────────────────────────────────
@@ -52,6 +57,49 @@ let atlasClearedForFonts = false
 // 非等宽字体，字形宽度 ≠ 单元格宽度，误差沿行累积就是「同一行后半段错位、字形互相压盖」。
 // 剩下确实超宽的字形（emoji 等）由 rescaleOverlappingGlyphs 压回单元格（需 WebGL 渲染器）。
 const FONT_FAMILY = 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Roam Symbols", monospace'
+const FRAME_STORAGE_PREFIX = 'roam:terminal-frame:'
+const FRAME_MAX_AGE_MS = 15000
+
+type StoredTerminalFrame = { savedAt: number; dataUrl: string }
+
+// 把 xterm 的一个或多个 canvas 合成为单张位图。WebGL 使用 preserveDrawingBuffer，因而这里
+// 能同步读取刚刚显示的像素；DOM renderer 没有 canvas 时返回 false，由正常重绘路径兜底。
+function copyTerminalFrame(source: HTMLElement, target: HTMLCanvasElement): boolean {
+  const sourceRect = source.getBoundingClientRect()
+  const canvases = [...source.querySelectorAll('canvas')].filter((canvas) => canvas.width > 0 && canvas.height > 0)
+  if (!canvases.length || sourceRect.width <= 0 || sourceRect.height <= 0) return false
+  const dpr = Math.max(1, window.devicePixelRatio || 1)
+  target.width = Math.max(1, Math.round(sourceRect.width * dpr))
+  target.height = Math.max(1, Math.round(sourceRect.height * dpr))
+  const ctx = target.getContext('2d')
+  if (!ctx) return false
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.fillStyle = xtermTheme().background
+  ctx.fillRect(0, 0, sourceRect.width, sourceRect.height)
+  try {
+    for (const canvas of canvases) {
+      const rect = canvas.getBoundingClientRect()
+      ctx.drawImage(canvas, rect.left - sourceRect.left, rect.top - sourceRect.top, rect.width, rect.height)
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+function loadStoredTerminalFrame(name: string): string | undefined {
+  try {
+    const key = FRAME_STORAGE_PREFIX + name
+    const raw = sessionStorage.getItem(key)
+    sessionStorage.removeItem(key) // 快照只供紧接着的一次页面恢复使用
+    if (!raw) return undefined
+    const frame = JSON.parse(raw) as StoredTerminalFrame
+    if (!frame.dataUrl || Date.now() - frame.savedAt > FRAME_MAX_AGE_MS) return undefined
+    return frame.dataUrl
+  } catch {
+    return undefined
+  }
+}
 
 // xterm 不认 CSS var()，需具体色值：读 <html> 上的同名变量，随黑/白主题切换。
 function xtermTheme() {
@@ -121,35 +169,98 @@ const Term = forwardRef<TermHandle, {
   onImagePaste?: (files: File[]) => void // 粘贴事件含图片时回调（绕过键盘拦截时的兜底）
 }>(function Term({ name, fontSize, active, onStatus, onContextMenu, onSelectionMenu, onPaste, onImagePaste }, ref) {
   const elRef = useRef<HTMLDivElement>(null)
+  const handoffCanvasRef = useRef<HTMLCanvasElement>(null)
+  const restoredFrameRef = useRef<HTMLImageElement>(null)
+  const [restoredFrame] = useState(() => loadStoredTerminalFrame(name))
   const termRef = useRef<Terminal>()
   const fitRef = useRef<FitAddon>()
   const wsRef = useRef<WebSocket>()
   const unmounted = useRef(false)
   const retry = useRef<any>()
   const webglRef = useRef<WebglAddon>()
+  const activeRef = useRef(active)
+  activeRef.current = active
+  const hasServerFrame = useRef(false)
+  const handoffVisible = useRef(false)
+  const handoffAwaitingServer = useRef(false)
+  const handoffReleaseTimer = useRef<ReturnType<typeof setTimeout>>()
+  const handoffSafetyTimer = useRef<ReturnType<typeof setTimeout>>()
+  const handoffRaf = useRef<number>()
+  const resumeProbeTimer = useRef<ReturnType<typeof setTimeout>>()
+  const resumeProbeID = useRef('')
+  const resumeProbeSeq = useRef(0)
+  const silentReconnect = useRef(false)
+  const resumeHealPending = useRef(false)
+  const rebuildRendererRef = useRef<() => void>()
   // 自增一次 = 拆掉 xterm 实例重建（渲染器/纹理图集/WebSocket 全新），效果等同刷新整页
   const [gen, setGen] = useState(0)
+
+  const hideVisualHandoff = () => {
+    handoffVisible.current = false
+    handoffAwaitingServer.current = false
+    if (handoffCanvasRef.current) handoffCanvasRef.current.style.display = 'none'
+    if (restoredFrameRef.current) restoredFrameRef.current.style.display = 'none'
+  }
+
+  const releaseVisualHandoff = (delay = 80) => {
+    clearTimeout(handoffReleaseTimer.current)
+    handoffReleaseTimer.current = setTimeout(() => {
+      cancelAnimationFrame(handoffRaf.current || 0)
+      handoffRaf.current = requestAnimationFrame(() => {
+        handoffRaf.current = requestAnimationFrame(hideVisualHandoff)
+      })
+    }, delay)
+  }
+
+  // resize canvas 会按规范清空像素。先同步复制旧帧覆盖在 xterm 上面，等新数据 parse + render 后
+  // 再切掉覆盖层，用户看到的是旧帧直接交接到新帧，而不是中间那张空白画布。
+  const beginVisualHandoff = () => {
+    if (!activeRef.current || !hasServerFrame.current || handoffVisible.current) return
+    const el = elRef.current, canvas = handoffCanvasRef.current
+    if (!el || !canvas || !copyTerminalFrame(el, canvas)) return
+    handoffVisible.current = true
+    canvas.style.display = 'block'
+    clearTimeout(handoffSafetyTimer.current)
+    handoffSafetyTimer.current = setTimeout(hideVisualHandoff, 2000)
+  }
+
+  const acknowledgeConnection = () => {
+    if (!resumeProbeID.current) return
+    resumeProbeID.current = ''
+    clearTimeout(resumeProbeTimer.current)
+  }
 
   // 已上报给后端的尺寸。相同尺寸重复上报没有意义，却会让后端 Setsize → SIGWINCH →
   // tmux 整屏重排 → 肉眼一闪，所以这里做去重闸门。新连接时清零以强制重报（新 tmux 客户端要知道尺寸）。
   const lastSent = useRef({ cols: 0, rows: 0 })
   const resizeTimer = useRef<any>()
 
-  const applyResize = () => {
+  // 唯一的“测量 → 本地 fit → 必要时通知 tmux”入口。所有普通布局来源都只能直接或防抖后走这里。
+  const applyResize = (): TerminalDimensions | null => {
     const t = termRef.current, ws = wsRef.current, fit = fitRef.current, el = elRef.current
-    if (!t || !fit || !el) return
-    // 未激活的标签是 display:none、尺寸为 0：此时 fit 拿不到真实宽度，会让终端停在默认 80 列，
-    // tmux 便渲染成左侧窄条。隐藏或尚未布局时跳过，等可见(切回标签)再 fit。
-    if (el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0) return
+    if (!t || !fit || !el) return null
+    // 尚未布局（例如整个停靠栏收起）时 fit 拿不到真实宽度，会让终端停在默认 80 列，
+    // tmux 便渲染成左侧窄条。此时跳过，等容器恢复布局后再由 ResizeObserver / active effect 适配。
+    if (el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0) return null
     try {
       const dims = fit.proposeDimensions()
-      if (!dims || !isFinite(dims.cols) || !isFinite(dims.rows) || dims.cols < 2 || dims.rows < 2) return
+      if (!dims || !isFinite(dims.cols) || !isFinite(dims.rows) || dims.cols < 2 || dims.rows < 2) return null
+      const changesCells = dims.cols !== t.cols || dims.rows !== t.rows
+      if (changesCells) beginVisualHandoff()
       fit.fit()
-      if (!ws || ws.readyState !== 1) return
-      if (t.cols === lastSent.current.cols && t.rows === lastSent.current.rows) return
-      lastSent.current = { cols: t.cols, rows: t.rows }
-      ws.send(JSON.stringify({ type: 'resize', cols: t.cols, rows: t.rows }))
-    } catch {}
+      const current = { cols: t.cols, rows: t.rows }
+      let sentResize = false
+      if (ws?.readyState === 1 && (current.cols !== lastSent.current.cols || current.rows !== lastSent.current.rows)) {
+        lastSent.current = current
+        ws.send(JSON.stringify({ type: 'resize', ...current }))
+        sentResize = true
+      }
+      if (handoffVisible.current) {
+        handoffAwaitingServer.current = changesCells && sentResize
+        if (!handoffAwaitingServer.current) releaseVisualHandoff()
+      }
+      return current
+    } catch { return null }
   }
 
   // 高频尺寸变化合并成一次。手机上触发源极密集：软键盘弹出/收起的动画每帧一次、地址栏随页面
@@ -307,45 +418,85 @@ const Term = forwardRef<TermHandle, {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws'
     // 带上当前尺寸：后端据此建 pty，tmux attach 首帧就按真实尺寸画，省掉「先按 80x24 画完再跳一次」
     const t0 = termRef.current
-    const q = t0 && t0.cols > 1 && t0.rows > 1 ? `?cols=${t0.cols}&rows=${t0.rows}` : ''
+    const requested = t0 && t0.cols > 1 && t0.rows > 1 ? { cols: t0.cols, rows: t0.rows } : null
+    const q = requested ? `?cols=${requested.cols}&rows=${requested.rows}` : ''
     const ws = new WebSocket(`${proto}://${location.host}/api/term/${encodeURIComponent(name)}${q}`)
     ws.binaryType = 'arraybuffer'
     wsRef.current = ws
     ws.onopen = () => {
+      silentReconnect.current = false
       onStatus?.('connected'); termRef.current?.focus()
-      lastSent.current = { cols: 0, rows: 0 } // 新 tmux 客户端要重新告知尺寸，绕过去重闸门
+      // query 已经决定了新 pty 的尺寸，把它记为“已同步”。若连接建立期间布局又变了，
+      // applyResize 会只补发最终的新尺寸；没有变化则不再发送一次重复 resize。
+      lastSent.current = requested || { cols: 0, rows: 0 }
       applyResize()
-      // attach 尺寸常与上个客户端不同(桌面↔手机)，宽行重折行会在 TUI 屏上留错位垃圾；
-      // 等首次 resize 生效后自动抖动重绘一次，进来就是干净画面。
-      // 但尺寸与上次 attach 相同时不抖：手机切后台/锁屏/网络抖动会频繁断线重连，
-      // 每次都抖两下 SIGWINCH 就成了周期性闪烁，而同尺寸重连本来就没有折行垃圾要清。
+      // 首次 attach 已在 URL query 里带真实尺寸，不再自动 cols-1 → cols 抖两次：刷新页面时
+      // 那两次 SIGWINCH 正是稳定复现的闪屏。仅真实尺寸变化或久置恢复的强制重同步才 jiggle。
       setTimeout(() => {
         const t = termRef.current
         if (!t) return
         const prev = lastAttach.current
         const forced = forceRepaint.current
         forceRepaint.current = false
-        lastAttach.current = { cols: t.cols, rows: t.rows }
-        if (!forced && prev && prev.cols === t.cols && prev.rows === t.rows) return
-        jiggleResize()
+        const current = { cols: t.cols, rows: t.rows }
+        lastAttach.current = current
+        if (shouldJiggleAfterAttach(prev, current, forced)) jiggleResize()
       }, 600)
     }
     ws.onmessage = (e) => {
       const t = termRef.current
       if (!t) return
-      if (typeof e.data === 'string') t.write(stripMouseEnableStr(e.data))
-      else t.write(stripMouseEnableBytes(new Uint8Array(e.data as ArrayBuffer)))
+      if (typeof e.data === 'string') {
+        const pong = parseTerminalPong(e.data)
+        if (pong) {
+          if (pong.id === resumeProbeID.current) acknowledgeConnection()
+          return
+        }
+      }
+      // 收到任何 PTY 数据都足以证明连接存活；写入解析完成后再让新帧接管旧帧。
+      acknowledgeConnection()
+      hasServerFrame.current = true
+      const data = typeof e.data === 'string'
+        ? stripMouseEnableStr(e.data)
+        : stripMouseEnableBytes(new Uint8Array(e.data as ArrayBuffer))
+      t.write(data, () => releaseVisualHandoff())
     }
     ws.onclose = () => {
-      onStatus?.('closed')
+      acknowledgeConnection()
+      const reconnectImmediately = silentReconnect.current
+      if (!reconnectImmediately) onStatus?.('closed')
       if (unmounted.current) return
-      retry.current = setTimeout(connect, 1200) // 断线自动重连
+      retry.current = setTimeout(connect, reconnectImmediately ? 0 : 1200) // 探测失败立即接管；普通断线稍后重试
     }
+  }
+
+  // 浏览器在后台可能冻结网络事件，readyState=OPEN 并不一定代表链路仍活着。恢复时先发无副作用
+  // ping；pong 或任何 PTY 数据都算存活。只有超时才静默重连，正常恢复不改变绿点、不重画 tmux。
+  const probeConnection = () => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    clearTimeout(resumeProbeTimer.current)
+    const id = `${Date.now()}-${++resumeProbeSeq.current}`
+    resumeProbeID.current = id
+    try {
+      ws.send(JSON.stringify({ type: 'ping', id }))
+    } catch {
+      resumeProbeID.current = ''
+      return
+    }
+    resumeProbeTimer.current = setTimeout(() => {
+      if (resumeProbeID.current !== id || wsRef.current !== ws) return
+      resumeProbeID.current = ''
+      beginVisualHandoff()
+      silentReconnect.current = true
+      onStatus?.('connecting')
+      try { ws.close() } catch {}
+    }, 2500)
   }
 
   useImperativeHandle(ref, () => ({
     send: (s, keepFocus) => { const ws = wsRef.current; if (ws && ws.readyState === 1) ws.send(s); if (!keepFocus) termRef.current?.focus() },
-    fit: () => applyResize(),
+    fit: () => { applyResize() },
     copy: () => {
       const sel = termRef.current?.getSelection() || ''
       if (sel) copyText(sel)
@@ -361,6 +512,7 @@ const Term = forwardRef<TermHandle, {
     toBottom: () => sendScroll('bottom', 0),
     selectPaneAt: (clientX, clientY) => selectPaneAtClient(clientX, clientY),
     redraw: () => jiggleResize(),
+    beginVisualHandoff,
   }))
 
   useEffect(() => {
@@ -381,19 +533,26 @@ const Term = forwardRef<TermHandle, {
     term.open(elRef.current!)
     termRef.current = term
     fitRef.current = fit
+    if (restoredFrame) {
+      // 正常由首批 PTY 数据的 write callback 撤下；后端异常/会话已消失时也不能永久盖着旧图。
+      clearTimeout(handoffSafetyTimer.current)
+      handoffSafetyTimer.current = setTimeout(hideVisualHandoff, 2000)
+    }
     const diagEntry = { name, term, el: elRef.current, webgl: () => !!webglRef.current }
     liveTerms.add(diagEntry)
 
     // WebGL 渲染器：默认的 DOM 渲染器每格一个 span，单元格宽是分数像素，手机 dpr 常为 2.625/3
     // 这类非整数，亚像素误差累积会裁字/叠字，整屏重绘也更容易看到闪烁。WebGL 按纹理网格绘制，
     // 顺带让 rescaleOverlappingGlyphs 生效。
+    // preserveDrawingBuffer=true：终端旁边的标签/页面发生 DOM 更新时，Chrome 可能重新合成 WebGL
+    // canvas；不保留绘制缓冲会在 xterm 下一次 render 前露出空帧。这里优先保证 IDE 终端画面稳定。
     // 上下文丢失（后台切回/GPU 回收/同页 WebGL 上下文超上限被回收最老的那个）时**先试着重建**，
     // 连着重建都失败才退回 DOM 渲染器——旧写法一丢就永久 dispose，此后这个标签一直是降级渲染。
     let lostAt = 0
     const mountWebgl = () => {
       if (unmounted.current) return
       try {
-        const webgl = new WebglAddon()
+        const webgl = new WebglAddon(true)
         webgl.onContextLoss(() => {
           try { webgl.dispose() } catch {}
           webglRef.current = undefined
@@ -413,12 +572,15 @@ const Term = forwardRef<TermHandle, {
     // 不重连、不动后端，只修「本地画丢了」这一类故障。
     const rebuildRenderer = () => {
       if (unmounted.current || termRef.current !== term) return
+      beginVisualHandoff()
       try { webglRef.current?.dispose() } catch {}
       webglRef.current = undefined
       mountWebgl()
       applyResize()
       try { term.refresh(0, term.rows - 1) } catch {}
+      releaseVisualHandoff(100)
     }
+    rebuildRendererRef.current = rebuildRenderer
 
     // dpr 变化（桌面浏览器缩放 Ctrl+± / 拖到另一块缩放比不同的屏、手机页面缩放/横竖屏）：
     // xterm 要按新 dpr 重建纹理图集与画布，这条路径上偶发整屏画空，且后端重绘救不回来。
@@ -438,22 +600,23 @@ const Term = forwardRef<TermHandle, {
     }
     armDprWatch()
 
-    // 切后台再回来（手机上最常见：用一会 → 切出去 → 过一阵回来 → 整屏花）。分两级自愈，
+    // 切后台再回来（手机上最常见：用一会 → 切出去 → 过一阵回来 → 整屏花）。
     // 因为「花屏」其实有两种，修法完全不同（用 __roamTermDiag(true) 把缓冲跟 tmux capture 一比就能分）：
     //   ① 画布/纹理图集坏了：缓冲内容是对的，只是画错了 → 重建渲染器即可；
     //   ② 内容本身就是坏的：安卓会把后台页整个冻住，WebSocket 常常「半死」——readyState 还是 1，
     //      数据其实早就断了；tmux 那头也不会主动重画，于是回来看到的是「旧内容 + 半截新内容」。
     //      这种只重建渲染器没用（把错的东西再画一遍），必须整条链路重来。
-    // 所以：离开 >1.5s 重建渲染器；离开 >10s 再叠一层——关掉 socket 触发重连（新 tmux 客户端 =
-    // 整屏重画），并置 forceRepaint 让这次 attach 无条件抖一次尺寸，把 TUI 重排的垃圾也清掉。
-    const RESYNC_AFTER_MS = 10000
+    // 旧实现按离开时长无条件关闭每一个 WS，导致全部绿点先变红、随后集体重连闪屏。现在渲染器
+    // 只在真正可见的终端上通过帧交接重建；连接一律先 ping 探测，失败才静默重连。
     let hiddenAt = 0
     const healAfterAway = (away: number) => {
       if (away <= 1500) return
-      setTimeout(rebuildRenderer, 60)
-      if (away <= RESYNC_AFTER_MS) return
-      forceRepaint.current = true
-      try { wsRef.current?.close() } catch {} // onclose → 1.2s 后自动重连，走完整 attach 重画
+      resumeHealPending.current = true
+      if (activeRef.current) {
+        resumeHealPending.current = false
+        setTimeout(rebuildRenderer, 60)
+      }
+      probeConnection()
     }
     const onVisibility = () => {
       if (document.visibilityState === 'hidden') { hiddenAt = performance.now(); return }
@@ -463,11 +626,22 @@ const Term = forwardRef<TermHandle, {
       healAfterAway(away)
     }
     document.addEventListener('visibilitychange', onVisibility)
-    // 从 bfcache 恢复（安卓返回键、iOS 侧滑返回）不一定走 visibilitychange：一律按「久置」处理
-    const onPageShow = (e: PageTransitionEvent) => { if (e.persisted) healAfterAway(RESYNC_AFTER_MS + 1) }
+    // 从 bfcache 恢复（安卓返回键、iOS 侧滑返回）不一定走 visibilitychange。
+    const onPageShow = (e: PageTransitionEvent) => { if (e.persisted) healAfterAway(1501) }
     window.addEventListener('pageshow', onPageShow)
 
-    setTimeout(() => { try { fit.fit() } catch {} }, 0)
+    // 硬刷新会销毁整个 document，运行时的覆盖层无法跨文档存在。离开前仅为当前终端保存一张
+    // 短时 session 快照；新文档首个真实 PTY 帧完成后立即移除。bfcache 自带旧 DOM，无需保存。
+    const onPageHide = (e: PageTransitionEvent) => {
+      if (e.persisted || !activeRef.current || !hasServerFrame.current || !elRef.current) return
+      const frame = document.createElement('canvas')
+      if (!copyTerminalFrame(elRef.current, frame)) return
+      try {
+        const stored: StoredTerminalFrame = { savedAt: Date.now(), dataUrl: frame.toDataURL('image/webp', 0.92) }
+        sessionStorage.setItem(FRAME_STORAGE_PREFIX + name, JSON.stringify(stored))
+      } catch { /* storage quota / WebGL 读取失败时继续走普通首屏 */ }
+    }
+    window.addEventListener('pagehide', onPageHide)
 
     // 预热符号补字集。两点必须注意：
     //   1. 带 unicode-range 的 webfont 是「按需加载」的，而 WebGL/Canvas 渲染器是把字形画进
@@ -567,7 +741,21 @@ const Term = forwardRef<TermHandle, {
       }
       ws.send(d)
     })
-    const onViewportChange = () => scheduleResize()
+    // 首次恢复标签时外层 Content 会执行 200ms 宽度过渡。过去 connect() 立即拿到过渡首帧的
+    // 309 列，稍后又 resize 到 181 列；现在等待 ResizeObserver 安静 250ms，再按最终尺寸 attach。
+    let initialConnectTimer: ReturnType<typeof setTimeout> | undefined
+    const connectAfterLayoutSettles = () => {
+      clearTimeout(initialConnectTimer)
+      initialConnectTimer = setTimeout(() => {
+        if (unmounted.current || wsRef.current) return
+        if (!applyResize()) { connectAfterLayoutSettles(); return }
+        connect()
+      }, 250)
+    }
+    const onViewportChange = () => {
+      scheduleResize()
+      if (!wsRef.current) connectAfterLayoutSettles()
+    }
     const ro = new ResizeObserver(onViewportChange)
     if (elRef.current) ro.observe(elRef.current)
     window.addEventListener('resize', onViewportChange)
@@ -763,11 +951,12 @@ const Term = forwardRef<TermHandle, {
     }
     el.addEventListener('drop', onDropGuard)
 
-    connect()
+    connectAfterLayoutSettles()
 
     return () => {
       unmounted.current = true
       clearTimeout(retry.current)
+      clearTimeout(initialConnectTimer)
       ro.disconnect()
       themeObs.disconnect()
       window.removeEventListener('resize', onViewportChange)
@@ -793,6 +982,12 @@ const Term = forwardRef<TermHandle, {
       try { dprMq?.removeEventListener('change', onDpr) } catch {}
       document.removeEventListener('visibilitychange', onVisibility)
       window.removeEventListener('pageshow', onPageShow)
+      window.removeEventListener('pagehide', onPageHide)
+      rebuildRendererRef.current = undefined
+      acknowledgeConnection()
+      clearTimeout(handoffReleaseTimer.current)
+      clearTimeout(handoffSafetyTimer.current)
+      cancelAnimationFrame(handoffRaf.current || 0)
       liveTerms.delete(diagEntry)
       try { wsRef.current?.close() } catch {}
       // 拆终端务必吞异常：这里是 React 的 effect cleanup，抛出去会顺着卸载流程把整棵树炸掉
@@ -809,18 +1004,18 @@ const Term = forwardRef<TermHandle, {
 
   useEffect(() => {
     const t = termRef.current
-    if (t) { t.options.fontSize = fontSize; setTimeout(applyResize, 0) }
+    if (t) { beginVisualHandoff(); t.options.fontSize = fontSize; scheduleResize() }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fontSize])
 
-  // 切回该标签：display 从 none → block，需在浏览器完成布局后再 fit。单次 setTimeout 易踩竞态，
-  // 用 rAF 连续重试几帧，确保可见终端按真实宽度铺满（修复"会话变窄条"）。
+  // 非当前标签用 visibility 隐藏但始终保留相同布局尺寸，切回时不需要再次 fit，只需聚焦。
   useEffect(() => {
     if (!active) return
-    let raf = 0, n = 0
-    // applyResize 自带尺寸去重，连打几帧只会真发一次
-    const tick = () => { applyResize(); if (n === 0) termRef.current?.focus(); if (++n < 4) raf = requestAnimationFrame(tick) }
-    raf = requestAnimationFrame(tick)
+    if (resumeHealPending.current) {
+      resumeHealPending.current = false
+      setTimeout(() => rebuildRendererRef.current?.(), 60)
+    }
+    const raf = requestAnimationFrame(() => termRef.current?.focus())
     return () => cancelAnimationFrame(raf)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])
@@ -842,8 +1037,16 @@ const Term = forwardRef<TermHandle, {
     // 后面的兄弟节点之上：Claude/Codex 对话面板正是这样被一层**透明**画布盖住的——看得见、点不着，
     // 表现为对话区滑不动历史、发送/停止按不动（画布吃掉了所有 pointer/touch）。isolate 把这些
     // z-index 关回终端自己这一层，覆盖层就能正常接事件。真机 CDP 命中测试可复现/回归。
-    <div style={{ position: 'relative', width: '100%', height: '100%', isolation: 'isolate', WebkitTouchCallout: 'none' } as CSSProperties}>
+    <div style={{ position: 'relative', width: '100%', height: '100%', isolation: 'isolate', contain: 'layout paint style', WebkitTouchCallout: 'none' } as CSSProperties}>
       <div ref={elRef} style={{ width: '100%', height: '100%' }} />
+      {restoredFrame && <img ref={restoredFrameRef} data-terminal-restored-frame src={restoredFrame} alt="" aria-hidden style={{
+        position: 'absolute', inset: 0, zIndex: 5, width: '100%', height: '100%', objectFit: 'fill',
+        pointerEvents: 'none', background: 'var(--xterm-bg)',
+      }} />}
+      <canvas ref={handoffCanvasRef} data-terminal-handoff-frame aria-hidden style={{
+        display: 'none', position: 'absolute', inset: 0, zIndex: 5, width: '100%', height: '100%',
+        pointerEvents: 'none', background: 'var(--xterm-bg)',
+      }} />
       {handles && (['start', 'end'] as const).map((which) => (
         <div key={which} onTouchStart={dragHandle(which)} style={handleStyle(which)} />
       ))}

--- a/frontend/src/prompt.test.ts
+++ b/frontend/src/prompt.test.ts
@@ -1,7 +1,7 @@
 // detectPrompt 的回归用例。重点是**窄屏**：手机 attach 后 tmux 窗格常只剩 40 多列，
 // Claude 的选项会折成五六行，早期按「行距 ≤3」分组会把每个选项拆成孤岛 → 手机上根本不弹提问框。
 import { describe, it, expect } from 'vitest'
-import { detectPrompt } from './prompt'
+import { advancePromptSignal, detectPrompt } from './prompt'
 
 // 宽屏：选项彼此紧挨
 const WIDE = `
@@ -45,6 +45,30 @@ const PLAIN_LIST = `
    Done.
 `
 
+// Agent 正常工作时最常见的误报：编号总结里包含 run / command / continue，
+// 这些只是正文，不是一个正在等待用户操作的选择框。
+const COMMAND_LIST = `
+   Running implementation work…
+     1. Run the formatter command
+     2. Continue with the typecheck
+     3. Write the result > report.txt
+   Working…
+`
+
+const NO_CURSOR_PROMPT = `
+   Are you sure you want to proceed?
+     1. Yes, continue
+     2. No, go back
+   Enter to confirm · Esc to cancel
+`
+
+const QUOTED_LIST = `
+   Documentation example:
+   > 1. Run the command
+   > 2. Continue editing
+   Done.
+`
+
 describe('detectPrompt', () => {
   it('宽屏选择框：识别出全部选项与当前游标', () => {
     const p = detectPrompt(WIDE)
@@ -62,13 +86,33 @@ describe('detectPrompt', () => {
 
   it('y/n 提示走兜底分支', () => {
     expect(detectPrompt('Overwrite existing file? (y/n)')?.kind).toBe('yesno')
+    expect(detectPrompt('Documentation: answer (y/n)\nDone.')).toBeNull()
   })
 
   it('普通编号列表不误判', () => {
     expect(detectPrompt(PLAIN_LIST)).toBeNull()
   })
 
+  it('包含 run/command/continue 和重定向符的工作输出不误判', () => {
+    expect(detectPrompt(COMMAND_LIST)).toBeNull()
+    expect(detectPrompt(QUOTED_LIST)).toBeNull()
+  })
+
+  it('没有可见游标时，明确提问和操作提示组合仍可识别', () => {
+    expect(detectPrompt(NO_CURSOR_PROMPT)?.kind).toBe('select')
+  })
+
   it('空屏返回 null', () => {
     expect(detectPrompt('')).toBeNull()
+  })
+
+  it('待确认状态需要连续两次相同采样才切换', () => {
+    const firstPositive = advancePromptSignal(undefined, true)
+    expect(firstPositive.stable).toBe(false)
+    const confirmedPositive = advancePromptSignal(firstPositive, true)
+    expect(confirmedPositive.stable).toBe(true)
+    const firstNegative = advancePromptSignal(confirmedPositive, false)
+    expect(firstNegative.stable).toBe(true)
+    expect(advancePromptSignal(firstNegative, false).stable).toBe(false)
   })
 })

--- a/frontend/src/prompt.tsx
+++ b/frontend/src/prompt.tsx
@@ -11,11 +11,14 @@ import { useI18n } from './i18n'
 export interface Choice { num: number; label: string; selected: boolean }
 export interface Prompt { kind: 'select' | 'yesno'; question: string; choices: Choice[] }
 
-const CURSOR = /[❯➤▶►▸→›»☞◉●>]/u                      // 选中游标常见字形（含 ASCII >）
+const CURSOR_PREFIX = /^[❯➤▶►▸→›»☞◉●>]\s*/u           // 选中游标必须位于选项开头，不能匹配正文里的 > / ●
 const LEAD = /^[\s│┃|╎┆┊╭╰├╞┝─━═]+/u                  // 行首方框线/竖线/空白
 const TAIL = /[\s│┃|╎┆┊╮╯┤╡┥─━═]+$/u                  // 行尾同上
 const OPT = /^(?:[❯➤▶►▸→›»☞◉●>]\s*)?(\d+)[.)]\s+(\S.*)$/u // [游标?] N. 文本
-const KW = /(would you like|proceed|allow|continue|overwrite|apply|approve|trust|run|command|是否|确认|继续|允许|要不要|执行|命令)/i
+// 无可见游标时只接受“明确提问 + 操作提示”的组合。run/command/执行/命令太常见，
+// Agent 的普通编号总结很容易命中，造成后台标签在“待确认/运行中”之间反复闪动。
+const QUESTION = /(?:would you like|do you want|are you sure|should (?:we|i)|(?:proceed|allow|continue|overwrite|approve|trust).*[?？]|是否(?:继续|允许|确认|执行)|(?:继续|允许|确认|执行).*[?？])/i
+const ACTION_HINT = /(?:(?:enter|return).*(?:select|confirm|continue|submit|accept)|(?:esc|escape).*(?:cancel|back)|(?:回车|enter).*(?:选择|确认|继续)|(?:按|press).*(?:y|n|yes|no).*(?:确认|confirm))/i
 const ANSI = /\x1b\[[0-?]*[ -/]*[@-~]/g
 const CTRL = /[\x00-\x08\x0b-\x1f\x7f]/g
 const stripCtl = (s: string) => s.replace(ANSI, '').replace(CTRL, '')
@@ -28,7 +31,7 @@ export function detectPrompt(capture: string): Prompt | null {
   const opts: P[] = []
   lines.forEach((raw, idx) => {
     const m = clean(raw).match(OPT)
-    if (m) opts.push({ num: Number(m[1]), label: m[2].trim(), selected: CURSOR.test(raw), idx })
+    if (m) opts.push({ num: Number(m[1]), label: m[2].trim(), selected: CURSOR_PREFIX.test(clean(raw)), idx })
   })
   // 取最后一组选项。绑定条件是「编号正好接上」而不是单纯挨得近：手机 attach 后 tmux 窗格常只有
   // 40 多列，Claude 的选项被折成五六行，按行距卡 ≤3 会把每个选项都拆成孤岛 → 一条都识别不出来
@@ -52,8 +55,10 @@ export function detectPrompt(capture: string): Prompt | null {
     }
     const question = qlines.join(' ').trim()
     const windowText = lines.slice(Math.max(0, g[0].idx - 8), Math.min(lines.length, g[g.length - 1].idx + 3)).map(clean).join(' ')
-    // 有游标，或上下文像个确认提示 → 认定为选择框（capture 无颜色，故用游标/关键词双保险）
-    if (g.some((o) => o.selected) || KW.test(question) || KW.test(windowText)) {
+    // 有开头游标，或“明确提问 + Enter/Esc 等操作提示”同时成立，才认定为选择框。
+    // 不能仅凭普通关键词判断，否则 Agent 输出的命令清单会被误报为待确认。
+    const selectedCount = g.filter((o) => o.selected).length
+    if (selectedCount === 1 || (QUESTION.test(question) && ACTION_HINT.test(windowText))) {
       const choices = g.map((o) => ({ num: o.num, label: o.label, selected: o.selected }))
       if (!choices.some((c) => c.selected)) choices[0].selected = true
       return { kind: 'select', question, choices }
@@ -62,9 +67,21 @@ export function detectPrompt(capture: string): Prompt | null {
   // y/n 兜底
   for (let i = lines.length - 1; i >= 0 && lines.length - i <= 12; i--) {
     const c = clean(lines[i])
+    if (!c) continue
     if (/\((?:y\/n|yes\/no|y\/N|Y\/n)\)|\[y\/n\]/i.test(c)) return { kind: 'yesno', question: c, choices: [] }
+    break // 只检查屏幕最后一条非空行，避免把历史说明文字里的 (y/n) 当作当前提示
   }
   return null
+}
+
+// 后台标签的待确认状态需要连续采样后才切换。终端 TUI 在重绘中途可能短暂形成
+// “编号列表 + 游标”的残帧；单次采样不能让标签立刻增删“待确认”并造成视觉闪动。
+export interface PromptSignal { candidate: boolean; streak: number; stable: boolean }
+export function advancePromptSignal(previous: PromptSignal | undefined, candidate: boolean, confirmations = 2): PromptSignal {
+  const sameCandidate = previous?.candidate === candidate
+  const streak = sameCandidate ? (previous?.streak || 0) + 1 : 1
+  const stable = streak >= confirmations ? candidate : (previous?.stable || false)
+  return { candidate, streak, stable }
 }
 
 function PromptActions({ p, accent, busy, choose, press }: {

--- a/frontend/src/terminal-lifecycle.test.ts
+++ b/frontend/src/terminal-lifecycle.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { parseTerminalPong } from './terminal-lifecycle'
+
+describe('parseTerminalPong', () => {
+  it('accepts a matching terminal heartbeat response', () => {
+    expect(parseTerminalPong('{"type":"pong","id":"resume-7"}')).toEqual({ type: 'pong', id: 'resume-7' })
+  })
+
+  it('does not consume terminal text or unrelated JSON controls', () => {
+    expect(parseTerminalPong('shell output')).toBeNull()
+    expect(parseTerminalPong('{"type":"resize","cols":120}')).toBeNull()
+    expect(parseTerminalPong('{not-json')).toBeNull()
+  })
+})

--- a/frontend/src/terminal-lifecycle.ts
+++ b/frontend/src/terminal-lifecycle.ts
@@ -1,0 +1,15 @@
+export type TerminalPong = { type: 'pong'; id: string }
+
+// PTY 的普通输出一律是 binary frame；text frame 只承载少量控制消息。
+// 仍然严格校验结构，避免未来某条文本输出刚好以 “{” 开头时被误吞。
+export function parseTerminalPong(data: string): TerminalPong | null {
+  if (!data.startsWith('{')) return null
+  try {
+    const value = JSON.parse(data) as Partial<TerminalPong>
+    return value.type === 'pong' && typeof value.id === 'string'
+      ? { type: 'pong', id: value.id }
+      : null
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/terminal-resize.test.ts
+++ b/frontend/src/terminal-resize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { shouldJiggleAfterAttach } from './terminal-resize'
+
+describe('shouldJiggleAfterAttach', () => {
+  it('does not jiggle the first correctly-sized attach after a page refresh', () => {
+    expect(shouldJiggleAfterAttach(null, { cols: 181, rows: 86 }, false)).toBe(false)
+  })
+
+  it('does not jiggle a same-size reconnect', () => {
+    expect(shouldJiggleAfterAttach({ cols: 181, rows: 86 }, { cols: 181, rows: 86 }, false)).toBe(false)
+  })
+
+  it('jiggles a reconnect whose terminal geometry really changed', () => {
+    expect(shouldJiggleAfterAttach({ cols: 181, rows: 86 }, { cols: 120, rows: 60 }, false)).toBe(true)
+  })
+
+  it('honors an explicit resync after a long background suspension', () => {
+    expect(shouldJiggleAfterAttach(null, { cols: 181, rows: 86 }, true)).toBe(true)
+  })
+})

--- a/frontend/src/terminal-resize.ts
+++ b/frontend/src/terminal-resize.ts
@@ -1,0 +1,12 @@
+export interface TerminalDimensions { cols: number; rows: number }
+
+// 首次 attach 已通过 WebSocket query 携带真实尺寸，不需要再故意 cols-1 → cols 抖两次。
+// 只有同一前端实例发生了真实尺寸变化，或久置恢复明确要求强制重同步时，才需要 jiggle。
+export function shouldJiggleAfterAttach(
+  previous: TerminalDimensions | null,
+  current: TerminalDimensions,
+  forced: boolean,
+): boolean {
+  if (forced) return true
+  return !!previous && (previous.cols !== current.cols || previous.rows !== current.rows)
+}


### PR DESCRIPTION
## 概要

- 统一终端尺寸协调入口，首次布局稳定后再 attach，普通变化只提交最终尺寸
- 增加 WebGL 旧帧到新帧的视觉交接，覆盖拖动、刷新、字号与 DPR 变化
- 后台恢复改为 ping/pong 存活探测，健康连接不再集体变红和重连
- 收紧 Claude/Codex 待确认识别，并用连续采样消除后台状态误报
- 更新产品审计 HTML，明确通用项目记忆尚未实现及对应验收标准

## 验证

- `bash scripts/dev/quality/check.sh full`
- Vitest：14 个相关测试通过
- 真实 Chromium：拖动 `94x49 -> 77x49`，帧交接正常撤下
- 后台恢复连续采样 165 次，非绿色状态 0 次
- 强制刷新使用短时快照，约 127ms 后交接到新 PTY 首帧

## 说明

- 未包含本地 `frontend/package.json` 与 `start.sh` 的未提交构建设置
- 没有新增需要翻译的产品文案