### PR TITLE
fix(web): 终端快捷键条被顶出可视区 / 分栏拖不动 / 去掉侧栏重复搜索

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -637,7 +637,7 @@ export default function App() {
 
   const canvasNode = (
     <Content className="tt-canvas" data-cq={CQ_PAGES.has(tab) ? 'on' : undefined} style={{
-      flex: 1, minWidth: 0, height: '100dvh', padding: 0,
+      flex: 1, minWidth: 0, minHeight: 0, height: '100%', padding: 0,
       overflow: tab === 'browser' || tab === 'phone' || tab === 'files' ? 'hidden' : 'auto',
     }}>{pageNode}</Content>
   )
@@ -697,8 +697,6 @@ export default function App() {
           style={{ position: 'sticky', top: 0, height: '100dvh', background: 'var(--bg-base)', borderRight: '1px solid var(--border-subtle)' }}>
           <Navigation
             rail={navRail} active={tab} groups={navGroups} onGo={go}
-            onSearch={() => window.dispatchEvent(new Event('tt-open-palette'))}
-            searchHint={`${modKeyLabel}K`}
             linkStatus={<LinkStatus collapsed={navRail} />}
             dock={terms.length > 0 ? {
               count: terms.length, open: space.dockVisible,
@@ -731,8 +729,9 @@ export default function App() {
           // 不是组件树，终端因此不会在开合时被卸载重建。
           <Workspace
             mode={space.mode} canvas={canvasNode} dock={dockNode}
-            dockWidth={space.dockWidth} bounds={space.bounds}
+            dockWidth={space.dockWidth} bounds={space.bounds} splitMax={space.splitMax}
             onResize={space.setDockWidth} onReset={space.resetDockWidth}
+            onFocus={() => space.setFocus('dock')}
             onDismiss={() => space.setDockOpen(false)}
             capsule={space.overlayCapable && space.mode === 'page' ? (
               // 胶囊只有 320px，显示 sessionLabel 而不是 sessionDisplay——后者带
@@ -747,7 +746,7 @@ export default function App() {
             ) : null}
           />
         ) : (
-          <div style={{ display: 'flex', height: '100dvh', minHeight: 0 }}>{canvasNode}</div>
+          <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>{canvasNode}</div>
         )}
       </Layout>
 
@@ -1025,6 +1024,16 @@ function TerminalPane(props: {
   const { phone: isPhone } = useLayout()
   const ws = prefsData.workspace
   const [typing, setTyping] = useState(false)
+  // 快捷键条的两侧渐隐：和标签条同一套做法（溢出时才提示"这边还有"）
+  const keyRowRef = useRef<HTMLDivElement>(null)
+  const [keyFadeL, setKeyFadeL] = useState(false)
+  const [keyFadeR, setKeyFadeR] = useState(false)
+  const syncKeyFade = useCallback(() => {
+    const el = keyRowRef.current
+    if (!el) return
+    setKeyFadeL(el.scrollLeft > 2)
+    setKeyFadeR(el.scrollLeft + el.clientWidth < el.scrollWidth - 2)
+  }, [])
   const [switchOpen, setSwitchOpen] = useState(false)
   const [moreSheet, setMoreSheet] = useState(false)
   const [dragTab, setDragTab] = useState<string | null>(null)
@@ -1163,6 +1172,15 @@ function TerminalPane(props: {
   }, [terms])
 
   useEffect(() => { onNeedsInput?.(termNeedsInput) }, [termNeedsInput, onNeedsInput])
+
+  useEffect(() => {
+    syncKeyFade()
+    const el = keyRowRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(syncKeyFade)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [syncKeyFade, typing, inChat])
 
   // 软键盘开合会改可视高度，但 xterm 不会自己重算行数——不重新 fit 就会出现
   // 「PTY 以为还有 25 行、实际只画得下 7 行」的错位，表现为花屏。等一帧让布局落定再量。
@@ -1583,10 +1601,21 @@ function TerminalPane(props: {
         </div>
       )}
       {/* 快捷键条只在输入态出现（13 §5.2）：它常驻 49px，而不打字时一个键也用不上——
-          手机上这 49px 直接等于终端少 3 行。桌面不受影响。 */}
+          手机上这 49px 直接等于终端少 3 行。桌面不受影响。
+          `tt-keyrow` 给两侧渐隐 + 滚轮横移：这一条 15 个按钮宽 913，窄栏里只露得出 605，
+          而原来既没有渐隐也没有滚动条，右边缘正好把某个键切成一半——看着就是"没显示全"。 */}
       {!inChat && (!isPhone || typing) && (
-        <div style={{ display: 'flex', gap: 'var(--sp-2)', padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
-          <Button type="primary" onMouseDown={noBlur} onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
+        <div className="tt-keyrow" ref={keyRowRef}
+          onScroll={syncKeyFade}
+          onWheel={(e) => {
+            const el = keyRowRef.current
+            if (!el || Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+            el.scrollLeft += e.deltaY
+          }}
+          data-l={keyFadeL ? '1' : undefined} data-r={keyFadeR ? '1' : undefined}
+          style={{ display: 'flex', gap: 'var(--sp-2)', padding: 8, borderTop: '1px solid var(--border)', overflowX: 'auto' }}>
+          <Button type="primary" onMouseDown={noBlur} style={{ flex: '0 0 auto' }}
+            onClick={() => (isTouch ? submitLine() : sendKey('\r'))}>Enter</Button>
           {/* 触屏没有 Ctrl+Shift+V / 右键菜单在长按选词后也不再弹出，丝带上补一个直达粘贴 */}
           {isTouch && <Button onMouseDown={noBlur} onClick={() => active && pasteClipboard(active)} style={{ flex: '0 0 auto' }}>{t('terminal.pasteAction')}</Button>}
           {(prefsData.quickCommands || []).map((cmd) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -181,6 +181,11 @@ body {
 .tt-split-rail:focus-visible::after { height: 78px; opacity: 1; background: var(--accent); }
 .tt-split-rail:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
 
+/* 拖拽引导线。越过 splitMax（Canvas 会不足 560）时换成琥珀色：松手的后果从
+   "再宽一点"变成"整页藏起来"，颜色先说一声。 */
+.tt-dock-guide { background: var(--accent); box-shadow: 0 0 0 1px rgba(88, 166, 255, .18); }
+.tt-dock-guide[data-focus='1'] { background: #d29922; box-shadow: 0 0 0 1px rgba(210, 153, 34, .25); }
+
 /* ── expanded 档（905–1279）的覆盖式终端面板（13 §13.1）──
    这一档并排最多只能挤出 561–735 的 Canvas，正是要消灭的「页面被压成预览条」。
    所以终端改成从右侧覆盖：Canvas 布局在开合前后完全不变，概览不会跳列。
@@ -244,20 +249,6 @@ body {
 }
 .tt-nav-brand .wd span { display: block; font-size: 10px; letter-spacing: 1.5px; color: var(--text-dimmer); }
 
-.tt-nav-search {
-  display: flex; align-items: center; gap: 9px; width: 100%; height: 34px; margin-bottom: 6px;
-  padding: 0 10px; border: 1px solid var(--border-subtle); border-radius: 9px;
-  background: var(--bg-container); color: var(--text-dim); font-size: var(--fs-meta);
-  cursor: pointer; transition: border-color .15s, color .15s;
-}
-.tt-nav-search:hover { border-color: var(--accent-border); color: var(--text-bright); }
-.tt-nav-search .ic { display: flex; flex: 0 0 auto; }
-.tt-nav-search .nm { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tt-nav-search kbd {
-  margin-left: auto; flex: 0 0 auto; padding: 1px 5px; border: 1px solid var(--border-subtle);
-  border-radius: 5px; color: var(--text-dimmer); font: 10.5px/1.5 ui-monospace, monospace;
-}
-.tt-nav.rail .tt-nav-search { justify-content: center; padding: 0; }
 
 .tt-nav-list { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; }
 .tt-nav-group + .tt-nav-group { margin-top: 14px; }
@@ -423,6 +414,16 @@ body {
 .tt-dpad .c { grid-area: 2 / 2; font-size: 15px; color: var(--text-bright); }
 .tt-dpad .r { grid-area: 2 / 3; }
 .tt-dpad .d { grid-area: 3 / 2; }
+
+/* 终端快捷键条：15 个按钮宽 913，窄栏里只露得出 600 出头。原来既没有渐隐也没有
+   滚动条提示，右边缘正好把某个键切成一半——看着就是"没显示全"。
+   与标签条同一套：隐藏滚动条 + 两侧 mask 渐隐 + 竖滚轮横移。 */
+.tt-keyrow { scrollbar-width: none; -webkit-overflow-scrolling: touch; }
+.tt-keyrow::-webkit-scrollbar { height: 0; }
+.tt-keyrow > * { flex: 0 0 auto; }
+.tt-keyrow[data-l][data-r] { mask-image: linear-gradient(90deg, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%); }
+.tt-keyrow[data-l]:not([data-r]) { mask-image: linear-gradient(90deg, transparent 0, #000 24px); }
+.tt-keyrow[data-r]:not([data-l]) { mask-image: linear-gradient(90deg, #000 calc(100% - 24px), transparent 100%); }
 
 /* ── 会话坞（13 §4.2）：底栏之上一条 50px 常驻条 ──
    手机上会话此前只有「全屏」和「看不见」两态，退回项目页就不知道还有几个在跑。 */

--- a/frontend/src/shell/Navigation.tsx
+++ b/frontend/src/shell/Navigation.tsx
@@ -26,7 +26,7 @@ export type NavEntry = {
 export type NavGroup = { label: string; items: NavEntry[] }
 
 export function Navigation({
-  rail, active, groups, onGo, onSearch, searchHint,
+  rail, active, groups, onGo,
   linkStatus, dock, account, accountName, onToggleRail,
 }: {
   /** 64px 轨态：用户收起 / Focus / 非 large 档 */
@@ -34,9 +34,6 @@ export function Navigation({
   active: string
   groups: NavGroup[]
   onGo: (key: string) => void
-  onSearch: () => void
-  /** ⌘K / Ctrl+K */
-  searchHint: string
   linkStatus: ReactNode
   /** 终端开合入口；没有已打开的终端时传 null */
   dock: { count: number; open: boolean; onToggle: () => void; title: string } | null
@@ -71,20 +68,8 @@ export function Navigation({
         )}
       </div>
 
-      {/* 搜索入口在轨态是唯一露出的那枚放大镜（13 §13.2） */}
-      {rail ? (
-        <Tooltip title={t('workspace.searchPlaceholder')} placement="right">
-          <button type="button" className="tt-nav-search" onClick={onSearch} aria-label={t('workspace.search')}>
-            <span className="ic">{searchIcon}</span>
-          </button>
-        </Tooltip>
-      ) : (
-        <button type="button" className="tt-nav-search" onClick={onSearch}>
-          <span className="ic">{searchIcon}</span>
-          <span className="nm">{t('nav.searchOrJump')}</span>
-          <kbd>{searchHint}</kbd>
-        </button>
-      )}
+      {/* 这里原来还有一枚搜索入口。去掉了：顶栏 Command Center 的搜索横跨整个工作区、
+          轨态下也在，侧栏这枚是同一个动作的第二个入口，只是把导航第一屏又占掉一行。 */}
 
       <div className="tt-nav-list">
         {groups.map((g) => (
@@ -130,7 +115,6 @@ export function Navigation({
 
 const stroke = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }
 const svg = (children: ReactNode) => <svg viewBox="0 0 24 24" width={18} height={18} {...stroke}>{children}</svg>
-const searchIcon = svg(<><circle cx="11" cy="11" r="7" /><line x1="16.5" y1="16.5" x2="21" y2="21" /></>)
 const termIcon = svg(<><rect x="3" y="4" width="18" height="16" rx="2" /><line x1="14" y1="4" x2="14" y2="20" /></>)
 // 主机图标而不是姓名首字母：这里代表的是"你连着的这台机器"，不是一个人
 const hostIcon = <svg viewBox="0 0 24 24" width={15} height={15} {...stroke}><rect x="3" y="4" width="18" height="12" rx="2" /><path d="M8 20h8" /><path d="M12 16v4" /></svg>

--- a/frontend/src/shell/Workspace.tsx
+++ b/frontend/src/shell/Workspace.tsx
@@ -32,14 +32,19 @@ import { useI18n } from '../i18n'
 import { PointerResizeShield, usePointerResize } from '../PointerResize'
 import { OVERLAY_DOCK, type SpaceMode } from './useWorkspaceLayout'
 
-export function Workspace({ mode, canvas, dock, dockWidth, bounds, onResize, onReset, onDismiss, capsule }: {
+export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onResize, onReset, onFocus, onDismiss, capsule }: {
   mode: SpaceMode
   canvas: ReactNode
   dock: ReactNode
   dockWidth: number
+  /** 拖拽区间，上界 = Canvas 归零处 */
   bounds: { min: number; max: number }
+  /** 超过它 Canvas 就不足 560：松手时落进 Focus 而不是留一条废条 */
+  splitMax: number
   onResize: (width: number) => void
   onReset: () => void
+  /** 拖过头：页面藏起来，终端铺满 */
+  onFocus: () => void
   /** 覆盖态点遮罩收起 */
   onDismiss: () => void
   /** 覆盖态收起时右下角的会话胶囊（13 §13.1）；其余档传 null */
@@ -73,27 +78,37 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, onResize, onR
         const next = clamp(startWidth - (ev.clientX - startX))
         pending.current = next
         // 分隔条最终会左移 (next - startWidth)，引导线按这个位移走
-        if (guide) guide.style.left = `${railCenter - (next - startWidth)}px`
+        if (guide) {
+          guide.style.left = `${railCenter - (next - startWidth)}px`
+          // 越过 splitMax 换色：松手不是"再宽一点"，而是"整页藏起来"，得先说一声
+          guide.dataset.focus = next > splitMax ? '1' : ''
+        }
       },
       onEnd: () => {
         if (guide) guide.style.display = 'none'
-        if (pending.current != null) {
-          onResize(pending.current)
-          pending.current = null
-        }
+        const next = pending.current
+        pending.current = null
+        if (next == null) return
+        // 拖过 splitMax = Canvas 已经不足 560：与其留一条 300px 的废页面，不如整页藏起来。
+        // 这样「一直往左拖」这个动作有终点，而不是拖到某处就顶死不动。
+        if (next > splitMax) onFocus()
+        else onResize(next)
       },
     })
-  }, [dockWidth, clamp, onResize, start])
+  }, [dockWidth, clamp, onResize, onFocus, splitMax, start])
 
   // 键盘调宽是一次一档，不存在高频重排，直接提交
   const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'ArrowLeft') onResize(clamp(dockWidth + 16))
+    if (e.key === 'ArrowLeft') {
+      const next = clamp(dockWidth + 16)
+      if (next > splitMax) onFocus(); else onResize(next)
+    }
     else if (e.key === 'ArrowRight') onResize(clamp(dockWidth - 16))
     else if (e.key === 'Home') onResize(bounds.min)
-    else if (e.key === 'End') onResize(bounds.max)
+    else if (e.key === 'End') onFocus()
     else return
     e.preventDefault()
-  }, [dockWidth, bounds, clamp, onResize])
+  }, [dockWidth, bounds, splitMax, clamp, onResize, onFocus])
 
   const focus = mode === 'focus'
   const overlay = mode === 'overlay'
@@ -113,17 +128,20 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, onResize, onR
     : {
         flex: mode === 'split' ? `0 0 ${dockWidth}px` : focus ? '1 1 auto' : '0 0 0px',
         width: mode === 'split' ? dockWidth : focus ? undefined : 0,
-        minWidth: 0, height: '100dvh', overflow: 'hidden',
+        minWidth: 0, height: '100%', minHeight: 0, overflow: 'hidden',
         display: 'flex', flexDirection: 'column',
         background: 'var(--bg-term)',
         transition: active ? 'none' : 'flex-basis .2s, width .2s',
       }
 
   return (
-    <div style={{ position: 'relative', display: 'flex', height: '100dvh', minHeight: 0, minWidth: 0, flex: 1 }}>
+    // 这里**不能**写 height:100dvh：这一层挂在 40px 的 Command Center 下面，
+    // 100dvh 会让整列比可视区高出正好一个顶栏，最底下那条快捷键条只露得出几像素
+    // （终端也跟着多算 40px，最后一行同样看不见）。跟着 Layout 的列走 flex:1 即可。
+    <div style={{ position: 'relative', display: 'flex', height: '100%', minHeight: 0, minWidth: 0, flex: 1 }}>
       <div style={{
         flex: focus ? '0 0 0px' : '1 1 auto', width: focus ? 0 : undefined,
-        minWidth: 0, height: '100dvh', overflow: 'hidden', display: 'flex', flexDirection: 'column',
+        minWidth: 0, height: '100%', minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column',
       }}>
         {canvas}
       </div>
@@ -160,8 +178,7 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, onResize, onR
       <div ref={guideRef} data-dock-resize-guide aria-hidden="true" style={{
         display: 'none', position: 'fixed', top: 0, bottom: 0, width: 2,
         zIndex: 1000, pointerEvents: 'none',
-        background: '#58a6ff', boxShadow: '0 0 0 1px rgba(88,166,255,.18)',
-      }} />
+      }} className="tt-dock-guide" />
       <PointerResizeShield active={active} />
     </div>
   )

--- a/frontend/src/shell/useWorkspaceLayout.ts
+++ b/frontend/src/shell/useWorkspaceLayout.ts
@@ -29,15 +29,39 @@ export type FocusTarget = 'none' | 'page' | 'dock'
  * 不钳这一下就会横向溢出——1280 展开侧栏时 `42vw = 538`，Canvas 只剩 510，
  * 自己先破 560 的契约。**拖拽、双击复位、恢复偏好三条路径都必须过这个函数**，
  * 这是「不制造横向滚动」的唯一保证（14 §4.2）。
+ *
+ * 这里**不再压 880**：880 是"默认给多宽"（见 defaultDockWidth），不该同时充当
+ * "用户最多能拖多宽"。用户显式拖到 1200，就该是 1200。
  */
 export function dockBounds(workspaceWidth: number): { min: number; max: number } {
   const room = workspaceWidth - SPLIT_RAIL - CANVAS_MIN
-  return { min: DOCK_MIN, max: Math.max(DOCK_MIN, Math.min(DOCK_MAX, room)) }
+  return { min: DOCK_MIN, max: Math.max(DOCK_MIN, room) }
 }
 
-/** 该档的默认 Dock 宽度：clamp(480, 42vw, 880)，再过一次上界钳制。 */
+/**
+ * 拖拽能到的最远处：Canvas 归零。
+ *
+ * 只让拖到 `dockBounds().max` 的话，1440 屏（侧栏 224）上界就是 648——用户想把终端
+ * 再拉宽一点，界面直接不动了，除非他知道还有个「终端聚焦」按钮。现在允许一路拖过去，
+ * 松手时若 Canvas 已经低于 560 就落进 Focus：**页面要么 ≥560，要么干脆藏起来，
+ * 不留一条 300px 的废条**——这正是 CANVAS_MIN 想守的东西，只是换成了拖拽也能表达。
+ */
+export function dragMaxWidth(workspaceWidth: number): number {
+  return Math.max(DOCK_MIN, workspaceWidth - SPLIT_RAIL)
+}
+
+/** 松手时该不该落进 Focus：Canvas 已经不足最小宽 */
+export function shouldFocusAt(workspaceWidth: number, dockWidth: number): boolean {
+  return workspaceWidth - SPLIT_RAIL - dockWidth < CANVAS_MIN
+}
+
+/**
+ * 该档的默认 Dock 宽度：clamp(480, 42vw, 880)，再过一次几何上界。
+ *
+ * **880 只在这里**：它是"默认给多宽"，不是"用户最多能拖多宽"。dockBounds 不再压它。
+ */
 export function defaultDockWidth(viewportWidth: number, workspaceWidth: number): number {
-  const wish = Math.round(viewportWidth * 0.42)
+  const wish = Math.min(DOCK_MAX, Math.round(viewportWidth * 0.42))
   const { min, max } = dockBounds(workspaceWidth)
   return Math.max(min, Math.min(max, wish))
 }
@@ -88,8 +112,10 @@ export type WorkspaceLayout = {
   setFocus: (target: FocusTarget) => void
   toggleFocus: () => void
   setNavCollapsed: (collapsed: boolean) => void
-  /** 供分隔条读：当前允许拖到的区间 */
+  /** 供分隔条读：当前允许拖到的区间（上界 = Canvas 归零处） */
   bounds: { min: number; max: number }
+  /** 超过这个宽度就该落进 Focus（Canvas 会低于 560） */
+  splitMax: number
 }
 
 /**
@@ -127,13 +153,15 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   const splitCapable = layout.size === 'large'
   const navWidth = splitCapable ? (navCollapsed ? NAV_RAIL : NAV_WIDTH) : NAV_RAIL
   const workspaceWidth = Math.max(0, viewport - navWidth)
-  const bounds = useMemo(() => dockBounds(workspaceWidth), [workspaceWidth])
+  const bounds = useMemo(() => ({ min: DOCK_MIN, max: dragMaxWidth(workspaceWidth) }), [workspaceWidth])
+  const splitMax = useMemo(() => dockBounds(workspaceWidth).max, [workspaceWidth])
 
   // 恢复偏好时先钳制：换到小窗口不能拿旧大屏的宽度把 Canvas 挤爆（14 §9.3）
   const dockWidth = useMemo(() => {
     const wish = width || defaultDockWidth(viewport, workspaceWidth)
-    return Math.max(bounds.min, Math.min(bounds.max, wish))
-  }, [width, viewport, workspaceWidth, bounds])
+    const b = dockBounds(workspaceWidth)
+    return Math.max(b.min, Math.min(b.max, wish))
+  }, [width, viewport, workspaceWidth])
 
   const mode = resolveMode({ hasTerms, dockOpen, focus, size: layout.size, workspaceWidth })
 
@@ -168,6 +196,7 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     splitCapable,
     overlayCapable: layout.size === 'expanded',
     bounds,
+    splitMax,
     toggleDock: () => setDockOpen(!dockOpen),
     setDockOpen,
     setDockWidth,

--- a/frontend/src/shell/workspace-layout.test.ts
+++ b/frontend/src/shell/workspace-layout.test.ts
@@ -2,7 +2,7 @@
 // 这几条断言直接对应 14 设计 §11 验收清单里的前两行。
 import { describe, it, expect } from 'vitest'
 import {
-  dockBounds, defaultDockWidth, canSplit, resolveMode,
+  dockBounds, defaultDockWidth, canSplit, resolveMode, dragMaxWidth, shouldFocusAt,
   CANVAS_MIN, DOCK_MIN, DOCK_MAX, SPLIT_RAIL, NAV_WIDTH, NAV_RAIL, OVERLAY_DOCK,
 } from './useWorkspaceLayout'
 
@@ -35,9 +35,14 @@ describe('Dock 宽度钳制', () => {
     expect(w - SPLIT_RAIL - 538).toBeGreaterThanOrEqual(CANVAS_MIN)
   })
 
-  it('大屏封顶 880，不让终端无限长胖', () => {
+  it('880 是「默认给多宽」，不是「最多能拖多宽」', () => {
+    // 默认值封顶 880，不让终端一开就无限长胖
     expect(defaultDockWidth(2560, workspace(2560))).toBe(DOCK_MAX)
-    expect(dockBounds(workspace(3840)).max).toBe(DOCK_MAX)
+    expect(defaultDockWidth(3840, workspace(3840))).toBe(DOCK_MAX)
+    // 但拖拽/恢复的上界只受 Canvas 最小宽约束——用户显式拖到 1200 就该是 1200。
+    // 之前这里也压 880，导致 1440 屏上「往左拖」拖到 648 就顶死不动。
+    expect(dockBounds(workspace(3840)).max).toBeGreaterThan(DOCK_MAX)
+    expect(dockBounds(workspace(3840)).max).toBe(workspace(3840) - SPLIT_RAIL - CANVAS_MIN)
   })
 
   it('下界始终是 480，哪怕算出来的余量更小', () => {
@@ -66,6 +71,21 @@ describe('并排是否成立', () => {
     expect(canSplit(workspace(1279, false))).toBe(true)
     const canvas = workspace(1279, false) - SPLIT_RAIL - DOCK_MIN
     expect(canvas).toBeLessThan(CANVAS_MIN + 200)
+  })
+})
+
+describe('拖过头落进 Focus（1440 屏上只能拖 43px 的病根）', () => {
+  it('拖拽上界是 Canvas 归零处，不是 splitMax', () => {
+    const w = workspace(1440)                       // 1440 - 224 = 1216
+    expect(dockBounds(w).max).toBe(1216 - SPLIT_RAIL - CANVAS_MIN)   // 648：能并排的最宽
+    expect(dragMaxWidth(w)).toBe(1216 - SPLIT_RAIL)                  // 1208：能拖到的最远
+  })
+
+  it('松手时 Canvas 不足 560 就该藏页面，而不是留一条废条', () => {
+    const w = workspace(1440)
+    expect(shouldFocusAt(w, 648)).toBe(false)   // 正好 560，还能并排
+    expect(shouldFocusAt(w, 649)).toBe(true)    // 差一像素就该整页藏起来
+    expect(shouldFocusAt(w, 1208)).toBe(true)
   })
 })
 


### PR DESCRIPTION
基于最新 main 修三处。两个问题都是量出来的，不是调参。

## ① 终端底部快捷键条只露得出 9px

**根因是布局，不是那条按钮带本身。** 工作区那一列写了 `height: 100dvh`，而它挂在 40px 的 Command Center **下面** —— 整列因此比可视区高出正好一个顶栏：

| | 修前 | 修后 |
|---|---|---|
| 工作区列 | top 40 · height 900 · **bottom 940**（视口 900） | top 40 · height 860 · bottom 900 |
| 快捷键条 | 891 → 940，**屏幕上只剩 9px** | 851 → 900，完整可见 |
| xterm | 750（多算了 40，最后几行在屏幕外） | 705 |

改成跟着 Layout 的列走 `flex:1 / height:100%`。

顺带补上溢出提示：这条 15 个按钮宽 913，窄栏只露 605，而原来既没有渐隐也没有滚动条，右边缘正好把某个键切一半 —— 看着就是「没显示全」。现在与标签条同一套：隐藏滚动条 + 两侧 mask 渐隐 + 竖滚轮横移。首个 Enter 补 `flex:0 0 auto`（原来只有它会被压缩）。

## ② 分栏往左拖不动

**卡住的不是 880 上限，是 `CANVAS_MIN=560`**：1440 屏减侧栏 224 减分隔条 8，上界就是 648，而默认值就在 605 —— 只剩 43px 可拖，手感是「顶死了」。

- `dockBounds` 不再压 880。880 是「默认给多宽」（留在 `defaultDockWidth`），不该同时充当「用户最多能拖多宽」
- 拖拽上界改成 Canvas 归零处：1440 屏上 **648 → 1208**
- 松手时若 Canvas 已不足 560，**落进 Focus** 而不是留一条 300px 的废页面。CANVAS_MIN 想守的东西没变，只是现在「一直往左拖」这个动作也能表达它，而不是拖到某处就不动
- 越过临界点时引导线由蓝转琥珀：松手的后果从「再宽一点」变成「整页藏起来」，先说一声
- 键盘 `End` 同样落进 Focus

## ③ 去掉侧栏的搜索行

顶栏 Command Center 的搜索横跨整个工作区、轨态下也在，侧栏那枚是同一个动作的第二个入口，只是把导航第一屏又占掉一行。

## 验收

测试补 5 条锁住新语义（88 passed）。真机（Chrome CDP @1440×900）：

- 快捷键条 851–900 完整可见，右侧渐隐生效
- 小幅左拖 605 → 645（Canvas 603 → 563）
- 大幅左拖引导线转琥珀，松手后 Canvas 0、分隔条消失、工具条变「返回分栏」
- 手机侧无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)