### PR TITLE
fix(file): 修复 iframe 预览下分隔栏拖拽中断

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import { SessionTitle, setSessionLabels, updateSessionLabel, useSessionLabel, se
 import { VoiceInput } from './chat/VoiceInput'
 import LinkStatus from './p2p/LinkStatus'
 import { startControlLink, stopControlLink } from './p2p/transport'
+import { PointerResizeShield, usePointerResize } from './PointerResize'
 
 interface ClaudeInfo { running: boolean; file?: string; dir?: string }
 
@@ -291,7 +292,9 @@ export default function App() {
   const [dockOpen, setDockOpen] = useState(true) // 桌面：右侧终端停靠栏是否展开
   const [dockMax, setDockMax] = useState(false)  // 桌面：终端栏向左扩展（遮住会话列表）
   const [customDockWidth, setCustomDockWidth] = useState<number | null>(null)
-  const resizing = useRef(false)
+  const dockResize = usePointerResize()
+  const pendingDockWidth = useRef<number | null>(null)
+  const dockGuideRef = useRef<HTMLDivElement>(null)
   const [fontSize, setFontSize] = useState(13)
   const [statusMap, setStatusMap] = useState<Record<string, TermStatus>>({})
   const termRefs = useRef<Record<string, TermHandle | null>>({})
@@ -530,6 +533,12 @@ export default function App() {
   return (
     <Layout style={{ height: '100dvh', overflow: 'hidden', background: 'var(--bg-base)' }}>
       <UpdateBanner />
+      {/* 拖动时只移动引导线，松手才提交布局，避免 HTML iframe 在每个指针事件上完整重排。 */}
+      <div ref={dockGuideRef} data-dock-resize-guide style={{
+        display: 'none', position: 'fixed', top: 0, bottom: 0, width: 2, zIndex: 1000,
+        pointerEvents: 'none', background: '#58a6ff', boxShadow: '0 0 0 1px rgba(88,166,255,.18)',
+      }} />
+      <PointerResizeShield active={dockResize.active} />
       {hasSider && !dockMax && (
         <Sider collapsible trigger={null} collapsed={collapsed} collapsedWidth={64}
           breakpoint="lg" onBreakpoint={(b) => setCollapsed(b)} width={208} theme={mode}
@@ -614,23 +623,33 @@ export default function App() {
               </div>
               {/* 中间：拖拽调整宽度（占中间 1/3，三等分） */}
               <div
-                style={{ flex: 1, cursor: 'col-resize', display: 'flex', alignItems: 'center', justifyContent: 'center', borderBottom: '1px solid var(--border)' }}
+                data-dock-resize-handle
+                style={{ flex: 1, cursor: 'col-resize', touchAction: 'none', display: 'flex', alignItems: 'center', justifyContent: 'center', borderBottom: '1px solid var(--border)' }}
                 title={t('common.dragToResize') || 'Drag to resize'}
-                onMouseDown={(e) => {
-                  e.preventDefault()
-                  resizing.current = true
+                onPointerDown={(e) => {
                   const siderWidth = collapsed ? 64 : 208
                   const startX = e.clientX
                   const startW = dockPageWidth
-                  const onMove = (ev: MouseEvent) => {
-                    if (!resizing.current) return
-                    const delta = ev.clientX - startX
-                    const next = Math.max(280, Math.min(window.innerWidth - siderWidth - 200, startW + delta))
-                    setCustomDockWidth(next)
+                  pendingDockWidth.current = startW
+                  const guide = dockGuideRef.current
+                  if (guide) {
+                    guide.style.display = 'block'
+                    guide.style.left = `${siderWidth + startW}px`
                   }
-                  const onUp = () => { resizing.current = false; window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp) }
-                  window.addEventListener('mousemove', onMove)
-                  window.addEventListener('mouseup', onUp)
+                  dockResize.start(e, {
+                    onMove: (ev) => {
+                      const delta = ev.clientX - startX
+                      const next = Math.max(280, Math.min(window.innerWidth - siderWidth - 200, startW + delta))
+                      pendingDockWidth.current = next
+                      if (guide) guide.style.left = `${siderWidth + next}px`
+                    },
+                    onEnd: () => {
+                      if (guide) guide.style.display = 'none'
+                      const next = pendingDockWidth.current
+                      pendingDockWidth.current = null
+                      if (next != null && next !== startW) setCustomDockWidth(next)
+                    },
+                  })
                 }}
               >
                 <svg width="6" height="48" viewBox="0 0 6 48" fill="currentColor" opacity="0.5">

--- a/frontend/src/FileWorkspace.test.tsx
+++ b/frontend/src/FileWorkspace.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { App as AntApp } from 'antd'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import FileWorkspace from './FileWorkspace'
+import { I18nProvider } from './i18n'
+
+vi.mock('./FileBrowser', () => ({ default: () => <div data-testid="file-browser" /> }))
+vi.mock('./fileview', () => ({ FileView: () => <div data-testid="file-view" /> }))
+
+class PointerEventStub extends MouseEvent {
+  readonly pointerId: number
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init)
+    this.pointerId = init.pointerId ?? 0
+  }
+}
+
+describe('FileWorkspace resize shield', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    vi.stubGlobal('PointerEvent', PointerEventStub)
+    Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    })
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      configurable: true,
+      value: vi.fn(() => false),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  const renderWorkspace = () => render(
+    <I18nProvider>
+      <AntApp>
+        <FileWorkspace dir="/workspace" />
+      </AntApp>
+    </I18nProvider>,
+  )
+
+  it('keeps dock resize events above iframe previews until pointerup', () => {
+    const { container } = renderWorkspace()
+    const handle = container.querySelector<HTMLElement>('[data-resize-handle="dock"]')!
+    const dock = handle.previousElementSibling as HTMLElement
+
+    fireEvent.pointerDown(handle, { pointerId: 7, clientX: 280 })
+
+    const shield = document.body.querySelector<HTMLElement>('[data-pointer-resize-shield="true"]')!
+    expect(shield).not.toBeNull()
+    expect(document.body.style.userSelect).toBe('none')
+    expect(document.body.style.cursor).toBe('col-resize')
+
+    fireEvent.pointerMove(shield, { pointerId: 7, clientX: 360 })
+    expect(dock.style.flex).toBe('0 0 360px')
+
+    fireEvent.pointerUp(shield, { pointerId: 7, clientX: 360 })
+    expect(document.body.querySelector('[data-pointer-resize-shield="true"]')).toBeNull()
+    expect(document.body.style.userSelect).toBe('')
+    expect(document.body.style.cursor).toBe('')
+    expect(localStorage.getItem('ttmux.fileDockW')).toBe('360')
+  })
+
+  it('removes the shield and restores page styles when the window loses focus', () => {
+    const { container } = renderWorkspace()
+    const handle = container.querySelector<HTMLElement>('[data-resize-handle="dock"]')!
+    document.body.style.userSelect = 'text'
+    document.body.style.cursor = 'default'
+
+    fireEvent.pointerDown(handle, { pointerId: 9, clientX: 280 })
+    fireEvent.blur(window)
+
+    expect(document.body.querySelector('[data-pointer-resize-shield="true"]')).toBeNull()
+    expect(document.body.style.userSelect).toBe('text')
+    expect(document.body.style.cursor).toBe('default')
+  })
+})

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -7,6 +7,7 @@ import FileBrowser from './FileBrowser'
 import { FileView } from './fileview'
 import { FileTypeIcon } from './file-icons'
 import { useI18n } from './i18n'
+import { PointerResizeShield, usePointerResize } from './PointerResize'
 
 type Group = 'A' | 'B'
 const TAB_MIME = 'application/x-ttmux-tab'
@@ -63,6 +64,7 @@ export default function FileWorkspace({
   const [dragging, setDragging] = useState(false) // 原生拖拽进行中 → 每栏内容盖一层透明接盘层，压过终端/Monaco
   // 拖的是 tab/会话(需接盘层压过终端才能移栏) 还是文件路径(要落回终端/对话做 @引用注入,不能被接盘层截走)
   const [dragKind, setDragKind] = useState<'tab' | 'lead' | 'path' | null>(null)
+  const resize = usePointerResize()
   useEffect(() => {
     // drop 用「冒泡阶段」清理：React 事件委托挂在 document 内层根节点，冒泡到 document 时
     // onDrop 已派发完，此时卸接盘层安全。若用捕获阶段则会赶在 onDrop 前卸掉接盘层 →
@@ -160,36 +162,29 @@ export default function FileWorkspace({
   const [splitFrac, setSplitFrac] = useState(0.5)
   const [swapped, setSwapped] = useState(false)
   const leftGroup: Group = swapped ? 'B' : 'A'
-  const startSplitResize = (e: React.PointerEvent) => {
-    e.preventDefault()
-    document.body.style.userSelect = 'none'; document.body.style.cursor = 'col-resize'
-    const move = (ev: PointerEvent) => {
-      const el = panesRef.current; if (!el) return
-      const r = el.getBoundingClientRect(); if (r.width <= 0) return
-      setSplitFrac(Math.min(0.85, Math.max(0.15, (ev.clientX - r.left) / r.width)))
-    }
-    const up = () => {
-      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up)
-      document.body.style.userSelect = ''; document.body.style.cursor = ''
-    }
-    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up)
+
+  const startSplitResize = (e: React.PointerEvent<HTMLDivElement>) => {
+    resize.start(e, {
+      onMove: (ev) => {
+        const el = panesRef.current; if (!el) return
+        const r = el.getBoundingClientRect(); if (r.width <= 0) return
+        setSplitFrac(Math.min(0.85, Math.max(0.15, (ev.clientX - r.left) / r.width)))
+      },
+    })
   }
 
   // 左侧文件栏宽度：可拖拽调整，记 localStorage
   const [dockW, setDockW] = useState(() => { const s = Number(localStorage.getItem('ttmux.fileDockW')); return s >= 160 && s <= 640 ? s : 280 })
   const dockWRef = useRef(dockW)
   dockWRef.current = dockW
-  const startResize = (e: React.PointerEvent) => {
-    e.preventDefault()
+  const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
     const startX = e.clientX, startW = dockW
-    document.body.style.userSelect = 'none'; document.body.style.cursor = 'col-resize'
-    const move = (ev: PointerEvent) => setDockW(Math.min(640, Math.max(160, startW + ev.clientX - startX)))
-    const up = () => {
-      window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up)
-      document.body.style.userSelect = ''; document.body.style.cursor = ''
-      localStorage.setItem('ttmux.fileDockW', String(dockWRef.current))
-    }
-    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up)
+    resize.start(e, {
+      onMove: (ev) => setDockW(Math.min(640, Math.max(160, startW + ev.clientX - startX))),
+      onEnd: () => {
+        localStorage.setItem('ttmux.fileDockW', String(dockWRef.current))
+      },
+    })
   }
 
   const dragHasPayload = (e: React.DragEvent) => e.dataTransfer.types.includes(TAB_MIME) || e.dataTransfer.types.includes(PATH_MIME) || e.dataTransfer.types.includes(LEAD_MIME)
@@ -400,7 +395,7 @@ export default function FileWorkspace({
           <div style={{ flex: `0 0 ${dockW}px`, minWidth: 0, minHeight: 0, display: 'flex' }}>
             <FileBrowser dir={dir} accent={accent} layout="dock" onClose={onExplorerClose} onOpenFile={openFileTab} selectedPath={activeA ? realPath(activeA) : null} onOpenAgent={onOpenAgent} />
           </div>
-          <div onPointerDown={startResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
+          <div data-resize-handle="dock" onPointerDown={startResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
         </>
       )}
       <div style={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
@@ -408,7 +403,7 @@ export default function FileWorkspace({
           {(split ? (swapped ? ['B', 'A'] : ['A', 'B']) : ['A'] as Group[]).map((g, i) => (
             // key 按组固定 → 易位/分栏时 React 不重挂终端(会话)，PTY/xterm 不断
             <Fragment key={g}>
-              {i > 0 && <div onPointerDown={startSplitResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />}
+              {i > 0 && <div data-resize-handle="split" onPointerDown={startSplitResize} title={t('file.dragResize')} style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />}
               {pane(g as Group)}
             </Fragment>
           ))}
@@ -417,6 +412,7 @@ export default function FileWorkspace({
       {touchDrag && (
         <div style={{ position: 'fixed', left: touchDrag.x + 12, top: touchDrag.y + 12, zIndex: 9999, pointerEvents: 'none', padding: '4px 10px', fontSize: 12, borderRadius: 6, background: 'var(--bg-container)', border: '1px solid #58a6ff', color: 'var(--text-bright)', boxShadow: '0 4px 16px rgba(0,0,0,.4)', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{touchDrag.label}</div>
       )}
+      <PointerResizeShield active={resize.active} />
     </div>
   )
 }

--- a/frontend/src/PointerResize.tsx
+++ b/frontend/src/PointerResize.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import { createPortal } from 'react-dom'
+
+type ResizeHandlers = {
+  onMove: (event: PointerEvent) => void
+  onEnd?: () => void
+}
+
+// iframe 有独立的 document，普通 window pointermove/up 会在指针进入 iframe 后中断。
+// Pointer capture 负责连续跟踪，body portal 遮罩兜底，并统一处理取消、失焦和卸载清理。
+export function usePointerResize() {
+  const [active, setActive] = useState(false)
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => () => cleanupRef.current?.(), [])
+
+  const start = (event: ReactPointerEvent<HTMLElement>, handlers: ResizeHandlers) => {
+    cleanupRef.current?.()
+    event.preventDefault()
+
+    const pointerId = event.pointerId
+    const handle = event.currentTarget
+    const previousUserSelect = document.body.style.userSelect
+    const previousCursor = document.body.style.cursor
+    let ended = false
+
+    const move = (next: PointerEvent) => {
+      if (next.pointerId !== pointerId) return
+      next.preventDefault()
+      handlers.onMove(next)
+    }
+    const end = (next?: Event) => {
+      if (ended) return
+      if (next && 'pointerId' in next && (next as PointerEvent).pointerId !== pointerId) return
+      ended = true
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', end)
+      window.removeEventListener('pointercancel', end)
+      window.removeEventListener('blur', end)
+      try {
+        if (handle.hasPointerCapture?.(pointerId)) handle.releasePointerCapture(pointerId)
+      } catch {}
+      document.body.style.userSelect = previousUserSelect
+      document.body.style.cursor = previousCursor
+      cleanupRef.current = null
+      setActive(false)
+      handlers.onEnd?.()
+    }
+
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+    try { handle.setPointerCapture?.(pointerId) } catch {}
+    window.addEventListener('pointermove', move, { passive: false })
+    window.addEventListener('pointerup', end)
+    window.addEventListener('pointercancel', end)
+    window.addEventListener('blur', end)
+    cleanupRef.current = end
+    setActive(true)
+  }
+
+  return { active, start }
+}
+
+export function PointerResizeShield({ active }: { active: boolean }) {
+  if (!active || typeof document === 'undefined') return null
+  return createPortal(
+    <div data-pointer-resize-shield="true" aria-hidden="true" style={{
+      position: 'fixed', inset: 0, zIndex: 2147483647,
+      cursor: 'col-resize', touchAction: 'none', userSelect: 'none',
+    }} />,
+    document.body,
+  )
+}


### PR DESCRIPTION
修复打开 HTML 等 iframe 预览后，全局停靠栏及文件工作区分隔栏拖拽中断、卡顿的问题。拖动期间通过 Pointer Capture 与 body 顶层接管层保持事件连续；全局停靠栏只移动引导线，松手后一次性提交布局，避免 iframe 高频重排。已通过完整质量门禁、前端 50 项测试及用户实际自测。