### PR TITLE
概览/项目/会话：三页分工 + 桌面版排布重做

### DIFF
--- a/docs/design/web/13-mobile-responsive/ia.html
+++ b/docs/design/web/13-mobile-responsive/ia.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><title>概览 / 项目 / 会话 三页分工</title>
+<style>
+:root{
+  --bg:#0d1117;--card:#161b22;--line:#21262d;--line2:#30363d;
+  --tx:#e6edf3;--dim:#8b949e;--dimmer:#6e7681;
+  --acc:#58a6ff;--solid:#4e90dc;--soft:rgba(31,111,235,.14);--accb:rgba(88,166,255,.45);
+  --amber:#d29922;--green:#3fb950;--purple:#a371f7;
+  --micro:11px;--meta:12px;--sm:13px;--body:15px;--lg:16px;--title:22px;
+  --r1:6px;--r2:10px;--r3:14px;--rp:999px;--s1:4px;--s2:8px;--s3:12px;--s4:16px;
+}
+*{box-sizing:border-box}
+body{margin:0;background:#07090d;color:var(--tx);font:14px/1.55 Inter,-apple-system,"PingFang SC",sans-serif}
+.wrap{max-width:1400px;margin:0 auto;padding:28px 22px 70px}
+h1{font-size:21px;margin:0 0 6px}
+h3{font-size:var(--lg);margin:0 0 10px}
+.lede{color:var(--dim);font-size:var(--sm);max-width:78ch;line-height:1.75;margin:0 0 24px}
+.row{display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
+.cap{font-size:var(--meta);color:var(--dim);margin:0 0 8px;display:flex;align-items:center;gap:8px}
+.cap b{color:var(--tx);font-size:var(--sm)}
+.tag{font-size:var(--micro);padding:1px 7px;border-radius:var(--rp);border:1px solid var(--line2);color:var(--dimmer)}
+.tag.bad{color:#f2a6a0;border-color:rgba(248,81,73,.4)}
+.tag.good{color:#7fd18f;border-color:rgba(63,185,80,.4)}
+.note{margin-top:10px;font-size:var(--meta);color:var(--dim);line-height:1.7;max-width:330px}
+.note u{text-decoration:none;color:var(--tx)}
+hr{border:0;border-top:1px solid var(--line);margin:34px 0 24px}
+
+/* 分工表 */
+table{border-collapse:collapse;width:100%;max-width:900px;font-size:var(--sm);margin:4px 0 22px}
+th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--dimmer);font-size:var(--meta);font-weight:600}
+td b{color:var(--tx)}
+td.dim{color:var(--dim)}
+
+/* 手机框 */
+.ph{width:330px;height:600px;border-radius:24px;border:1px solid var(--line2);background:var(--bg);
+  overflow:hidden;display:flex;flex-direction:column}
+.ph .b{flex:1;min-height:0;overflow:hidden;padding:10px 12px}
+.ph .nav{flex:0 0 52px;display:flex;border-top:1px solid var(--line);background:var(--card)}
+.ph .nav i{flex:1;display:grid;place-items:center;font-size:var(--micro);color:var(--dimmer);font-style:normal}
+.ph .nav i.on{color:var(--acc)}
+
+.h2{font-size:20px;margin:0 0 8px;letter-spacing:-.02em}
+.stat{display:flex;gap:16px;align-items:center;height:38px;padding:0 11px;border-radius:var(--r2);
+  background:var(--card);font-size:var(--meta);color:var(--dim);margin-bottom:12px}
+.stat b{font:700 var(--sm)/1 ui-monospace,monospace;color:var(--tx)}
+.stat i{width:6px;height:6px;border-radius:50%;background:var(--green);display:inline-block;margin-right:6px}
+.stat i.a{background:var(--amber)}
+.sect{display:flex;align-items:center;gap:8px;font-size:var(--sm);font-weight:600;margin:0 0 8px}
+.sect .n{min-width:20px;height:20px;padding:0 6px;display:grid;place-items:center;border-radius:var(--rp);
+  background:var(--card);color:var(--dim);font:600 var(--micro)/1 ui-monospace,monospace}
+.sect .go{margin-left:auto;font-size:var(--meta);color:var(--acc);font-weight:400}
+.tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);margin-bottom:10px}
+.tabs s{text-decoration:none;padding:8px 11px;font-size:var(--body);color:var(--dim);border-bottom:2px solid transparent}
+.tabs s.on{color:var(--tx);font-weight:600;border-bottom-color:var(--acc)}
+
+.act{border:1px solid rgba(210,153,34,.28);border-radius:var(--r3);padding:11px 12px;margin-bottom:10px;
+  background:linear-gradient(145deg,rgba(210,153,34,.09),rgba(210,153,34,.02))}
+.act .ty{font-size:var(--meta);color:#e3b341;font-weight:600}
+.act b{display:block;margin-top:6px;font-size:var(--body)}
+.act .go{display:block;margin-top:8px;font-size:var(--meta);color:var(--acc)}
+
+.pcard{background:var(--card);border:1px solid var(--line);border-radius:var(--r3);padding:11px 12px;margin-bottom:10px}
+.pcard b{font-size:var(--body)}
+.pcard .p{font:var(--micro)/1.3 ui-monospace,monospace;color:var(--dimmer);margin-top:2px}
+.task{background:#0b0f14;border-radius:var(--r1);padding:6px 8px;margin-top:7px;display:flex;align-items:center;gap:8px;font-size:var(--sm)}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--green);flex:0 0 auto}
+.task .t{margin-left:auto;font-size:var(--meta);color:var(--dimmer)}
+
+/* 新：会话流 */
+.flow{display:flex;flex-direction:column}
+.frow{display:flex;align-items:center;gap:9px;min-height:44px;padding:6px 8px;border-radius:var(--r2)}
+.frow+.frow{border-top:1px solid var(--line)}
+.frow .pj{color:var(--dimmer);font-size:var(--meta);flex:0 1 auto;min-width:0;overflow:hidden;white-space:nowrap}
+.frow .nm{font-size:var(--sm);font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.frow .ag{font-size:var(--micro);padding:1px 6px;border-radius:var(--rp);flex:0 0 auto;
+  color:#9ccaff;background:rgba(31,111,235,.14)}
+.frow .ag.cx{color:#7fd18f;background:rgba(63,185,80,.12)}
+.frow .t{margin-left:auto;flex:0 0 auto;font-size:var(--meta);color:var(--dimmer)}
+.frow.w{background:rgba(210,153,34,.06)}
+.frow.w .dot{background:var(--amber)}
+
+.dupe{outline:2px solid rgba(248,81,73,.55);outline-offset:3px;border-radius:var(--r3)}
+.badge{display:inline-block;font-size:var(--micro);color:#f2a6a0;border:1px solid rgba(248,81,73,.4);
+  border-radius:var(--rp);padding:1px 7px;margin-left:6px}
+</style></head><body><div class="wrap">
+
+<h1>概览 / 项目 / 会话：三页到底各管什么</h1>
+<p class="lede">
+问题不在样式，在分工：<b>概览把另外两页各复制了一份</b>——第三层是项目卡网格（和项目页几乎逐像素一样），
+还挂了个「会话」tab 直接把整个会话列表页嵌进来。于是同一批会话在三个页面上以三种几乎相同的样子出现，
+用户看不出该去哪一页。
+</p>
+
+<h3>一、现状：重叠在哪</h3>
+<div class="row">
+  <div>
+    <p class="cap"><b>概览（现状）</b><span class="tag bad">第三层 = 项目页</span></p>
+    <div class="ph">
+      <div class="b">
+        <h2 class="h2">晚上好，今天有 1 件事需要你</h2>
+        <div class="stat"><span><i></i><b>12</b> 运行中</span><span><i class="a"></i><b>1</b> 待收尾</span></div>
+        <div class="tabs"><s class="on">项目</s><s>会话</s></div>
+        <div class="sect">需要你 <span class="n">1</span></div>
+        <div class="act"><div class="ty">待收尾 · blade-agent</div><b>1 个任务待收尾</b></div>
+        <div class="sect">活跃项目 <span class="n">8</span></div>
+        <div class="dupe">
+          <div class="pcard"><b>roam</b><div class="p">/home/ai/codes/ttmux</div>
+            <div class="task"><i class="dot"></i>桌面版页面也出一版<span class="t">刚刚</span></div>
+            <div class="task"><i class="dot"></i>roam-bug修复<span class="t">1 天前</span></div></div>
+        </div>
+      </div>
+      <div class="nav"><i class="on">概览</i><i>项目</i><i>文件</i><i>更多</i></div>
+    </div>
+  </div>
+
+  <div>
+    <p class="cap"><b>项目页（现状）</b></p>
+    <div class="ph">
+      <div class="b">
+        <div class="tabs" style="border:0;margin-bottom:8px"><s class="on" style="border:0;padding:0">全部 12</s><s style="border:0">活跃 8</s></div>
+        <div class="dupe">
+          <div class="pcard"><b>roam</b><div class="p">/home/ai/codes/ttmux</div>
+            <div class="task"><i class="dot"></i>桌面版页面也出一版<span class="t">刚刚</span></div>
+            <div class="task"><i class="dot"></i>roam-bug修复<span class="t">1 天前</span></div></div>
+        </div>
+        <div class="pcard"><b>blade-agent</b><div class="p">/home/ai/codes/blade-agent</div>
+          <div class="task"><i class="dot"></i>blade-agent-/tmp<span class="t">27 分钟前</span></div></div>
+      </div>
+      <div class="nav"><i>概览</i><i class="on">项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">红框里两张卡<u>完全一样</u>——同一个组件、同一批数据、同一个交互。
+    概览等于把项目页的前几张卡搬了过来。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>概览「会话」tab（现状）</b><span class="tag bad">= 整个会话页</span></p>
+    <div class="ph">
+      <div class="b">
+        <h2 class="h2" style="font-size:16px">晚上好，今天有 1 件事需要你</h2>
+        <div class="tabs"><s>项目</s><s class="on">会话</s></div>
+        <div class="dupe">
+          <div style="display:flex;gap:6px;margin-bottom:8px">
+            <span style="flex:1;height:30px;border:1px solid var(--line2);border-radius:var(--r2);
+              display:flex;align-items:center;padding:0 9px;color:var(--dimmer);font-size:var(--meta)">⌕ 搜索会话名…</span>
+          </div>
+          <div style="display:flex;gap:6px;font-size:var(--meta);color:var(--dim);margin-bottom:8px">
+            <span style="color:#fff;background:var(--solid);padding:3px 9px;border-radius:var(--r2)">全部 13</span>
+            <span style="padding:3px 9px">待确认 0</span><span style="padding:3px 9px">Claude 9</span>
+          </div>
+          <div class="frow"><i class="dot"></i><span class="nm">桌面版页面也出一版</span><span class="t">刚刚</span></div>
+          <div class="frow"><i class="dot"></i><span class="nm">auth接入第三方</span><span class="t">刚刚</span></div>
+        </div>
+      </div>
+      <div class="nav"><i class="on">概览</i><i>项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">这一整块就是会话页本体（搜索 + 六个筛选 + 列表），
+    <u>连底栏都还高亮在「概览」</u>——用户在概览里，看的却是会话页。</p>
+  </div>
+</div>
+
+<hr>
+
+<h3>二、分工：三个不同的维度</h3>
+<p class="lede" style="margin-bottom:10px">
+三页要成立，得各自回答一个<b>别人回答不了</b>的问题。同一批会话可以出现在三处，但组织维度必须不同：
+</p>
+<table>
+  <tr><th style="width:78px">页面</th><th style="width:150px">回答的问题</th><th style="width:96px">组织维度</th><th>形态</th></tr>
+  <tr><td><b>概览</b></td><td>现在该动手的是什么</td><td class="dim">时间 / 紧急度</td>
+      <td class="dim">行动卡（要你动手的）＋ <b>最近会话</b>（跨项目会话流，按最近活动倒序，<b>排除已进行动卡的</b>）</td></tr>
+  <tr><td><b>项目</b></td><td>某个仓库里有什么</td><td class="dim">空间 / 归属</td>
+      <td class="dim">项目卡网格，卡内列该项目的会话（会话隶属项目，这是卡片的一部分）</td></tr>
+  <tr><td><b>会话</b></td><td>所有会话，按条件找</td><td class="dim">全集 / 筛选</td>
+      <td class="dim">平铺列表 ＋ 搜索 ＋ Agent/等待/空闲筛选 ＋ 排序</td></tr>
+</table>
+<p class="note" style="max-width:900px">
+按这个分工，概览要<u>删掉</u>两样：<b>活跃项目卡网格</b>（那是项目页）和<b>「项目 / 会话」tab</b>（那是把会话页塞进来）。
+补上一样：<b>「最近会话」会话流</b>——扁平、跨项目、按最近活动倒序，一行一个。
+它和项目页的区别是<u>不按仓库分组</u>，和会话页的区别是<u>不做筛选、只取最近 8 条</u>。
+</p>
+
+<h3 style="margin-top:26px">三、概览新版</h3>
+<div class="row">
+  <div>
+    <p class="cap"><b>概览（新）</b><span class="tag good">无重复区块</span></p>
+    <div class="ph">
+      <div class="b">
+        <h2 class="h2">晚上好，今天有 1 件事需要你</h2>
+        <div class="stat"><span><i></i><b>12</b> 运行中</span><span><i class="a"></i><b>1</b> 待收尾</span></div>
+        <div class="sect">需要你 <span class="n">1</span></div>
+        <div class="act"><div class="ty">待收尾 · blade-agent</div><b>1 个任务待收尾</b>
+          <span class="go">去收尾 ›</span></div>
+        <div class="sect" style="margin-top:14px">最近会话
+          <span class="go">全部会话 ›</span></div>
+        <div class="flow">
+          <div class="frow"><i class="dot"></i><span class="pj">roam ·</span><span class="nm">桌面版页面也出一版</span><span class="ag">C</span><span class="t">刚刚</span></div>
+          <div class="frow"><i class="dot"></i><span class="pj">临时 ·</span><span class="nm">ds4双机部署</span><span class="ag">C</span><span class="t">13 分钟前</span></div>
+          <div class="frow"><i class="dot"></i><span class="pj">xiaohui ·</span><span class="nm">app-音乐feed</span><span class="ag cx">Cx</span><span class="t">39 分钟前</span></div>
+          <div class="frow"><i class="dot"></i><span class="pj">roam ·</span><span class="nm">roam-bug修复</span><span class="ag">C</span><span class="t">1 天前</span></div>
+        </div>
+      </div>
+      <div class="nav"><i class="on">概览</i><i>项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">
+      三层全是「现在」：<u>要你动手的</u> → <u>其余在跑的</u> → （页尾）最近发生的。
+      会话流一行 44，带项目前缀，<b>按最近活动倒序而不按仓库分组</b>——这正是它和项目页的分工线。<br><br>
+      自审改掉三处：① 区块头原本写「正在进行 <b>12</b>」，和上面状态条的「<b>12</b> 运行中」是同一个数，
+      去掉计数；② 会话流里原本有一条琥珀色的「等待输入」，但它<u>已经在上面的行动卡里了</u>——
+      现在会话流<b>排除所有已进入行动卡的会话</b>，两层严格互补；③ 「正在进行」有歧义（没跑 Agent 的算不算？），
+      它其实只是按时间倒序，改叫<b>最近会话</b>。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>项目页（不动）</b><span class="tag good">唯一的项目视图</span></p>
+    <div class="ph">
+      <div class="b">
+        <div style="display:flex;gap:6px;margin-bottom:10px;font-size:var(--meta)">
+          <span style="color:var(--acc);border:1px solid var(--accb);background:var(--soft);padding:4px 11px;border-radius:var(--rp)">全部 12</span>
+          <span style="border:1px solid var(--line2);padding:4px 11px;border-radius:var(--rp);color:var(--dim)">活跃 8</span>
+        </div>
+        <div class="pcard"><b>roam</b><div class="p">/home/ai/codes/ttmux</div>
+          <div class="task"><i class="dot"></i>桌面版页面也出一版<span class="t">刚刚</span></div>
+          <div class="task"><i class="dot"></i>roam-bug修复<span class="t">1 天前</span></div></div>
+        <div class="pcard"><b>blade-agent</b><div class="p">/home/ai/codes/blade-agent</div>
+          <div class="task"><i class="dot"></i>blade-agent-/tmp<span class="t">27 分钟前</span></div></div>
+      </div>
+      <div class="nav"><i>概览</i><i class="on">项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">卡内会话保留——「这个仓库下有哪些活」是项目卡的一部分，不是重复。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>会话页（不动）</b><span class="tag good">唯一的全集 + 筛选</span></p>
+    <div class="ph">
+      <div class="b">
+        <div style="display:flex;gap:6px;margin-bottom:8px;font-size:var(--meta);color:var(--dim)">
+          <span style="color:#fff;background:var(--solid);padding:4px 10px;border-radius:var(--r2)">全部 13</span>
+          <span style="padding:4px 10px">待确认 0</span><span style="padding:4px 10px">Claude 9</span>
+        </div>
+        <div class="frow"><i class="dot"></i><span class="nm">桌面版页面也出一版</span><span class="ag">C</span><span class="t">刚刚</span></div>
+        <div class="frow"><i class="dot"></i><span class="nm">auth接入第三方</span><span class="ag">C</span><span class="t">刚刚</span></div>
+        <div class="frow"><i class="dot"></i><span class="nm">ds4双机部署</span><span class="ag">C</span><span class="t">13 分钟前</span></div>
+        <div class="frow"><i class="dot"></i><span class="nm">blade-os图标配置</span><span class="ag cx">Cx</span><span class="t">3 天前</span></div>
+      </div>
+      <div class="nav"><i>概览</i><i>项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">概览的会话流<u>只取最近 8 条、不带筛选</u>；要翻全部、要按 Agent 筛，才来这一页。</p>
+  </div>
+</div>
+
+</div></body></html>

--- a/docs/design/web/14-desktop-workspace.md
+++ b/docs/design/web/14-desktop-workspace.md
@@ -7,7 +7,14 @@
 > [D2 项目工作台](./14-desktop-workspace/projects.html) ·
 > [D3 终端分栏](./14-desktop-workspace/terminal-split.html) ·
 > [D4 终端 Focus](./14-desktop-workspace/terminal-focus.html) ·
-> [D5 超宽屏](./14-desktop-workspace/ultrawide.html)
+> [D5 超宽屏](./14-desktop-workspace/ultrawide.html) ·
+> [D6 概览/项目/会话 三页桌面排布](./14-desktop-workspace/desktop-ia.html)
+>
+> D6 是后补的一稿：三页的**分工**在
+> [13-mobile-responsive/ia.html](./13-mobile-responsive/ia.html) 里定完之后，
+> 桌面仍在用手机那批组件——列表拉到 1174 宽，内容贴左、时间贴右，中间 570–700px 是空的。
+> D6 定的是同一套信息在桌面怎么排：对齐成列、中间的宽度换成「位置」列（⎇ 分支 / 目录）、
+> 破坏性动作随 hover。已实现。
 >
 > 状态：**设计草案，未实现**。本稿只定义 `large ≥ 1280` 的桌面形态；`< 1280`
 > 的手机、平板与小笔电由 [13 · 移动端响应式布局重做](./13-mobile-responsive.md) 负责，

--- a/docs/design/web/14-desktop-workspace/desktop-ia.html
+++ b/docs/design/web/14-desktop-workspace/desktop-ia.html
@@ -1,0 +1,514 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><title>桌面版：概览 / 项目 / 会话</title>
+<style>
+:root{
+  --bg:#0d1117;--card:#161b22;--inset:#0b0f14;--line:#21262d;--line2:#30363d;
+  --tx:#e6edf3;--dim:#8b949e;--dimmer:#6e7681;
+  --acc:#58a6ff;--solid:#4e90dc;--soft:rgba(31,111,235,.14);--accb:rgba(88,166,255,.45);
+  --amber:#d29922;--green:#3fb950;--purple:#a371f7;--cyan:#39c5cf;--red:#f85149;
+  --micro:11px;--meta:12px;--sm:13px;--body:15px;--lg:16px;--title:22px;
+  --r1:6px;--r2:10px;--r3:14px;--rp:999px;
+}
+*{box-sizing:border-box}
+body{margin:0;background:#07090d;color:var(--tx);
+  font:14px/1.55 Inter,-apple-system,"PingFang SC","Microsoft YaHei",sans-serif}
+.wrap{max-width:1060px;margin:0 auto;padding:30px 24px 80px}
+h1{font-size:22px;margin:0 0 8px;letter-spacing:-.01em}
+h2{font-size:var(--lg);margin:36px 0 6px;padding-top:24px;border-top:1px solid var(--line)}
+.lede{color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch;margin:0 0 16px}
+.lede b{color:var(--tx);font-weight:600}
+code{font:var(--meta)/1.4 ui-monospace,monospace;color:#c9d5e2;background:rgba(148,163,184,.1);
+  padding:2px 6px;border-radius:4px}
+ul.meas{margin:0 0 22px;padding-left:19px;max-width:80ch;color:var(--dim);font-size:var(--sm);line-height:1.9}
+ul.meas b{color:#f2a6a0;font:600 var(--sm)/1 ui-monospace,monospace}
+ol.rules{margin:0 0 8px;padding-left:20px;max-width:80ch;color:var(--dim);font-size:var(--sm);line-height:1.85}
+ol.rules li{margin-bottom:8px}
+ol.rules b{color:var(--tx)}
+
+.cap{display:flex;align-items:center;gap:9px;margin:22px 0 9px;font-size:var(--meta);color:var(--dim)}
+.cap b{color:var(--tx);font-size:var(--sm)}
+.tag{font-size:var(--micro);padding:1px 8px;border-radius:var(--rp);border:1px solid var(--line2);color:var(--dimmer)}
+.tag.bad{color:#f2a6a0;border-color:rgba(248,81,73,.42)}
+.tag.good{color:#7fd18f;border-color:rgba(63,185,80,.42)}
+.note{margin:11px 0 0;font-size:var(--meta);color:var(--dim);line-height:1.85;max-width:80ch}
+.note u{text-decoration:none;color:var(--tx)}
+.note em{font-style:normal;color:#f2a6a0}
+.legend{display:flex;gap:16px;font-size:var(--micro);color:var(--dimmer);margin:8px 0 0}
+.legend i{display:inline-block;width:11px;height:11px;border-radius:3px;vertical-align:-2px;margin-right:5px}
+.legend i.v{border:1px dashed rgba(248,81,73,.55);background:rgba(248,81,73,.09)}
+.legend i.n{border:1px dashed rgba(63,185,80,.5);background:rgba(63,185,80,.09)}
+
+/* 桌面框：真实 1216 宽的画布，zoom 缩到 .78（zoom 参与布局，框高自动贴合内容） */
+.stage{overflow:hidden;border-radius:12px;border:1px solid var(--line2);background:var(--bg)}
+.dk{zoom:.78;width:1216px;padding-bottom:18px}
+
+.ph{padding:20px 24px 0}
+.kick{font-size:var(--micro);letter-spacing:.14em;text-transform:uppercase;color:var(--dimmer);font-weight:700}
+.ph h3{margin:5px 0 0;font-size:26px;letter-spacing:-.02em}
+.ph p{margin:8px 0 0;font-size:var(--sm);color:var(--dim)}
+.phrow{display:flex;align-items:flex-end;gap:20px}
+.phrow .sp{flex:1}
+
+.sum{display:flex;align-items:center;gap:22px;height:40px;padding:0 13px;border-radius:var(--r2);
+  background:var(--card);font-size:var(--meta);color:var(--dim);margin:16px 24px 0}
+.sum b,.sumi b{font:700 var(--sm)/1 ui-monospace,monospace;color:var(--tx);margin-right:5px}
+.sum i,.sumi i{width:6px;height:6px;border-radius:50%;background:var(--green);display:inline-block;margin-right:7px}
+.sum i.a,.sumi i.a{background:var(--amber)}
+.sumi{display:flex;align-items:center;gap:20px;font-size:var(--meta);color:var(--dim);padding-bottom:5px}
+
+/* 空白量尺：写在结构里，不用绝对定位，永远对得上 */
+.void{flex:1;min-width:0;height:20px;margin:0 10px;border:1px dashed rgba(248,81,73,.5);border-radius:4px;
+  display:flex;align-items:center;justify-content:center;font:11px/1 ui-monospace,monospace;color:#f2a6a0;
+  background:repeating-linear-gradient(45deg,rgba(248,81,73,.1),rgba(248,81,73,.1) 5px,transparent 5px,transparent 11px)}
+.new{background:rgba(63,185,80,.07);box-shadow:inset 0 0 0 1px rgba(63,185,80,.28)}
+
+.sect{display:flex;align-items:center;gap:9px;font-size:var(--sm);font-weight:600;margin:22px 24px 9px}
+.sect .ln{flex:1}
+.sect .go{font-size:var(--meta);font-weight:400;color:var(--acc)}
+.body{padding:0 24px}
+.grid2{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:20px;align-items:start;padding:0 24px}
+
+.old{display:flex;align-items:center;gap:9px;height:44px;padding:0 8px;border-bottom:1px solid var(--line)}
+.old .pj{color:var(--dimmer);font-size:var(--meta)}
+.old .nm{font-size:var(--sm);font-weight:600}
+.old .tm{font-size:var(--meta);color:var(--dimmer)}
+.ag{padding:1px 7px;border-radius:var(--rp);font-size:var(--micro);color:#9ccaff;background:var(--soft)}
+.ag.cx{color:#7fd18f;background:rgba(63,185,80,.12)}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--green);flex:0 0 auto}
+.dot.a{background:var(--amber)} .dot.z{background:var(--dimmer)}
+
+.tbl{display:grid;grid-template-columns:8px 128px minmax(170px,1fr) 60px 260px 74px;
+  align-items:center;column-gap:14px;padding:0 8px}
+.tbl .c{height:40px;display:flex;align-items:center;min-width:0;border-bottom:1px solid var(--line)}
+.tbl .c.pj{color:var(--dimmer);font-size:var(--meta);overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+.tbl .c.nm{font-size:var(--sm);font-weight:600;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+.tbl .c.loc{font:var(--meta)/1 ui-monospace,monospace;color:var(--dimmer);overflow:hidden;white-space:nowrap;
+  padding-left:8px;margin-left:-8px}
+.tbl .c.loc .br{color:#7ed0d8}
+.tbl .c.tm{font-size:var(--meta);color:var(--dimmer);justify-content:flex-end}
+
+.pgrid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px;padding:0 24px;align-items:start}
+.pcard{background:var(--card);border:1px solid var(--line);border-radius:var(--r3);padding:14px 15px}
+.pcard.empty{border-style:dashed;border-color:rgba(248,81,73,.45)}
+.pcard h4{margin:0;font-size:var(--body)}
+.pcard .p{font:var(--micro)/1.3 ui-monospace,monospace;color:var(--dimmer);margin-top:4px}
+.pcard .m{font-size:var(--meta);color:var(--dim);margin-top:8px}
+.pcard .m b{color:var(--tx);font-family:ui-monospace,monospace}
+.pcard .hollow{height:44px;margin-top:9px;border-radius:var(--r1);
+  background:repeating-linear-gradient(45deg,rgba(248,81,73,.09),rgba(248,81,73,.09) 5px,transparent 5px,transparent 11px)}
+.task{background:var(--inset);border-radius:var(--r1);padding:8px 10px;margin-top:9px;
+  display:flex;align-items:center;gap:9px;font-size:var(--sm)}
+.task .t{margin-left:auto;font-size:var(--meta);color:var(--dimmer)}
+.chip{height:28px;padding:0 13px;border-radius:var(--rp);border:1px solid var(--line2);
+  display:inline-flex;align-items:center;gap:7px;font-size:var(--meta);color:var(--dim)}
+.chip.on{color:var(--acc);border-color:var(--accb);background:var(--soft)}
+.chip .n{font:var(--micro)/1 ui-monospace,monospace;color:var(--dimmer)}
+.bar{display:flex;align-items:center;gap:9px;padding:0 24px;margin:18px 0}
+.bar .sp{flex:1}
+.solid{background:var(--solid);color:#fff;border-radius:var(--r1);padding:5px 11px;font-size:var(--meta)}
+.plain{color:var(--dim);font-size:var(--meta);padding:5px 9px}
+.srch{height:30px;flex:0 0 240px;border:1px solid var(--line2);border-radius:var(--r2);background:var(--card);
+  display:flex;align-items:center;padding:0 11px;color:var(--dimmer);font-size:var(--meta)}
+.rest{padding:0 24px}
+.rrow{display:grid;grid-template-columns:150px minmax(0,1fr) 92px;align-items:center;column-gap:14px;
+  height:36px;border-bottom:1px solid var(--line);font-size:var(--sm)}
+.rrow .p{font:var(--meta)/1 ui-monospace,monospace;color:var(--dimmer);overflow:hidden;white-space:nowrap}
+.rrow .k{font-size:var(--micro);color:#7fd18f;justify-self:end}
+
+.slist .row{display:grid;grid-template-columns:8px minmax(180px,1fr) 124px minmax(160px,1.25fr) 120px 82px 92px;
+  align-items:center;column-gap:14px;height:40px;padding:0 10px;border-bottom:1px solid var(--line)}
+.slist .row .id{color:var(--dimmer);font-size:var(--meta);font-weight:400;margin-left:5px}
+.slist .row .nm{font-size:var(--sm);font-weight:600;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;min-width:0}
+.slist .row .pj{font-size:var(--meta);color:var(--dimmer);overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+.slist .row .br{font:var(--meta)/1 ui-monospace,monospace;color:#7ed0d8;overflow:hidden;white-space:nowrap}
+.slist .row .tm{font-size:var(--meta);color:var(--dimmer);text-align:right}
+.slist .row .act{font-size:var(--meta);color:var(--acc);text-align:right;opacity:0}
+.slist .row.hov{background:var(--card);border-radius:var(--r1)}
+.slist .row.hov .act{opacity:1}
+.slist .newcol{background:rgba(63,185,80,.07);box-shadow:inset 0 0 0 1px rgba(63,185,80,.22);
+  border-radius:3px;padding:3px 6px;margin:0 -6px}
+.old2{padding:9px 10px;border-bottom:1px solid var(--line)}
+.old2 .l1{display:flex;align-items:center;gap:9px}
+.old2 .l2{margin:5px 0 0 17px;font-size:var(--meta);color:var(--dimmer)}
+.old2 .nm{font-size:var(--sm);font-weight:700}
+.old2 .id{color:var(--dimmer);font-size:var(--meta);font-weight:400}
+.tg{font-size:var(--micro);padding:1px 7px;border-radius:var(--r1);border:1px solid var(--line2);color:var(--dim)}
+.tg.b{color:#9ccaff;border-color:rgba(88,166,255,.4);background:var(--soft)}
+.tg.g{color:#7fd18f;border-color:rgba(63,185,80,.4);background:rgba(63,185,80,.1)}
+.tg.c{color:#7ed0d8;border-color:rgba(57,197,207,.4);background:rgba(57,197,207,.08);font-family:ui-monospace,monospace}
+.acts{display:flex;gap:18px;font-size:var(--sm)}
+.acts a{color:var(--acc)}
+.acts .kill{color:var(--red)}
+.rail{background:var(--card);border-radius:var(--r3);padding:14px}
+.rail h4{margin:0 0 12px;font-size:var(--sm)}
+.ev{position:relative;padding-left:18px;margin-bottom:15px}
+.ev::before{content:"";position:absolute;left:1px;top:4px;width:7px;height:7px;border-radius:50%;background:var(--cyan)}
+.ev b{display:block;font-size:var(--meta)}
+.ev p{margin:3px 0 0;font-size:var(--meta);color:var(--dim);line-height:1.5}
+.ev time{display:block;margin-top:3px;font-size:var(--micro);color:var(--dimmer)}
+table.tt{border-collapse:collapse;width:100%;font-size:var(--sm);margin:8px 0 20px}
+table.tt th,table.tt td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+table.tt th{color:var(--dimmer);font-size:var(--meta);font-weight:600}
+table.tt td{color:var(--dim)}
+table.tt td b{color:var(--tx)}
+</style></head><body><div class="wrap">
+
+<h1>桌面版：概览 / 项目 / 会话</h1>
+<p class="lede">
+手机版刚把三页的分工定完（<b>概览＝时间 · 项目＝空间 · 会话＝全集</b>），但桌面沿用的是同一批组件，
+于是<b>桌面成了「更宽的手机」</b>：列表被拉到 1174，内容还贴在左边，时间还贴在右边，中间是空的。
+1440×900（侧栏 224）实测：
+</p>
+<ul class="meas">
+  <li>概览会话行宽 838，名称右缘到时间左缘 <b>570px</b> 是空的（占行宽 68%）</li>
+  <li>状态条宽 1174，里面只有 <b>82px</b> 内容——<b>1092px</b> 是一枚空胶囊</li>
+  <li>会话页每行内容右缘 x=636，操作区起点 x=1333，中间 <b>697px</b> 是空的</li>
+  <li>概览左栏内容到 y=590 就结束，视口 900——下方 <b>310px</b> 空着，右轨却排到 992</li>
+  <li>项目页 4 个 0 任务的项目，占掉 <b>467px</b> 的卡片网格</li>
+</ul>
+<p class="lede" style="margin-bottom:8px">宽度没有变成信息，变成了空气。</p>
+
+<h2>桌面四条原则</h2>
+<ol class="rules">
+  <li><b>对齐成列。</b>同类信息落在同一个 x 上，眼睛竖着扫一列；现在是每行左右横跳 570–700px。</li>
+  <li><b>中间那段宽度要给信息，不给空气。</b>桌面每行比手机多一列——<b>「它在哪」</b>（⎇ 分支 / 工作目录）。
+      这是手机放不下、桌面放得下的东西，也是桌面版存在的理由。</li>
+  <li><b>破坏性动作不常驻。</b><em>关闭</em> 只在 hover 该行时出现（仅 <code>data-pointer:fine</code>）；
+      12 行 12 个红字，是界面在冲用户喊。</li>
+  <li><b>桌面行高 36–40，一屏放得下更多。</b>44 是粗指针的命中下限、不是桌面的目标值；
+      会话条数手机 8 条、桌面 12 条。</li>
+</ol>
+<p class="legend"><span><i class="v"></i>红斜线＝量出来的空白</span><span><i class="n"></i>绿底＝桌面新增的信息列</span></p>
+
+<h2>一、概览</h2>
+
+<p class="cap"><b>现状</b><span class="tag bad">570 / 1092 / 310 三处空白</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="ph"><div class="kick">8月3日星期一</div>
+      <h3>晚上好，当前没有待处理事项</h3>
+      <p>12 个任务正在运行，最近一次活动在刚刚</p></div>
+    <div class="sum"><span style="flex:0 0 auto"><i></i><b>12</b>运行中</span>
+      <span class="void">状态条里 1092px 什么都没有</span></div>
+    <div class="grid2" style="margin-top:22px">
+      <div>
+        <div class="sect" style="margin:0 0 9px"><span>最近会话</span><span class="ln"></span><span class="go">全部会话 ›</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">roam ·</span><span class="nm">桌面版页面也出一版优化设计</span><span class="ag">Claude</span>
+          <span class="void">570px</span><span class="tm">刚刚</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">blade-agent ·</span><span class="nm">blade-agent-/tmp</span><span class="ag">Claude</span>
+          <span class="void"></span><span class="tm">6 分钟前</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">blade-oauth ·</span><span class="nm">auth接入第三方</span><span class="ag">Claude</span>
+          <span class="void"></span><span class="tm">6 分钟前</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">roam ·</span><span class="nm">roam-bug修复</span><span class="ag">Claude</span>
+          <span class="void"></span><span class="tm">6 分钟前</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">xiaohui-app ·</span><span class="nm">有个tv改进的worktree</span><span class="ag">Claude</span>
+          <span class="void"></span><span class="tm">6 分钟前</span></div>
+        <div class="old"><i class="dot"></i><span class="pj">临时 ·</span><span class="nm">你看看-jetson@192</span><span class="ag cx">Codex</span>
+          <span class="void"></span><span class="tm">29 分钟前</span></div>
+        <div style="height:120px;border:1px dashed rgba(248,81,73,.5);border-radius:6px;margin-top:14px;
+          display:flex;align-items:center;justify-content:center;font:11px/1 ui-monospace,monospace;color:#f2a6a0;
+          background:repeating-linear-gradient(45deg,rgba(248,81,73,.1),rgba(248,81,73,.1) 5px,transparent 5px,transparent 11px)">
+          左栏到这里就没了，右轨还在往下排 —— 310px</div>
+      </div>
+      <div class="rail">
+        <h4>最近活动</h4>
+        <div class="ev"><b>242d840 · roam</b><p>refactor(web): 概览不再复制项目页和会话页</p><time>7 分钟前</time></div>
+        <div class="ev"><b>83af9a4 · blade-agent</b><p>squash: merge docs/ba-prompt-analysis into main</p><time>14 分钟前</time></div>
+        <div class="ev"><b>8b1d45c · roam</b><p>fix(web): 对话态外壳 + 手机顶部 chrome 重设计</p><time>34 分钟前</time></div>
+        <div class="ev"><b>cac4fb9 · roam</b><p>feat(web): 方向簇只在 TUI 里出现</p><time>39 分钟前</time></div>
+        <div class="ev" style="margin-bottom:0"><b>0dd3454 · blade-oauth</b><p>feat(auth): web 登录改签落库的会话令牌</p><time>3 小时前</time></div>
+      </div>
+    </div>
+  </div>
+</div>
+<p class="note">
+状态条只剩一项时仍然撑满 1174；会话行是手机那行直接拉宽，名称与时间之间什么都没有；
+左栏比右轨短一大截，页面下半截是空的。三处都是同一个毛病：<u>宽度没换成信息</u>。
+</p>
+
+<p class="cap"><b>新版</b><span class="tag good">状态条并进页头 · 会话六列 · 桌面 12 条</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="ph"><div class="phrow">
+      <div><div class="kick">8月3日星期一</div>
+        <h3>晚上好，当前没有待处理事项</h3>
+        <p>12 个任务正在运行，最近一次活动在刚刚</p></div>
+      <div class="sp"></div>
+      <div class="sumi"><span><i></i><b>12</b>运行中</span><span><i class="a"></i><b>1</b>待收尾</span></div>
+    </div></div>
+    <div class="grid2" style="margin-top:20px">
+      <div>
+        <div class="sect" style="margin:0 0 6px"><span>最近会话</span><span class="ln"></span><span class="go">全部会话 ›</span></div>
+        <div class="tbl">
+          <div class="c"><i class="dot"></i></div><div class="c pj">roam</div><div class="c nm">桌面版页面也出一版优化设计</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new"><span class="br">⎇ redesign/overview-vs-projects</span></div><div class="c tm">刚刚</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">blade-agent</div><div class="c nm">blade-agent-/tmp</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new">~/codes/blade-agent</div><div class="c tm">6 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">blade-oauth</div><div class="c nm">auth接入第三方</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new"><span class="br">⎇ feat/web-session-tokens</span></div><div class="c tm">6 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">roam</div><div class="c nm">roam-bug修复</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new"><span class="br">⎇ main</span></div><div class="c tm">6 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">xiaohui-app</div><div class="c nm">有个tv改进的worktree</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new"><span class="br">⎇ feat/tv-live-fullscreen</span></div><div class="c tm">6 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">blade-service-deployer</div><div class="c nm">blade-os图标配置</div><div class="c"><span class="ag cx">Codex</span></div><div class="c loc new">~/codes/blade-service-deployer</div><div class="c tm">29 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">临时</div><div class="c nm">你看看-jetson@192</div><div class="c"><span class="ag cx">Codex</span></div><div class="c loc new">~/codes/tmp</div><div class="c tm">29 分钟前</div>
+          <div class="c"><i class="dot"></i></div><div class="c pj">线上问题排查</div><div class="c nm">响应布局</div><div class="c"><span class="ag cx">Codex</span></div><div class="c loc new">~/codes</div><div class="c tm">29 分钟前</div>
+          <div class="c"><i class="dot z"></i></div><div class="c pj">xiaohui</div><div class="c nm">app-音乐feed</div><div class="c"><span class="ag">Claude</span></div><div class="c loc new"><span class="br">⎇ feat/dev-music-telemetry</span></div><div class="c tm">34 分钟前</div>
+          <div class="c"><i class="dot z"></i></div><div class="c pj">临时</div><div class="c nm">ds4双机部署</div><div class="c"><span class="ag cx">Codex</span></div><div class="c loc new">~/codes/tmp</div><div class="c tm">1 小时前</div>
+          <div class="c"><i class="dot z"></i></div><div class="c pj">skills</div><div class="c nm">ssh-ai@192</div><div class="c"><span class="ag cx">Codex</span></div><div class="c loc new">~/codes/skills</div><div class="c tm">30 分钟前</div>
+          <div class="c" style="border:0"><i class="dot z"></i></div><div class="c pj" style="border:0">roam</div><div class="c nm" style="border:0">代码提交</div><div class="c" style="border:0"></div><div class="c loc new" style="border:0">~/codes/ttmux</div><div class="c tm" style="border:0">2 天前</div>
+        </div>
+      </div>
+      <div class="rail">
+        <h4>最近活动</h4>
+        <div class="ev"><b>242d840 · roam</b><p>refactor(web): 概览不再复制项目页和会话页</p><time>7 分钟前</time></div>
+        <div class="ev"><b>83af9a4 · blade-agent</b><p>squash: merge docs/ba-prompt-analysis into main</p><time>14 分钟前</time></div>
+        <div class="ev"><b>8b1d45c · roam</b><p>fix(web): 对话态外壳 + 手机顶部 chrome 重设计</p><time>34 分钟前</time></div>
+        <div class="ev"><b>cac4fb9 · roam</b><p>feat(web): 方向簇只在 TUI 里出现</p><time>39 分钟前</time></div>
+        <div class="ev"><b>0dd3454 · blade-oauth</b><p>feat(auth): web 登录改签落库的会话令牌</p><time>3 小时前</time></div>
+        <div class="ev" style="margin-bottom:0"><b>1dbf59d · roam</b><p>fix(web): 终端底部快捷键条被顶出可视区</p><time>5 小时前</time></div>
+      </div>
+    </div>
+  </div>
+</div>
+<p class="note">
+① <u>状态条并进页头右端</u>——省掉一整行，也不会再出现「一枚数字 + 1092px 空白」的胶囊；<br>
+② 会话流变六列：<u>● / 项目 / 名称 / Agent / 位置 / 时间</u>。中间那段宽度交给<b>位置</b>——
+有 worktree 就是 <span style="color:#7ed0d8;font-family:ui-monospace,monospace">⎇ 分支</span>，否则是工作目录；
+数据来自已经在拉的 <code>/sessions/annotations</code>，<u>零新接口</u>；<br>
+③ 桌面 12 条（手机 8 条），左栏与右轨终于等长。
+</p>
+<p class="note">
+<u>为什么「位置」列不是「它正在输出什么」？</u>抓屏最后一行实测是
+<code>⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents</code> 或整行制表符边框——
+TUI 的末行几乎永远是状态栏，不是内容。放上去只会得到一列噪声。
+</p>
+
+<h2>二、项目</h2>
+
+<p class="cap"><b>现状</b><span class="tag bad">4 个空项目占 467px · 两套控件语言</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="bar" style="margin-top:16px">
+      <span class="srch">搜索项目或路径</span>
+      <span class="chip on">全部 <span class="n">12</span></span>
+      <span class="chip">活跃 <span class="n">8</span></span>
+      <span class="chip">待收尾 <span class="n">0</span></span>
+      <span class="sp"></span>
+      <span class="plain">名称</span><span class="plain">创建时间</span><span class="solid">最近活跃</span>
+    </div>
+    <div class="pgrid">
+      <div class="pcard"><h4>roam</h4><div class="p">/home/ai/codes/ttmux</div>
+        <div class="m"><b>2</b> 任务 · <b>1</b> worktree</div>
+        <div class="task"><i class="dot"></i>桌面版页面也出一版优化设计<span class="t">刚刚</span></div>
+        <div class="task"><i class="dot"></i>roam-bug修复<span class="t">7 分钟前</span></div></div>
+      <div class="pcard"><h4>blade-agent</h4><div class="p">/home/ai/codes/blade-agent</div>
+        <div class="m"><b>1</b> 任务 · <b>1</b> worktree</div>
+        <div class="task"><i class="dot"></i>blade-agent-/tmp<span class="t">7 分钟前</span></div>
+        <div class="hollow"></div></div>
+      <div class="pcard empty"><h4>llm-gateway</h4><div class="p">/home/ai/codes/llm-gateway</div>
+        <div class="m"><b>0</b> 任务 · <b>2</b> worktree</div>
+        <div class="hollow" style="height:96px"></div></div>
+      <div class="pcard empty"><h4>blade-quant</h4><div class="p">/home/ai/codes/blade-quant</div>
+        <div class="m"><b>0</b> 任务 · <b>1</b> worktree</div></div>
+      <div class="pcard empty"><h4>skills</h4><div class="p">/home/ai/codes/skills</div>
+        <div class="m"><b>0</b> 任务 · <b>0</b> worktree</div></div>
+      <div class="pcard empty"><h4>swarm</h4><div class="p">/home/ai/codes/swarm</div>
+        <div class="m"><b>0</b> 任务</div></div>
+    </div>
+  </div>
+</div>
+<p class="note">
+0 任务的项目和正在跑 2 个任务的项目<u>占同样大的卡</u>，还被同一行最高的卡撑到 167px（红斜线就是撑出来的空）；
+页面下三分之一全是空卡。右上角排序是「两个裸文字 + 一个实心蓝块」，与左边的 pill 筛选<u>不是同一套控件语言</u>。
+</p>
+
+<p class="cap"><b>新版</b><span class="tag good">空项目折成一行 · 排序统一成 pill</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="bar" style="margin-top:16px">
+      <span class="srch">搜索项目或路径</span>
+      <span class="chip on">全部 <span class="n">12</span></span>
+      <span class="chip">活跃 <span class="n">8</span></span>
+      <span class="chip">待收尾 <span class="n">0</span></span>
+      <span class="sp"></span>
+      <span class="chip">最近活跃 ⌄</span>
+    </div>
+    <div class="pgrid">
+      <div class="pcard"><h4>roam</h4><div class="p">/home/ai/codes/ttmux</div>
+        <div class="m"><b>2</b> 任务 · <b>1</b> worktree</div>
+        <div class="task"><i class="dot"></i>桌面版页面也出一版优化设计<span class="t">刚刚</span></div>
+        <div class="task"><i class="dot"></i>roam-bug修复<span class="t">7 分钟前</span></div></div>
+      <div class="pcard"><h4>blade-agent</h4><div class="p">/home/ai/codes/blade-agent</div>
+        <div class="m"><b>1</b> 任务 · <b>1</b> worktree</div>
+        <div class="task"><i class="dot"></i>blade-agent-/tmp<span class="t">7 分钟前</span></div></div>
+      <div class="pcard"><h4>blade-oauth</h4><div class="p">/home/ai/codes/blade-oauth</div>
+        <div class="m"><b>1</b> 任务 · <b>4</b> worktree</div>
+        <div class="task"><i class="dot"></i>auth接入第三方<span class="t">7 分钟前</span></div></div>
+      <div class="pcard"><h4>xiaohui-app</h4><div class="p">/home/ai/codes/ybz/xh/XiaoHui</div>
+        <div class="m"><b>2</b> 任务 · <b>2</b> worktree</div>
+        <div class="task"><i class="dot"></i>有个tv改进的worktree<span class="t">7 分钟前</span></div>
+        <div class="task"><i class="dot z"></i>代码提交<span class="t">2 天前</span></div></div>
+      <div class="pcard"><h4>临时</h4><div class="p">/home/ai/codes/tmp</div>
+        <div class="m"><b>2</b> 任务</div>
+        <div class="task"><i class="dot"></i>你看看-jetson@192<span class="t">30 分钟前</span></div>
+        <div class="task"><i class="dot z"></i>ds4双机部署<span class="t">1 小时前</span></div></div>
+      <div class="pcard"><h4>线上问题排查</h4><div class="p">/home/ai/codes</div>
+        <div class="m"><b>2</b> 任务</div>
+        <div class="task"><i class="dot"></i>响应布局<span class="t">30 分钟前</span></div>
+        <div class="task"><i class="dot"></i>ssh-ai@192<span class="t">30 分钟前</span></div></div>
+    </div>
+    <div class="sect" style="margin:24px 24px 6px"><span>其他项目</span>
+      <span style="font-size:var(--meta);font-weight:400;color:var(--dimmer)">没有会话在跑</span><span class="ln"></span></div>
+    <div class="rest">
+      <div class="rrow"><span>llm-gateway</span><span class="p">/home/ai/codes/llm-gateway</span><span class="k">✓ 1 可清理</span></div>
+      <div class="rrow"><span>blade-quant</span><span class="p">/home/ai/codes/blade-quant</span><span class="k">✓ 1 可清理</span></div>
+      <div class="rrow"><span>skills</span><span class="p">/home/ai/codes/skills</span><span></span></div>
+      <div class="rrow" style="border:0"><span>swarm</span><span class="p">/home/ai/codes/swarm</span><span></span></div>
+    </div>
+  </div>
+</div>
+<p class="note">
+没有会话在跑的项目<u>不值一张卡</u>：折成页尾一行一个——名字 + 路径 + 可清理标，点开照样进项目页。
+卡片网格于是只留真正在动的项目，同样的高度里从 6 个项目变成 <u>6 张有内容的卡 + 4 行</u>。
+排序从三个裸文字换成一枚 pill，与左侧筛选同一套语言。
+</p>
+
+<h2>三、会话</h2>
+
+<p class="cap"><b>现状</b><span class="tag bad">每行 67px · 697px 空白 · 12 个常驻红字</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="body" style="padding-top:16px">
+      <div class="old2"><div class="l1"><i class="dot"></i><span class="nm">桌面版页面也出一版优化设计</span>
+        <span class="id">(2026-0730-1521-000v)</span><span class="tg c">⎇ redesign/overview-vs-projects</span>
+        <span class="tg b">✳ Claude</span><span style="font-size:var(--meta);color:var(--dim)">1 窗口</span>
+        <span class="void">697px</span>
+        <span class="acts"><a>派生</a><a class="kill">关闭</a></span></div>
+        <div class="l2">创建 4 天前 · 最后响应 刚刚</div></div>
+      <div class="old2"><div class="l1"><i class="dot"></i><span class="nm">roam-bug修复</span>
+        <span class="id">(2026-0729-1100-0005)</span><span class="tg b">✳ Claude</span>
+        <span style="font-size:var(--meta);color:var(--dim)">1 窗口</span>
+        <span class="void"></span>
+        <span class="acts"><a>派生</a><a class="kill">关闭</a></span></div>
+        <div class="l2">创建 5 天前 · 最后响应 7 分钟前</div></div>
+      <div class="old2"><div class="l1"><i class="dot"></i><span class="nm">blade-agent-/tmp</span>
+        <span class="id">(2026-0801-1720-001a)</span><span class="tg b">✳ Claude</span>
+        <span style="font-size:var(--meta);color:var(--dim)">1 窗口</span>
+        <span class="void"></span>
+        <span class="acts"><a>派生</a><a class="kill">关闭</a></span></div>
+        <div class="l2">创建 2 天前 · 最后响应 7 分钟前</div></div>
+      <div class="old2"><div class="l1"><i class="dot a"></i><span class="nm">auth接入第三方</span>
+        <span class="id">(2026-0803-1004-001c)</span><span class="tg c">⎇ feat/web-session-tokens</span>
+        <span class="tg b">✳ Claude</span><span style="font-size:var(--meta);color:var(--dim)">1 窗口</span>
+        <span class="void"></span>
+        <span class="acts"><a>派生</a><a class="kill">关闭</a></span></div>
+        <div class="l2">创建 12 小时前 · 最后响应 7 分钟前</div></div>
+      <div class="old2" style="border:0"><div class="l1"><i class="dot z"></i><span class="nm">blade-os图标配置</span>
+        <span class="id">(2026-0730-1040-000t)</span><span class="tg g">✸ Codex</span>
+        <span style="font-size:var(--meta);color:var(--dim)">1 窗口</span>
+        <span class="void"></span>
+        <span class="acts"><a>派生</a><a class="kill">关闭</a></span></div>
+        <div class="l2">创建 4 天前 · 最后响应 30 分钟前</div></div>
+    </div>
+  </div>
+</div>
+<p class="note">
+一条会话写成两行 67px，第二行只有「创建 · 最后响应」；中间 697px 空着，
+而<u>这条会话属于哪个项目</u>——概览都写了——这一页反而没有。会话 ID 与名字同权并排，
+每行还常驻一个红色「关闭」。
+</p>
+
+<p class="cap"><b>新版</b><span class="tag good">一行 40px · 补上项目列 · 关闭随 hover</span></p>
+<div class="stage">
+  <div class="dk">
+    <div class="body slist" style="padding-top:16px">
+      <div class="row hov"><i class="dot"></i>
+        <span class="nm">桌面版页面也出一版优化设计<span class="id">000v</span></span>
+        <span class="pj newcol">roam</span>
+        <span class="br newcol">⎇ redesign/overview-vs-projects</span>
+        <span><span class="tg b">Claude</span></span>
+        <span class="tm">刚刚</span><span class="act">派生 · 关闭</span></div>
+      <div class="row"><i class="dot"></i>
+        <span class="nm">roam-bug修复<span class="id">0005</span></span>
+        <span class="pj newcol">roam</span>
+        <span class="br newcol">⎇ main</span>
+        <span><span class="tg b">Claude</span></span>
+        <span class="tm">7 分钟前</span><span class="act">派生 · 关闭</span></div>
+      <div class="row"><i class="dot"></i>
+        <span class="nm">blade-agent-/tmp<span class="id">001a</span></span>
+        <span class="pj newcol">blade-agent</span>
+        <span class="br newcol">~/codes/blade-agent</span>
+        <span><span class="tg b">Claude</span></span>
+        <span class="tm">7 分钟前</span><span class="act">派生 · 关闭</span></div>
+      <div class="row"><i class="dot a"></i>
+        <span class="nm">auth接入第三方<span class="id">001c</span></span>
+        <span class="pj newcol">blade-oauth</span>
+        <span class="br newcol">⎇ feat/web-session-tokens</span>
+        <span style="display:flex;gap:6px;min-width:0"><span class="tg" style="color:#e3b341;border-color:rgba(210,153,34,.45);background:rgba(210,153,34,.1)">待确认</span><span class="tg b">Claude</span></span>
+        <span class="tm">7 分钟前</span><span class="act">派生 · 关闭</span></div>
+      <div class="row"><i class="dot"></i>
+        <span class="nm">有个tv改进的worktree<span class="id">001h</span></span>
+        <span class="pj newcol">xiaohui-app</span>
+        <span class="br newcol">⎇ feat/tv-live-fullscreen</span>
+        <span><span class="tg b">Claude</span></span>
+        <span class="tm">7 分钟前</span><span class="act">派生 · 关闭</span></div>
+      <div class="row"><i class="dot z"></i>
+        <span class="nm">blade-os图标配置<span class="id">000t</span></span>
+        <span class="pj newcol">blade-service-deployer</span>
+        <span class="br newcol">~/codes/blade-service-deployer</span>
+        <span><span class="tg g">Codex</span></span>
+        <span class="tm">30 分钟前</span><span class="act">派生 · 关闭</span></div>
+      <div class="row" style="border:0"><i class="dot z"></i>
+        <span class="nm">你看看-jetson@192<span class="id">0006</span></span>
+        <span class="pj newcol">临时</span>
+        <span class="br newcol">~/codes/tmp</span>
+        <span><span class="tg g">Codex</span></span>
+        <span class="tm">30 分钟前</span><span class="act">派生 · 关闭</span></div>
+    </div>
+  </div>
+</div>
+<p class="note">
+两行压成一行 40：<u>12 条从 799px 收到 480px</u>，一屏放得下整份列表。中间的空白换成两列真信息——
+<b>项目</b>（这一页原本没有）和<b>位置</b>（⎇ 分支 / 目录）；「创建 4 天前」不再占一行，移进名称的 title；
+会话 ID 只留尾 4 位、灰度降一档，要全名 hover 就有。<em>派生 / 关闭 只在 hover 该行时出现</em>——
+上面第一行就是 hover 态；粗指针档（平板）保持常驻。
+</p>
+
+<h2>四、自审：画完之后自己挑的毛病</h2>
+<ol class="rules">
+  <li><b>会话页把「1 窗口」和「创建时间」删了，得说清规则。</b>窗口数 99% 的会话都是 1，常驻就是一列噪声——
+      <u>只在 &gt;1 时才显示</u>；创建时间进名称的 <code>title</code>，列表里只留「最后响应」（排序默认也是它）。</li>
+  <li><b>名称列吃掉了全部富余，项目列前面又空出 150px。</b>初版名称列是 <code>1.3fr</code>、位置列 <code>1fr</code>，
+      富余全落在名称右边——正是刚批评过的毛病换了个地方。改成名称 <code>1fr</code> / 位置 <code>1.25fr</code>：
+      <u>富余给等宽字体的路径</u>，它多一点就能少截一截。</li>
+  <li><b>概览「位置」列原本定死 296。</b>只有 <code>~/codes</code> 的行会空出一大截。收到 260，
+      多出来的给名称。列内偶尔短是列对齐的成本，可以接受；<u>但不能宽到看着像空列</u>。</li>
+  <li><b>「其他项目」在筛选态下必须整块消失。</b>用户点了「活跃 8」，页尾还挂着 4 个不活跃项目就是自相矛盾——
+      它只在「全部」下出现。</li>
+  <li><b>状态数字挪进页头后，别看着像装饰。</b>它们现在仍然是导航入口（点进项目页），
+      所以 hover 态、手型、44 命中区一个都不能少——挪位置不等于降级成统计文本。</li>
+  <li><b>hover 才出现的操作对键盘用户是隐身的。</b>除了 <code>:hover</code> 还要 <code>:focus-within</code>，
+      Tab 到那一行时同样浮出来；粗指针档（平板）保持常驻，那里没有 hover。</li>
+  <li><b>会话页的标记列要装得下两枚标。</b>「待确认 + Claude」是最常见的组合，
+      74px 只够一枚——放宽到 132，超出的（蜂群）折进名称行的 title。</li>
+  <li><b>落地时才发现的：位置列会和项目列说同一句话。</b>非 git 项目的会话没有分支，
+      位置只能写工作目录，而那个目录<u>就是左边项目列那个项目的目录</u>——两列念同一件事。
+      规则改成：有分支写分支；没有分支且工作目录 ≠ 项目目录才写目录；<b>相同就留空</b>。
+      于是这一列只在「它确实在别处」时才出声。</li>
+  <li><b>落地时才发现的：两行排法不是「手机专属」，是「窄 Canvas 专属」。</b>
+      桌面拉开终端分栏后 Canvas 同样会窄到 900 以下。所以两行栅格写成<u>基础排法</u>、
+      七列写成 <code>@container</code> 覆盖——按视口档位写就会在分栏态露馅。</li>
+</ol>
+
+<h2>五、与手机版的对照</h2>
+<table class="tt">
+  <tr><th style="width:88px">区块</th><th style="width:230px">手机 compact</th><th>桌面 expanded / large</th></tr>
+  <tr><td><b>状态条</b></td><td>独占一行，零值项不渲染</td><td>并进页头右端，不再单独占一行</td></tr>
+  <tr><td><b>最近会话</b></td><td>一行 44：● 项目 · 名称 Agent 时间</td>
+      <td>六列 40：● / 项目 / 名称 / Agent / <b>位置</b> / 时间；8 条 → 12 条</td></tr>
+  <tr><td><b>项目列表</b></td><td>单列卡片；空项目同样折到页尾</td><td>2–3 列卡片 + 页尾「其他项目」紧凑行</td></tr>
+  <tr><td><b>会话列表</b></td><td>两行卡，操作常驻（拇指够得着优先）</td><td>一行 40 六列，操作随 hover</td></tr>
+</table>
+<p class="note" style="max-width:80ch">
+断点仍然只有 <code>useLayout()</code> 一个入口；这里的差异全是<b>纯样式</b>——走 <code>@container canvas</code> 与
+<code>html[data-pointer]</code>，不新增 JS 分支。唯一带 JS 的是「桌面 12 条 / 手机 8 条」，
+读的是已有的档位。
+</p>
+
+</div></body></html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -603,7 +603,8 @@ export default function App() {
   )
 
   const pages: any = {
-    overview: <OverviewPage openTerm={openTerm} renderSessions={() => <Sessions openTerm={openTerm} closeTerm={closeTerm} activeTerm={active} embedded />} />,
+    // 概览不再嵌会话列表：那是会话页的活（分工见 docs/design/web/13-mobile-responsive/ia.html）
+    overview: <OverviewPage openTerm={openTerm} />,
     swarm: <Swarm openTerm={openTerm} initialSwarm={swarmSub || undefined} onNav={(n) => { location.hash = n ? '#/swarm/' + encodeURIComponent(n) : '#/swarm' }} />,
     projects: <Projects openTerm={openTerm} closeTerm={closeTerm} initialKey={projectSub || undefined} activeTerm={active} />,
     sessions: <Sessions openTerm={openTerm} closeTerm={closeTerm} activeTerm={active} />,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,7 @@ import { reorderTabs } from './shell/tabs'
 import { requestIntent } from './intents'
 import { SessionDock, SessionSwitchSheet } from './shell/SessionDock'
 import { DPad } from './shell/DPad'
-import { sessionProject, setSessionProjects, buildSessionProjects } from './session-project'
+import { sessionProject, setSessionProjects, buildSessionProjects, useSessionProjects, sessionLocation } from './session-project'
 import { MobileSheet, SheetRow, SheetSection } from './shell/MobileSheet'
 import { WorkspaceTopbar, type PaletteItem } from './shell/WorkspaceTopbar'
 import { copyText } from './chat/blocks'
@@ -85,7 +85,7 @@ const MOBILE_MORE_KEYS = ['browser', 'phone', 'plugins', 'settings']
 
 // 用 Canvas 容器查询排版的页面（见 index.css 的 .tt-canvas[data-cq]）。逐页开，
 // 不是全局开：container-type 会改变 fixed 后代的包含块。
-const CQ_PAGES = new Set(['overview'])
+const CQ_PAGES = new Set(['overview', 'sessions'])
 
 // 旧链接兼容：/#/env 重定向到 /#/settings
 function normalizeRoute(raw: string): string {
@@ -2374,6 +2374,8 @@ function Sessions({ openTerm, closeTerm, activeTerm, embedded }: {
   const [wtDir, setWtDir] = useState<string | undefined>(undefined)
   // session→worktree 归属注解（cwd 现算的弱关联）：会话行 ⎇ Tag 的数据源
   const [wtAnn, setWtAnn] = useState<Record<string, any>>({})
+  // 会话→项目：桌面「项目」列的数据源。表是 App 那份轮询建的，这里只读（14 §6.3）
+  const sessProj = useSessionProjects()
   // 竞赛（W5/W6）：Race Service 业务数据，会话按竞赛聚组、组头进对比台
   const [races, setRaces] = useState<any[]>([])
   const [raceOpen, setRaceOpen] = useState(false)
@@ -2774,46 +2776,53 @@ function Sessions({ openTerm, closeTerm, activeTerm, embedded }: {
                   boxShadow: activeRow ? '0 0 0 1px rgba(88,166,255,.18), 0 0 18px rgba(31,111,235,.14)' : undefined,
                 }} onClick={() => openTerm(s.name)}>
                   {activeRow && <span aria-hidden style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: 4, background: '#58a6ff' }} />}
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-3)', width: '100%', minWidth: 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-3)', minWidth: 0, flex: 1 }}>
-                      <i title={waiting ? t('prompt.confirmRequired') : connected ? t('terminal.status.connected') : t('terminal.status.idle')} style={{ width: 8, height: 8, borderRadius: '50%', flex: '0 0 8px', background: waiting ? '#d29922' : connected ? '#3fb950' : 'var(--text-dimmer)' }} />
-                      <div style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column', gap: 3 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flexWrap: 'wrap' }}>
-                          {en.fam && <Tooltip title={t('session.fork.childOf', { parent: s.parent })}><span style={{ color: '#a371f7', flex: '0 0 auto', fontSize: 13 }}>⑂</span></Tooltip>}
-                          <span style={{ fontWeight: 700, color: activeRow ? '#fff' : 'var(--text-bright)', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={`${s.label || s.name}（${s.id || s.name}）`}>
-                            {s.label || s.name}
-                            {(s.id || s.name) !== (s.label || s.name) && <span style={{ opacity: .5, fontSize: 'var(--fs-meta)', marginLeft: 4, fontWeight: 400 }}>({s.id || s.name})</span>}
-                          </span>
-                          {(() => { // worktree 归属：⎇ 分支紧跟会话名(设计 W2)；外部 worktree 加 ⧉ 标识；手机端只显图标
-                            const ann = wtAnn[s.name]
-                            if (!ann?.primary?.linked) return null
-                            const tip = t('worktree.sessionTagTip', { path: ann.primary.worktree })
-                              + (ann.ambiguous ? ' · ' + t('worktree.sessionTagAmbiguous', { count: ann.matches?.length || 0 }) : '')
-                            return (<>
-                              <Tooltip title={tip}>
-                                <Tag color="cyan" style={{ margin: 0, flex: '0 0 auto', cursor: 'pointer', fontFamily: 'ui-monospace, monospace' }}
-                                  onClick={(e) => { e.stopPropagation(); setWtDir(ann.primary.repo); setWtOpen(true) }}>
-                                  {wide ? `⎇ ${ann.primary.branch}` : '⎇'}{ann.ambiguous ? ' +' : ''}
-                                </Tag>
-                              </Tooltip>
-                              {ann.primary.external && <Tag style={{ margin: 0, flex: '0 0 auto' }}>⧉ {wide ? t('worktree.external') : ''}</Tag>}
-                            </>)
-                          })()}
-                          {sw && <Tag color="blue" style={{ margin: 0, flex: '0 0 auto' }}>{t('nav.swarm')}:{sw.swarm}{sw.role === 'leader' ? `·${t('swarm.master')}` : ''}</Tag>}
-                          {waiting && <Tag color="warning" style={{ margin: 0, flex: '0 0 auto' }}>{t('session.waiting')}</Tag>}
-                          {cc[s.name] && <Tag color="blue" style={{ margin: 0, flex: '0 0 auto' }}>✳ Claude</Tag>}
-                          {cx[s.name] && <Tag color="green" style={{ margin: 0, flex: '0 0 auto' }}>✸ Codex</Tag>}
-                          {!sw && !agent && <Tag style={{ margin: 0, flex: '0 0 auto' }}>{connected ? t('terminal.status.connected') : t('terminal.status.idle')}</Tag>}
-                          <span style={{ color: 'var(--text-dim)', fontSize: 12, flex: '0 0 auto', whiteSpace: 'nowrap' }}>{t('session.windows', { count: s.windows })}</span>
-                        </div>
-                        <div style={{ color: 'var(--text-dimmer)', fontSize: 12, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                          <span title={absTime(s.created)}>{t('session.createdAt')} {relTime(s.created, t)}</span>
-                          <span style={{ margin: '0 6px' }}>·</span>
-                          <span title={absTime(s.last_activity)}>{t('session.lastActivity')} {relTime(s.last_activity, t)}</span>
-                        </div>
-                      </div>
-                    </div>
-                    <div onClick={(e) => e.stopPropagation()} style={{ marginLeft: 'auto', display: 'flex', gap: 'var(--sp-4)', alignItems: 'center', flex: '0 0 auto', whiteSpace: 'nowrap' }}>
+                  {/* 七个格子恒定：缺一个桌面上就整行错列，所以空的项目/位置格照样渲染（见 .tt-srow） */}
+                  <div className="tt-srow">
+                    <i title={waiting ? t('prompt.confirmRequired') : connected ? t('terminal.status.connected') : t('terminal.status.idle')} style={{ width: 8, height: 8, borderRadius: '50%', flex: '0 0 8px', background: waiting ? '#d29922' : connected ? '#3fb950' : 'var(--text-dimmer)' }} />
+                    <span className="nm" style={{ color: activeRow ? '#fff' : undefined }}
+                      title={`${s.label || s.name}（${s.id || s.name}）· ${t('session.createdAt')} ${absTime(s.created)}`}>
+                      {en.fam && <Tooltip title={t('session.fork.childOf', { parent: s.parent })}><span style={{ color: '#a371f7', fontSize: 13, marginRight: 6 }}>⑂</span></Tooltip>}
+                      {s.label || s.name}
+                      {/* 会话 ID 只留尾 4 位：全名与名字同权并排时，每行前半截都在念一串日期 */}
+                      {(s.id || s.name) !== (s.label || s.name) && <span className="id">{(s.id || s.name).slice(-4)}</span>}
+                    </span>
+                    <span className="pj">{sessProj[s.name]?.name}</span>
+                    {(() => { // 位置列：有 worktree 就是 ⎇ 分支（点开进 worktree 管理），否则是工作目录
+                      const ann = wtAnn[s.name]
+                      const loc = sessionLocation(ann, s.cwd, sessProj[s.name]?.dir)
+                      if (!loc.branch && !loc.path) return <span className="loc" />
+                      const tip = loc.branch
+                        ? t('worktree.sessionTagTip', { path: ann?.primary?.worktree || '' })
+                          + (ann?.ambiguous ? ' · ' + t('worktree.sessionTagAmbiguous', { count: ann.matches?.length || 0 }) : '')
+                        : loc.title
+                      return (
+                        <span className="loc" title={tip}
+                          onClick={ann?.primary?.linked ? (e) => { e.stopPropagation(); setWtDir(ann.primary.repo); setWtOpen(true) } : undefined}
+                          style={ann?.primary?.linked ? { cursor: 'pointer' } : undefined}>
+                          {loc.branch ? <span className="br">⎇ {loc.branch}{ann?.ambiguous ? ' +' : ''}</span> : loc.path}
+                        </span>
+                      )
+                    })()}
+                    <span className="tags">
+                      {(() => { // 窄档只留一枚 ⎇ 图标（桌面由位置列接管）；外部 worktree 加 ⧉
+                        const ann = wtAnn[s.name]
+                        if (!ann?.primary?.linked) return null
+                        return (<>
+                          <Tag className="wt" color="cyan" style={{ margin: 0, flex: '0 0 auto', cursor: 'pointer', fontFamily: 'ui-monospace, monospace' }}
+                            onClick={(e) => { e.stopPropagation(); setWtDir(ann.primary.repo); setWtOpen(true) }}>⎇</Tag>
+                          {ann.primary.external && <Tag className="wt" style={{ margin: 0, flex: '0 0 auto' }}>⧉</Tag>}
+                        </>)
+                      })()}
+                      {sw && <Tag color="blue" style={{ margin: 0, flex: '0 0 auto' }}>{t('nav.swarm')}:{sw.swarm}{sw.role === 'leader' ? `·${t('swarm.master')}` : ''}</Tag>}
+                      {waiting && <Tag color="warning" style={{ margin: 0, flex: '0 0 auto' }}>{t('session.waiting')}</Tag>}
+                      {cc[s.name] && <Tag color="blue" style={{ margin: 0, flex: '0 0 auto' }}>✳ Claude</Tag>}
+                      {cx[s.name] && <Tag color="green" style={{ margin: 0, flex: '0 0 auto' }}>✸ Codex</Tag>}
+                      {!sw && !agent && <Tag style={{ margin: 0, flex: '0 0 auto' }}>{connected ? t('terminal.status.connected') : t('terminal.status.idle')}</Tag>}
+                      {/* 窗口数 99% 的会话都是 1，常驻就是一列噪声——只在 >1 时说 */}
+                      {s.windows > 1 && <span style={{ color: 'var(--text-dim)', fontSize: 12, whiteSpace: 'nowrap' }}>{t('session.windows', { count: s.windows })}</span>}
+                    </span>
+                    <span className="tm" title={absTime(s.last_activity)}>{relTime(s.last_activity, t)}</span>
+                    <span className="acts" onClick={(e) => e.stopPropagation()}>
                       {!sw && wide && <a onClick={() => setForking(s.name)}>{t('session.fork.entry')}</a>}
                       {sw && <a onClick={() => goSwarm(sw.swarm)}>{t('session.swarmPage')}</a>}
                       {sw ? (
@@ -2833,7 +2842,7 @@ function Sessions({ openTerm, closeTerm, activeTerm, embedded }: {
                           <a style={{ color: '#f85149' }} onClick={() => { if (confirmKill !== s.name) beginClose(s.name) }}>{t('session.close')}</a>
                         </Popconfirm>
                       )}
-                    </div>
+                    </span>
                   </div>
                 </List.Item>
               )

--- a/frontend/src/Overview.tsx
+++ b/frontend/src/Overview.tsx
@@ -14,12 +14,17 @@ import { detectPrompt } from './prompt'
 import { relTime } from './App'
 import { sessionLabel } from './session-label'
 import { dot } from './Projects'
+import { useLayout } from './layout'
+import { sessionLocation } from './session-project'
 
 const OV_CSS = `
 .ov{display:flex;flex-direction:column;gap:var(--sp-4);padding-bottom:32px;max-width:var(--content-overview)}
 
 .ov-sum{display:flex;align-items:center;gap:var(--sp-2) var(--sp-5);flex-wrap:wrap;min-height:40px;
   padding:var(--sp-2) var(--sp-3);border-radius:var(--r-sm);background:var(--bg-container);font-size:var(--fs-meta)}
+/* 窄档：状态条是页头下方的一条横条（它挂在页头的 .acts 槽里，靠 100% 宽换行成整条） */
+.ov .tt-pagehead .acts{width:100%;margin-left:0}
+.ov .tt-pagehead .acts>.ov-sum{flex:1}
 .ov-sum button{display:inline-flex;align-items:center;gap:var(--sp-2);padding:var(--sp-1);margin:calc(var(--sp-1) * -1);border:0;border-radius:var(--r-xs);
   background:none;color:var(--text-dim);font:inherit;cursor:pointer}
 .ov-sum button:hover{color:var(--text-bright);background:var(--list-hover)}
@@ -85,6 +90,10 @@ const OV_CSS = `
 .ov-frow .ag{flex:0 0 auto;padding:1px 6px;border-radius:var(--r-pill);font-size:var(--fs-micro);
   color:#9ccaff;background:var(--accent-soft)}
 .ov-frow .ag.cx{color:#7fd18f;background:rgba(63,185,80,.12)}
+/* 六个格子在手机上按需塌陷：空的项目/Agent 格不占 gap，位置列整条不出现 */
+.ov-frow .agw{display:flex;gap:var(--sp-1);flex:0 0 auto}
+.ov-frow .pj::after{content:" ·"}
+.ov-frow .pj:empty,.ov-frow .agw:empty,.ov-frow .loc{display:none}
 .ov-frow .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer);white-space:nowrap}
 .ov-go-i{margin-left:3px;vertical-align:-1px;opacity:.75}
 a:hover>.ov-go-i,button:hover>.ov-go-i,.ov-card:hover .ov-go-i{opacity:1}
@@ -95,6 +104,25 @@ a:hover>.ov-go-i,button:hover>.ov-go-i,.ov-card:hover .ov-go-i{opacity:1}
 @container canvas (min-width: 900px){
   .ov-cards{grid-template-columns:repeat(2,minmax(0,1fr))}
   .ov-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  /* 会话流在桌面对齐成列（图纸 14-desktop-workspace/desktop-ia.html §一）。
+     手机那行是「名字贴左、时间贴右」，拉到 838 宽之后中间 570px 是空的；
+     桌面排成六列，空出来的宽度交给「位置」——⎇ 分支，或与项目目录不同时的工作目录。 */
+  .ov-frow{display:grid;grid-template-columns:8px 128px minmax(170px,1fr) 60px 260px 74px;
+    column-gap:var(--sp-3);align-items:center;min-height:40px}
+  .ov-frow>*{min-width:0}
+  .ov-frow .pj,.ov-frow .nm{flex:none;display:block}
+  .ov-frow .pj::after{content:none}
+  .ov-frow .agw{display:flex}
+  .ov-frow .loc{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+    font-family:ui-monospace,'SF Mono',Menlo,Consolas,monospace;font-size:var(--fs-meta);color:var(--text-dimmer)}
+  .ov-frow .loc .br{color:#7ed0d8}
+  .ov-frow .tm{margin-left:0;justify-self:end}
+  /* 状态条并进页头右端：省掉一整行，也不会再出现「一枚数字 + 1092px 空白」的胶囊。
+     它仍然是导航入口，所以只脱掉横条的底和内边距，hover/手型都留着。 */
+  .ov .tt-pagehead{align-items:flex-end}
+  .ov .tt-pagehead .acts{width:auto;margin-left:auto;padding-bottom:3px}
+  .ov .tt-pagehead .acts>.ov-sum{flex:0 0 auto}
+  .ov-sum{background:none;padding:0;min-height:0;border-radius:0}
 }
 @container canvas (min-width: 1180px){
   .ov-cards{grid-template-columns:repeat(3,minmax(0,1fr))}
@@ -151,6 +179,7 @@ function icoOf(name: string) {
 
 export default function Overview({ openTerm }: { openTerm: (n: string) => void }) {
   const { t, locale } = useI18n()
+  const { phone: isPhone } = useLayout()
   const [projects, setProjects] = useState<Proj[]>([])
   const [loose, setLoose] = useState<any[]>([])
   const [sessions, setSessions] = useState<any[]>([])
@@ -304,13 +333,16 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
   // 「最近会话」：跨项目扁平流，按最近活动倒序。这是概览与另外两页的分工线——
   // 项目页按仓库分组、会话页给全集+筛选，概览只回答「刚才在动的是哪几个」。
   // **排除已经进了行动卡的会话**：那条信息在上面已经说过一遍，重复出现两层就不互补了。
+  // 桌面多 4 条：桌面一行 40（手机 44），左栏本来比右侧「最近活动」短一大截，
+  // 8 条时页面下方空 310px（图纸 desktop-ia.html §一）。
   const recent = useMemo(() => {
     const inAction = new Set(cards.map((c) => c.session).filter(Boolean) as string[])
-    const rows = new Map<string, { name: string; at: number }>()
-    for (const s of projSess) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.last_activity || 0) })
-    for (const s of loose as any[]) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.lastActivity || 0) })
-    return [...rows.values()].filter((r) => !inAction.has(r.name)).sort((a, b) => b.at - a.at).slice(0, 8)
-  }, [projSess, loose, cards])
+    const rows = new Map<string, { name: string; at: number; cwd: string }>()
+    for (const s of projSess) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.last_activity || 0), cwd: s.cwd || '' })
+    for (const s of loose as any[]) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.lastActivity || 0), cwd: s.cwd || '' })
+    return [...rows.values()].filter((r) => !inAction.has(r.name))
+      .sort((a, b) => b.at - a.at).slice(0, isPhone ? 8 : 12)
+  }, [projSess, loose, cards, isPhone])
 
   // 最近活动：活跃 git 项目前 3 个各取头 2 条（commit+留痕），合并倒序（60s）
   useEffect(() => {
@@ -379,7 +411,8 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
     <div style={{ height: '100%', overflow: 'auto' }}>
       <style>{OV_CSS}</style>
       <div className="ov">
-        {/* ① 问候区：首屏第一句话回答「今天有几件事需要你」，零事项时是安静状态 */}
+        {/* ① 问候区：首屏第一句话回答「今天有几件事需要你」，零事项时是安静状态。
+            ② 状态概况挂在页头的 .acts 槽里：桌面并到标题右端（省一行），窄档换行成一条横条。 */}
         <header className="tt-pagehead ov-in">
           <div className="ttl">
             <div className="kicker">{kicker}</div>
@@ -390,17 +423,17 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
               ? t('overview.sublineRunning', { count: stats.running, time: relTime(lastAt, t) })
               : t('overview.sublineIdle')}</p>
           </div>
+          {(stats.running + stats.waiting + stats.unfinished + stats.swarms) > 0 && (
+            <div className="acts">
+              <div className="ov-sum ov-in" style={{ animationDelay: '50ms' }}>
+                {sumItem(stats.running, '', t('overview.sumRunning'))}
+                {sumItem(stats.waiting, 'a', t('overview.sumWaiting'))}
+                {sumItem(stats.unfinished, 'a', t('overview.sumUnfinished'))}
+                {sumItem(stats.swarms, 'p', t('overview.sumSwarms'))}
+              </div>
+            </div>
+          )}
         </header>
-
-        {/* ② 状态概况：一条顶掉旧版一排等权数字卡 */}
-        {(stats.running + stats.waiting + stats.unfinished + stats.swarms) > 0 && (
-          <div className="ov-sum ov-in" style={{ animationDelay: '50ms' }}>
-            {sumItem(stats.running, '', t('overview.sumRunning'))}
-            {sumItem(stats.waiting, 'a', t('overview.sumWaiting'))}
-            {sumItem(stats.unfinished, 'a', t('overview.sumUnfinished'))}
-            {sumItem(stats.swarms, 'p', t('overview.sumSwarms'))}
-          </div>
-        )}
 
         <div className="ov-layout">
             <div className="ov-feed">
@@ -443,13 +476,21 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
                     {recent.map((r) => {
                       const w = waiting[r.name]
                       const proj = projects.find((p) => (sessByProj.get(p.key) || []).some((x) => x.name === r.name))
+                      // 六个格子在桌面必须恒定，缺一个就整行错列——所以空的项目/Agent 格照样渲染，
+                      // 由 :empty 在手机上塌陷掉。
+                      const loc = sessionLocation(ann[r.name], r.cwd, proj?.dir)
                       return (
                         <div key={r.name} className="ov-frow" onClick={() => openTerm(r.name)}>
                           {dot(false, w ? '#d29922' : running(r.name) ? '#3fb950' : undefined)}
-                          {proj && <span className="pj">{proj.name} ·</span>}
+                          <span className="pj">{proj?.name}</span>
                           <span className="nm" title={r.name}>{sessionLabel(r.name)}</span>
-                          {cc[r.name] && <span className="ag">Claude</span>}
-                          {cx[r.name] && <span className="ag cx">Codex</span>}
+                          <span className="agw">
+                            {cc[r.name] && <span className="ag">Claude</span>}
+                            {cx[r.name] && <span className="ag cx">Codex</span>}
+                          </span>
+                          <span className="loc" title={loc.title}>
+                            {loc.branch ? <span className="br">⎇ {loc.branch}</span> : loc.path}
+                          </span>
                           <span className="tm">{relTime(r.at, t)}</span>
                         </div>
                       )

--- a/frontend/src/Overview.tsx
+++ b/frontend/src/Overview.tsx
@@ -7,14 +7,13 @@
 //      终端开合只改 Canvas，不该由 viewport 决定列数
 //   ⑤ 最近活动：Canvas ≥1180 进右侧 320 侧轨（sticky），窄于此自动落回页尾
 // 数据全部复用现有接口（/projects、annotations、per-session 探测、/swarms 投影、activity），零新后端。
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Tag } from 'antd'
+import { useEffect, useMemo, useState } from 'react'
 import { api } from './api'
 import { useI18n } from './i18n'
 import { detectPrompt } from './prompt'
 import { relTime } from './App'
-import { Lifec, dot } from './Projects'
-import { usePreferences, savePreferences } from './preferences'
+import { sessionLabel } from './session-label'
+import { dot } from './Projects'
 
 const OV_CSS = `
 .ov{display:flex;flex-direction:column;gap:var(--sp-4);padding-bottom:32px;max-width:var(--content-overview)}
@@ -27,16 +26,7 @@ const OV_CSS = `
 .ov-sum b{font-family:ui-monospace,monospace;font-weight:700;font-size:var(--fs-sm);color:var(--text-bright)}
 .ov-sum .d{width:6px;height:6px;border-radius:50%;background:#3fb950;flex:0 0 auto}
 .ov-sum .d.a{background:#d29922}.ov-sum .d.p{background:#a371f7}
-.ov-tabs{display:flex;align-items:center;gap:2px;margin-top:2px;
-  border-bottom:1px solid var(--border-subtle)}
-.ov-tab{padding:var(--sp-2) var(--sp-3);border:0;background:none;font:inherit;font-size:var(--fs-body);color:var(--text-dim);
-  cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s}
-.ov-tab:hover{color:var(--text-bright)}
-.ov-tab.on{color:var(--text-bright);border-bottom-color:var(--accent);font-weight:600}
-.ov-tab-go{margin-left:auto;display:inline-flex;align-items:center;font-size:var(--fs-meta)}
 /* 手指档把 tab 撑到 44：真机上默认高度只有 40（13 §7.1 的命中区下限） */
-html[data-pointer="coarse"] .ov-tab{min-height:44px}
-html[data-pointer="coarse"] .ov-tab-go{min-height:44px}
 
 .ov-layout{display:grid;grid-template-columns:minmax(0,1fr);gap:var(--sp-4);align-items:start}
 .ov-feed{min-width:0;display:flex;flex-direction:column;gap:var(--sp-3)}
@@ -67,33 +57,6 @@ html[data-pointer="coarse"] .ov-tab-go{min-height:44px}
 .ov-card .go{position:absolute;left:var(--sp-3);bottom:var(--sp-3);font-size:var(--fs-meta);color:var(--accent)}
 
 /* 项目卡栅格：阈值看 Canvas，不看 viewport */
-.ov-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:var(--sp-3)}
-.ov-proj{min-width:0;background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:var(--r-card);
-  padding:var(--sp-3) var(--sp-3) var(--sp-2);display:flex;flex-direction:column;gap:var(--sp-1);transition:border-color .15s}
-.ov-proj:hover{border-color:rgba(88,166,255,.35)}
-.ov-proj .hd{display:flex;align-items:center;gap:8px}
-.ov-ico{width:28px;height:28px;flex:0 0 auto;display:grid;place-items:center;border-radius:var(--r-sm);
-  font-size:12px;font-weight:800}
-.ov-proj .nm{min-width:0;flex:1 1 auto}
-.ov-proj .nm b{display:block;font-size:var(--fs-body);color:var(--text-bright);
-  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.ov-proj .nm span{display:block;margin-top:2px;font:var(--fs-micro)/1.3 ui-monospace,monospace;color:var(--text-dimmer);
-  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.ov-proj .hd a{flex:0 0 auto;font-size:var(--fs-meta)}
-.ov-trow{display:flex;align-items:center;gap:var(--sp-2);min-height:32px;padding:var(--sp-1) var(--sp-2);
-  border-radius:var(--r-xs);font-size:var(--fs-sm);cursor:pointer;transition:background .14s}
-.ov-trow:first-of-type{margin-top:6px}
-.ov-trow:hover{background:var(--list-hover)}
-.ov-trow .t{min-width:0;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.ov-trow .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer);white-space:nowrap}
-.ov-foot{display:flex;align-items:center;gap:var(--sp-2);min-height:28px;margin-top:var(--sp-1);
-  padding:var(--sp-1) var(--sp-2);border-radius:var(--r-xs);font-size:var(--fs-meta);border:1px solid rgba(163,113,247,.22);background:rgba(163,113,247,.05);color:#a371f7}
-.ov-foot.w{border-color:rgba(210,153,34,.24);background:rgba(210,153,34,.05);color:#e3b341}
-.ov-foot a{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta)}
-.ov-more{padding-left:var(--sp-2);font-size:var(--fs-meta);color:var(--text-dimmer)}
-.ov-rest{display:grid;place-items:center;min-height:96px;padding:var(--sp-3);cursor:pointer;
-  border:1px dashed var(--border-subtle);border-radius:var(--r-card);font-size:var(--fs-sm);color:var(--text-dimmer)}
-.ov-rest:hover{color:var(--text-dim);border-color:rgba(88,166,255,.35)}
 
 /* 最近活动：≥1180 时是右侧 sticky 侧轨；窄于此它只是网格的第二行，自然落回页尾 */
 .ov-rail{min-width:0;padding:var(--sp-3);border-radius:var(--r-card);background:var(--bg-container)}
@@ -110,11 +73,19 @@ html[data-pointer="coarse"] .ov-tab-go{min-height:44px}
   display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .ov-ev time{display:block;margin-top:var(--sp-1);font-size:var(--fs-micro);color:var(--text-dimmer)}
 
-.ov-loose{padding:var(--sp-3);border-radius:var(--r-card);background:var(--bg-container)}
-.ov-loose .row{display:flex;align-items:center;gap:var(--sp-2);min-height:32px;padding:var(--sp-1) 0;font-size:var(--fs-sm);
-  color:var(--text-dim);cursor:pointer}
-.ov-loose .row:hover{color:var(--text-bright)}
-.ov-loose .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer)}
+.ov-flow{display:flex;flex-direction:column}
+.ov-frow{display:flex;align-items:center;gap:var(--sp-2);min-height:44px;padding:var(--sp-1) var(--sp-2);
+  border-radius:var(--r-sm);cursor:pointer;transition:background .14s}
+.ov-frow+.ov-frow{border-top:1px solid var(--border-subtle)}
+.ov-frow:hover{background:var(--list-hover)}
+.ov-frow .pj{flex:0 100 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  color:var(--text-dimmer);font-size:var(--fs-meta)}
+.ov-frow .nm{flex:0 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  font-size:var(--fs-sm);font-weight:600}
+.ov-frow .ag{flex:0 0 auto;padding:1px 6px;border-radius:var(--r-pill);font-size:var(--fs-micro);
+  color:#9ccaff;background:var(--accent-soft)}
+.ov-frow .ag.cx{color:#7fd18f;background:rgba(63,185,80,.12)}
+.ov-frow .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer);white-space:nowrap}
 .ov-go-i{margin-left:3px;vertical-align:-1px;opacity:.75}
 a:hover>.ov-go-i,button:hover>.ov-go-i,.ov-card:hover .ov-go-i{opacity:1}
 .ov-mono{font-family:ui-monospace,'SF Mono',Menlo,Consolas,monospace}
@@ -153,6 +124,8 @@ type Proj = {
 type Card = {
   key: string; kind: 'waiting' | 'unfinished' | 'swarm'
   proj: string; title: string; desc: string; action: string; go: () => void
+  /** 等待输入卡对应的会话名——「最近会话」要把它排除掉，两层才是互补而不是重复 */
+  session?: string
 }
 
 // 项目图标底色：按名字取一个稳定色，卡片多了才能一眼分辨是哪个项目
@@ -176,12 +149,8 @@ function icoOf(name: string) {
   return ICO[h % ICO.length]
 }
 
-export default function Overview({ openTerm, renderSessions }: { openTerm: (n: string) => void; renderSessions?: () => ReactNode }) {
+export default function Overview({ openTerm }: { openTerm: (n: string) => void }) {
   const { t, locale } = useI18n()
-  // 项目/会话 切换 tab，选择记进偏好（跨设备记忆）。无会话视图（如手机 mini 场景不传）则退回项目视图。
-  const [prefs] = usePreferences()
-  const tab: 'projects' | 'sessions' = renderSessions && prefs.overviewTab === 'sessions' ? 'sessions' : 'projects'
-  const setTab = (v: 'projects' | 'sessions') => savePreferences({ overviewTab: v })
   const [projects, setProjects] = useState<Proj[]>([])
   const [loose, setLoose] = useState<any[]>([])
   const [sessions, setSessions] = useState<any[]>([])
@@ -230,7 +199,6 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
 
   // Agent 运行 + 待输入探测（只探项目内会话，上限 14 个防雪崩）
   useEffect(() => {
-    if (tab !== 'projects') return // 会话 tab 时列表页自行探测，避免双重轮询
     const names = projSess.map((s) => s.name).slice(0, 14)
     if (!names.length) return
     let stop = false
@@ -250,7 +218,7 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
     check()
     const i = setInterval(check, 6000)
     return () => { stop = true; clearInterval(i) }
-  }, [tab, projSess.map((s) => s.name).join('\n')])
+  }, [projSess.map((s) => s.name).join('\n')])
 
   // 蜂群投影（10s）：归属 = 指挥/成员会话 ∈ 某项目会话
   useEffect(() => {
@@ -294,7 +262,6 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
     })
     .sort((a, b) => (projNeeds(b) - projNeeds(a)) || ((b.lastActivity || 0) - (a.lastActivity || 0))),
   [projects, sessByProj, swarms, waiting])
-  const inactiveCount = projects.length - activeProjects.length
   const goProjects = () => { location.hash = '#/projects' }
   const goProject = (key: string) => { location.hash = '#/projects/' + encodeURIComponent(key) }
   const goSwarm = (name: string) => { location.hash = '#/swarm/' + encodeURIComponent(name) }
@@ -306,7 +273,7 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
       for (const s of (sessByProj.get(p.key) || [])) {
         if (!waiting[s.name]) continue
         items.push({
-          key: 'w' + s.name, kind: 'waiting', proj: p.name,
+          key: 'w' + s.name, kind: 'waiting', proj: p.name, session: s.name,
           title: s.label || s.name,
           desc: tail[s.name] || t('overview.cardWaitingDesc'),
           action: t('overview.cardGoSession'), go: () => openTerm(s.name),
@@ -333,6 +300,17 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
     }
     return items
   }, [projects, sessByProj, waiting, tail, swarms, t])
+
+  // 「最近会话」：跨项目扁平流，按最近活动倒序。这是概览与另外两页的分工线——
+  // 项目页按仓库分组、会话页给全集+筛选，概览只回答「刚才在动的是哪几个」。
+  // **排除已经进了行动卡的会话**：那条信息在上面已经说过一遍，重复出现两层就不互补了。
+  const recent = useMemo(() => {
+    const inAction = new Set(cards.map((c) => c.session).filter(Boolean) as string[])
+    const rows = new Map<string, { name: string; at: number }>()
+    for (const s of projSess) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.last_activity || 0) })
+    for (const s of loose as any[]) if (!rows.has(s.name)) rows.set(s.name, { name: s.name, at: Number(s.lastActivity || 0) })
+    return [...rows.values()].filter((r) => !inAction.has(r.name)).sort((a, b) => b.at - a.at).slice(0, 8)
+  }, [projSess, loose, cards])
 
   // 最近活动：活跃 git 项目前 3 个各取头 2 条（commit+留痕），合并倒序（60s）
   useEffect(() => {
@@ -424,19 +402,7 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
           </div>
         )}
 
-        {/* 内容切换与「进入项目页」同处一行：它们都是"看什么"，不该挤在标题右边和问候语抢
-            视线。tab 样式与项目详情页共用一套下划线语言——两页的 tab 长得一样才叫一套壳。 */}
-        <div className="ov-tabs ov-in" style={{ animationDelay: '70ms' }}>
-          {renderSessions && (['projects', 'sessions'] as const).map((k) => (
-            <button key={k} type="button" className={`ov-tab${tab === k ? ' on' : ''}`} onClick={() => setTab(k)}>
-              {t(k === 'projects' ? 'nav.projects' : 'nav.sessions')}
-            </button>
-          ))}
-          <a className="ov-tab-go" onClick={goProjects}>{t('overview.gotoProjects')}<Go /></a>
-        </div>
-
-        {tab === 'sessions' ? renderSessions!() : (
-          <div className="ov-layout">
+        <div className="ov-layout">
             <div className="ov-feed">
               {/* ③ 行动卡：最多三张，零事项整层不渲染 */}
               {cards.length > 0 && (
@@ -464,82 +430,38 @@ export default function Overview({ openTerm, renderSessions }: { openTerm: (n: s
                 </>
               )}
 
-              {/* ④ 活跃项目作战卡 */}
-              <div className="ov-sect">
-                <span>{t('overview.activeProjects')}</span><span className="n">{activeProjects.length}</span><span className="ln" />
-              </div>
-              <div className="ov-grid">
-                {activeProjects.map((p, i) => {
-                  const rows = (sessByProj.get(p.key) || [])
-                    .sort((a, b) => (Number(running(b.name)) - Number(running(a.name))) || (Number(b.last_activity || 0) - Number(a.last_activity || 0)))
-                  const shown = rows.slice(0, 3)
-                  const projSwarms = swarms.filter((sw) => sw.projKey === p.key)
-                  const [fg, bg] = icoOf(p.key)
-                  return (
-                    <div key={p.key} className="ov-proj ov-in" style={{ animationDelay: `${Math.min(i, 6) * 40}ms` }}>
-                      <div className="hd">
-                        <span className="ov-ico" style={{ color: fg, background: bg }}>{(p.name[0] || '?').toUpperCase()}</span>
-                        <span className="nm">
-                          <b title={p.name}>{p.name}</b>
-                          <span title={p.dir}>{p.dir}</span>
-                        </span>
-                        <a onClick={() => goProject(p.key)}>{t('overview.enterProject')}<Go /></a>
-                      </div>
-                      {shown.map((s) => {
-                        const w = waiting[s.name]
-                        const r = running(s.name)
-                        return (
-                          <div key={s.name} className="ov-trow" onClick={() => openTerm(s.name)}>
-                            {dot(false, w ? '#d29922' : r ? '#3fb950' : undefined)}
-                            <span className="t" title={`${s.label || s.name}（${s.id || s.name}）`}>{s.label || s.name}</span>
-                            {ann[s.name]?.primary?.linked && <Tag color="cyan" style={{ margin: 0, fontSize: 'var(--fs-micro)', lineHeight: '16px', padding: '0 5px' }}>⎇</Tag>}
-                            <Lifec done={r ? 1 : 2} cur={r && !w ? 2 : w ? 3 : undefined} />
-                            <span className="tm">{relTime(s.last_activity, t)}</span>
-                          </div>
-                        )
-                      })}
-                      {rows.length > 3 && <div className="ov-more">{t('overview.moreTasks', { count: rows.length - 3 })}</div>}
-                      {projSwarms.map((sw) => (
-                        <div key={sw.name} className="ov-foot">
-                          ⬡ <b>{sw.name}</b>
-                          <span style={{ color: 'var(--text-dimmer)' }}>{t('project.swarm.members', { mine: sw.inProj, total: sw.total })}</span>
-                          <a onClick={() => goSwarm(sw.name)}>{t('project.swarm.board')}<Go /></a>
-                        </div>
-                      ))}
-                      {p.unfinished > 0 && (
-                        <div className="ov-foot w">⚑ {t('overview.unfinishedN', { count: p.unfinished })}
-                          <a onClick={() => goProject(p.key)}>{t('overview.goFinish')}<Go /></a>
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-                {inactiveCount > 0 && (
-                  <div className="ov-rest" onClick={goProjects}>{t('overview.inactiveRest', { count: inactiveCount })}</div>
-                )}
-              </div>
-
-              {/* 散会话：不属于任何项目的会话，放在项目之后，避免被作战地图淹没 */}
-              {loose.length > 0 && (
-                <div className="ov-loose">
-                  <div className="ov-sect" style={{ marginBottom: 6 }}>
-                    <span>{t('project.loose')}</span><span className="n">{loose.length}</span><span className="ln" />
+              {/* ④ 最近会话：跨项目扁平流，按最近活动倒序。
+                  这一层**不是**项目卡网格——那是项目页的活；也不是带筛选的会话列表——那是会话页的活。
+                  概览只回答「刚才在动的是哪几个」，所以不分组、不筛选、只取 8 条。 */}
+              {recent.length > 0 && (
+                <>
+                  <div className="ov-sect">
+                    <span>{t('overview.recentSessions')}</span><span className="ln" />
+                    <a onClick={() => { location.hash = '#/sessions' }}>{t('overview.allSessions')}<Go /></a>
                   </div>
-                  {loose.slice(0, 5).map((s: any) => (
-                    <div key={s.name} className="row" onClick={() => openTerm(s.name)}>
-                      {dot(s.attached)}
-                      <b title={`${s.label || s.name}（${s.id || s.name}）`}>{s.label || s.name}</b>
-                      <span className="tm">{relTime(s.lastActivity, t)}</span>
-                    </div>
-                  ))}
-                </div>
+                  <div className="ov-flow">
+                    {recent.map((r) => {
+                      const w = waiting[r.name]
+                      const proj = projects.find((p) => (sessByProj.get(p.key) || []).some((x) => x.name === r.name))
+                      return (
+                        <div key={r.name} className="ov-frow" onClick={() => openTerm(r.name)}>
+                          {dot(false, w ? '#d29922' : running(r.name) ? '#3fb950' : undefined)}
+                          {proj && <span className="pj">{proj.name} ·</span>}
+                          <span className="nm" title={r.name}>{sessionLabel(r.name)}</span>
+                          {cc[r.name] && <span className="ag">Claude</span>}
+                          {cx[r.name] && <span className="ag cx">Codex</span>}
+                          <span className="tm">{relTime(r.at, t)}</span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </>
               )}
             </div>
 
-            {/* ⑤ 最近活动：Canvas ≥1180 是右侧 sticky 侧轨，窄于此落回页尾 */}
-            {railNode}
-          </div>
-        )}
+          {/* ⑤ 最近活动：Canvas ≥1180 是右侧 sticky 侧轨，窄于此落回页尾 */}
+          {railNode}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -47,6 +47,10 @@ const ico = (d: React.ReactNode) => (
 const ICON_SEARCH = ico(<><circle cx="11" cy="11" r="7" /><line x1="16.5" y1="16.5" x2="21" y2="21" /></>)
 const ICON_SORT = ico(<><path d="M7 4v16" /><path d="M4 8l3-4 3 4" /><path d="M17 20V4" /><path d="M14 16l3 4 3-4" /></>)
 const ICON_CHECK = ico(<polyline points="4 12 9 17 20 6" />)
+const ICON_CHEVRON = (
+  <svg viewBox="0 0 24 24" width={12} height={12} fill="none" stroke="currentColor" aria-hidden="true"
+    strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round"><polyline points="5 9 12 16 19 9" /></svg>
+)
 
 // ── 页面级样式（一次注入；产品 token 之上只做布局/微交互）──
 const PRJ_CSS = `
@@ -127,7 +131,9 @@ html[data-size="compact"] .prj-filters{overflow-x:auto;scrollbar-width:none;flex
 html[data-size="compact"] .prj-filters::-webkit-scrollbar{height:0}
 html[data-size="compact"] .prj-filters>*{flex:0 0 auto}
 html[data-size="compact"] .prj-filters .sp,
-html[data-size="compact"] .prj-filters .ant-segmented{display:none}
+/* 手机：排序走右侧钉住的 ⇅ 图标 + 底部 sheet，筛选带里那枚排序控件是重复的 */
+html[data-size="compact"] .prj-filters .ant-segmented,
+html[data-size="compact"] .prj-filters .prj-sortpill{display:none}
 /* 图标按钮：不描边——右边两个方框和左边的圆角 chip 不是一套语言。命中区靠伪元素撑到 44 */
 .prj-iconbtn{position:relative;flex:0 0 auto;width:32px;height:32px;display:none;place-items:center;
   border:0;border-radius:var(--r-sm);background:transparent;color:var(--text-dim);cursor:pointer}
@@ -147,8 +153,23 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
 .prj-chip .n{font-family:ui-monospace,monospace;font-size:var(--fs-micro);color:var(--text-dimmer)}
 .prj-chip.on .n{color:#79b8ff}
 
-/* 卡片列固定在 ≥320：原来是 minmax(270,1fr)，右侧一开终端就塌成一条极窄列表（14 §6.1） */
-.prj-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:var(--sp-4)}
+/* 卡片列固定在 ≥320：原来是 minmax(270,1fr)，右侧一开终端就塌成一条极窄列表（14 §6.1）。
+   align-items:start —— 默认的 stretch 会把整行卡片拉到最高那张的高度：一张列了两个会话、
+   邻座一个都没有时，邻座卡的下半截就是空的（实测整行被撑到 167）。 */
+.prj-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:var(--sp-4);align-items:start}
+
+/* 「其他项目」：没有会话在跑的项目不值一张卡（图纸 14-desktop-workspace/desktop-ia.html §二）——
+   实测 4 个空项目占掉 467px 的栅格。折成一行一个：名字 + 路径 + 可清理标。 */
+.prj-quiet{display:grid;grid-template-columns:minmax(96px,150px) minmax(0,1fr) auto;align-items:center;
+  gap:var(--sp-3);min-height:36px;padding:var(--sp-1) var(--sp-2);border-radius:var(--r-sm);
+  cursor:pointer;transition:background .14s}
+.prj-quiet+.prj-quiet{border-top:1px solid var(--border-subtle)}
+.prj-quiet:hover{background:var(--list-hover)}
+.prj-quiet .nm{font-size:var(--fs-sm);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.prj-quiet .p{font-family:ui-monospace,monospace;font-size:var(--fs-meta);color:var(--text-dimmer);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+html[data-size="compact"] .prj-quiet{grid-template-columns:minmax(0,1fr) auto;min-height:44px}
+html[data-size="compact"] .prj-quiet .p{display:none}
 
 .prj-card{background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:var(--r-card);
   padding:var(--sp-3) var(--sp-4);cursor:pointer;display:flex;flex-direction:column;gap:8px;
@@ -354,7 +375,12 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
   // 置顶与活跃共用同一套栅格，只靠 section header 分组（14 §6.1）——两套栅格会让
   // 卡片宽度在分组之间对不齐
   const pinned = visible.filter((p) => p.pinned)
-  const rest = visible.filter((p) => !p.pinned)
+  // 没有会话、也没有待收尾/竞赛的项目折到页尾（图纸 desktop-ia.html §二）：它们和「正在跑
+  // 两个任务」的项目占同样大的卡，还被同一行最高的卡撑高，页面下三分之一因此全是空卡。
+  // 「活跃 / 待收尾」筛选下 visible 里本来就没有它们，这里不必再判筛选态。
+  const isQuiet = (p: Proj) => p.sessions <= 0 && p.unfinished <= 0 && p.races <= 0
+  const rest = visible.filter((p) => !p.pinned && !isQuiet(p))
+  const quiet = visible.filter((p) => !p.pinned && isQuiet(p))
 
   // 上下左右移动选中：列数从栅格实际算，不写死——它随 Canvas 宽度变
   const onGridKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -451,8 +477,17 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
                 onClick={() => setFilter(k)}>{label}<span className="n">{n}</span></button>
             ))}
             <span className="sp" />
-            <Segmented size="small" value={sortBy} onChange={(v) => changeSort(v as ProjSort)}
-              options={SORTS.map((k) => ({ label: t(`project.sort.${k}`), value: k }))} />
+            {/* 排序与筛选同一套控件语言：原来左边是 pill 筛选、右边是「两个裸文字 + 一枚实心
+                蓝块」的 Segmented，一条工具带上两种语言（图纸 desktop-ia.html §二）。 */}
+            <Dropdown trigger={['click']} menu={{
+              selectable: true, selectedKeys: [sortBy],
+              items: SORTS.map((k) => ({ key: k, label: t(`project.sort.${k}`) })),
+              onClick: ({ key }) => changeSort(key as ProjSort),
+            }}>
+              <button type="button" className="prj-chip prj-sortpill" aria-label={t('project.sortBy')}>
+                {t(`project.sort.${sortBy}`)}{ICON_CHEVRON}
+              </button>
+            </Dropdown>
           </div>
           {/* 手机：搜索原地展开、排序进 sheet。两枚图标钉在右侧，不随筛选带横滑跑掉 */}
           <button type="button" className="prj-iconbtn find" aria-label={t('project.searchPlaceholder')}
@@ -491,6 +526,25 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
           <div className="prj-sect"><b>{t('overview.activeProjects')}</b><span className="n">{rest.length}</span><span className="ln" /></div>
         )}
         {rest.length > 0 && <div className="prj-grid" onKeyDown={onGridKey}>{rest.map(card)}</div>}
+
+        {quiet.length > 0 && (
+          <>
+            <div className="prj-sect" style={{ marginTop: 22 }}>
+              <b>{t('project.quietSection')}</b><span className="n">{quiet.length}</span>
+              <span style={{ color: 'var(--text-dimmer)', fontWeight: 400, fontSize: 'var(--fs-meta)' }}>
+                {t('project.quietHint')}</span>
+              <span className="ln" />
+            </div>
+            {quiet.map((p) => (
+              <div key={p.key} className="prj-quiet" onClick={() => open(p)}
+                role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); open(p) } }}>
+                <span className="nm">{p.name}</span>
+                <span className="p" title={p.dir}>{p.dir}</span>
+                <span>{p.cleanable > 0 && <Tag color="success" style={{ margin: 0 }}>{t('project.cleanableCount', { count: p.cleanable })}</Tag>}</span>
+              </div>
+            ))}
+          </>
+        )}
 
         {data.loose.length > 0 && (
           <>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1315,6 +1315,8 @@ const enUS = {
   'project.unpin': 'Unpin',
   'project.tasks': 'tasks',
   'project.loose': 'Loose sessions',
+  'project.quietSection': 'Other projects',
+  'project.quietHint': 'no sessions running',
   'project.enter': 'Enter',
   'project.forkTask': 'Fork',
   'project.notFound': 'Project not found or retired',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1477,6 +1477,8 @@ const enUS = {
   'overview.goFinish': 'Finish',
   'overview.gotoProjects': 'All projects',
   'overview.inactiveRest': '{count} more project(s) idle — see all on the Projects page',
+  'overview.recentSessions': 'Recent sessions',
+  'overview.allSessions': 'All sessions',
   'overview.recentActivity': 'Recent activity',
   'overview.moreTasks': '+{count} more',
   'overview.greetMorning': 'Good morning — ',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1315,6 +1315,8 @@ const zhCN = {
   'project.unpin': '取消置顶',
   'project.tasks': '任务',
   'project.loose': '散会话',
+  'project.quietSection': '其他项目',
+  'project.quietHint': '没有会话在跑',
   'project.enter': '进入',
   'project.forkTask': '派生',
   'project.notFound': '项目不存在或已退场',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1477,6 +1477,8 @@ const zhCN = {
   'overview.goFinish': '去收尾',
   'overview.gotoProjects': '进入项目页',
   'overview.inactiveRest': '其余 {count} 个项目无活动 —— 在「项目」页查看全部',
+  'overview.recentSessions': '最近会话',
+  'overview.allSessions': '全部会话',
   'overview.recentActivity': '最近活动',
   'overview.moreTasks': '+{count} 更多',
   // 概览问候区（14 §5.1）：第一句话回答「今天有几件事需要你」

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -355,6 +355,55 @@ html[data-size="compact"] .tt-pagehead { gap: var(--sp-2); }
   padding-bottom: calc(126px + env(safe-area-inset-bottom));
 }
 
+/* ── 会话行（图纸 14-desktop-workspace/desktop-ia.html §三）──────────────
+   一条会话原来写两行 67px：第二行只有「创建 · 最后响应」，中间 697px 是空的，
+   而「这条会话属于哪个项目」概览都写了、这一页反而没有。
+   现在同一份 DOM 两种排法：窄档一行折行排；Canvas ≥900 排成七列，
+   空出来的宽度换成两列真信息（项目 / 位置），行高收到 40。 */
+/* 窄档是两行栅格而不是 flex 折行：靠 flex 折的话，行会按名字长短随机折成一行或两行，
+   「关闭」有时孤零零掉到第二行——列表于是没有一条稳定的基线。
+   这是**基础**排法而不是 compact 专属：桌面拉开终端分栏时 Canvas 同样会窄到 <900。 */
+.tt-srow { display: grid; align-items: center; width: 100%; min-width: 0;
+  row-gap: var(--sp-1); column-gap: var(--sp-2);
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  grid-template-areas: "dot nm acts" "dot tags tm"; }
+.tt-srow > * { min-width: 0; }
+.tt-srow > i { grid-area: dot; align-self: start; margin-top: 6px; }
+.tt-srow .nm { grid-area: nm; font-weight: 700; color: var(--text-bright);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tt-srow .nm .id { margin-left: 4px; font-weight: 400; font-size: var(--fs-meta); opacity: .5; }
+.tt-srow .pj, .tt-srow .loc { display: none; }
+.tt-srow .tags { grid-area: tags; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.tt-srow .tm { grid-area: tm; justify-self: end; font-size: var(--fs-meta);
+  color: var(--text-dimmer); white-space: nowrap; }
+.tt-srow .acts { grid-area: acts; justify-self: end; display: flex; align-items: center;
+  gap: var(--sp-4); white-space: nowrap; }
+
+@container canvas (min-width: 900px) {
+  .tt-srow { column-gap: var(--sp-3); row-gap: 0; grid-template-areas: none;
+    grid-template-columns: 8px minmax(180px, 1fr) 124px minmax(150px, 1.25fr) 132px 82px 92px; }
+  /* 七列按 DOM 顺序自动落位：● / 名称 / 项目 / 位置 / 标记 / 时间 / 操作 */
+  .tt-srow > i, .tt-srow .nm, .tt-srow .tags, .tt-srow .tm, .tt-srow .acts { grid-area: auto; }
+  .tt-srow > i { align-self: center; margin-top: 0; }
+  .tt-srow .pj { display: block; font-size: var(--fs-meta); color: var(--text-dimmer);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tt-srow .loc { display: block; font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: var(--fs-meta); color: var(--text-dimmer); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tt-srow .loc .br { color: #7ed0d8; }
+  .tt-srow .tags { flex-wrap: nowrap; overflow: hidden; }
+  /* 位置列已经把分支写全了，行内那枚 ⎇ 标就是重复 */
+  .tt-srow .tags .wt { display: none; }
+  .tt-srow .tm { margin-left: 0; justify-self: end; }
+  /* 破坏性动作不常驻：12 行 12 个红色「关闭」是界面在冲用户喊。
+     :focus-within 一起写——只挂 hover 的话键盘用户永远够不着。 */
+  .tt-srow .acts { justify-self: end; opacity: 0; transition: opacity .14s; }
+  .ant-list-item:hover .tt-srow .acts,
+  .ant-list-item:focus-within .tt-srow .acts,
+  .tt-srow .acts:focus-within { opacity: 1; }
+}
+/* 手指档没有 hover，操作必须常驻 */
+html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
+
 .tt-seg-scroll { scrollbar-width: none; }
 .tt-seg-scroll::-webkit-scrollbar { height: 0; }
 .tt-seg-scroll > .ant-segmented { min-width: max-content; }

--- a/frontend/src/session-project.ts
+++ b/frontend/src/session-project.ts
@@ -8,7 +8,7 @@
 // 会话胶囊、标签右键菜单）散在各处，数据源却只有 App 那一份轮询。
 import { useSyncExternalStore } from 'react'
 
-export type SessionProject = { key: string; name: string; branch?: string }
+export type SessionProject = { key: string; name: string; dir: string; branch?: string }
 
 let table: Record<string, SessionProject> = {}
 const listeners = new Set<() => void>()
@@ -29,6 +29,23 @@ export function sessionProject(name?: string | null): SessionProject | undefined
   return name ? table[name] : undefined
 }
 
+/**
+ * 会话的「位置」——桌面列表里那一列（图纸 14-desktop-workspace/desktop-ia.html §一）。
+ *
+ * 优先给 worktree 分支：同名会话散在两个 worktree 上时，分支是唯一能分辨它们的东西。
+ * 没有分支就给工作目录（只留末两段）。**与项目目录相同时返回空**：那一行左边的项目列
+ * 已经说过一遍，再写一次是重复不是信息。
+ */
+export function sessionLocation(ann: any, cwd?: string, projectDir?: string):
+  { branch?: string; path?: string; title?: string } {
+  const branch = ann?.primary?.branch
+  if (branch) return { branch, title: ann?.primary?.worktree || branch }
+  const dir = cwd || ann?.home || ''
+  if (!dir || dir === projectDir) return {}
+  const parts = dir.split('/').filter(Boolean)
+  return { path: (parts.length > 2 ? '…/' : '/') + parts.slice(-2).join('/'), title: dir }
+}
+
 function subscribe(fn: () => void) {
   listeners.add(fn)
   return () => listeners.delete(fn)
@@ -36,6 +53,11 @@ function subscribe(fn: () => void) {
 
 export function useSessionProject(name?: string | null): SessionProject | undefined {
   return useSyncExternalStore(subscribe, () => sessionProject(name), () => sessionProject(name))
+}
+
+/** 整张表——会话列表要按行取项目名，一个个 hook 取不现实。 */
+export function useSessionProjects(): Record<string, SessionProject> {
+  return useSyncExternalStore(subscribe, () => table, () => table)
 }
 
 /**
@@ -49,8 +71,8 @@ export function buildSessionProjects(
   projects: { key: string; name: string; dir: string; git: boolean; top?: { name: string }[] | null }[],
   annotations: Record<string, any>,
 ): Record<string, SessionProject> {
-  const byDir = new Map<string, { key: string; name: string }>()
-  for (const p of projects) if (p.git) byDir.set(p.dir, { key: p.key, name: p.name })
+  const byDir = new Map<string, { key: string; name: string; dir: string }>()
+  for (const p of projects) if (p.git) byDir.set(p.dir, { key: p.key, name: p.name, dir: p.dir })
 
   const out: Record<string, SessionProject> = {}
   for (const [session, ann] of Object.entries(annotations || {})) {
@@ -61,7 +83,7 @@ export function buildSessionProjects(
   // 非 git 项目兜底：已经有归属的不覆盖（annotation 比 top 名单准）
   for (const p of projects) {
     if (p.git) continue
-    for (const s of p.top || []) if (!out[s.name]) out[s.name] = { key: p.key, name: p.name }
+    for (const s of p.top || []) if (!out[s.name]) out[s.name] = { key: p.key, name: p.name, dir: p.dir }
   }
   return out
 }


### PR DESCRIPTION
## 为什么

手机版刚把三页的分工定完（概览＝时间 · 项目＝空间 · 会话＝全集），但两件事没做完：

1. **概览还在复制另外两页**——第三层是项目卡网格（和项目页几乎逐像素一样），还挂了个「会话」tab 直接把整个会话列表页嵌了进来；
2. **桌面还在用手机那批组件**——列表拉到 1174 宽，内容贴左、时间贴右，中间是空的。

1440×900（侧栏 224）实测：

| 位置 | 空白 |
|---|---|
| 概览会话行（838 宽） | 名称右缘到时间左缘 **570px**，占行宽 68% |
| 状态条（1174 宽） | 内容只有 82px，**1092px** 是空胶囊 |
| 会话页每行 | 内容右缘 x=636、操作区 x=1333，中间 **697px** |
| 概览左栏 | 内容到 y=590 结束、视口 900，下方 **310px** 空着 |
| 项目页 | 4 个 0 任务的项目占掉 **467px** 卡片网格 |

## 图纸

- [`13-mobile-responsive/ia.html`](docs/design/web/13-mobile-responsive/ia.html) — 三页分工（第一个 commit）
- [`14-desktop-workspace/desktop-ia.html`](docs/design/web/14-desktop-workspace/desktop-ia.html) — 桌面排布（第二个 commit），含**自审**一节：画完之后自己挑的 9 处毛病与改法

桌面四条原则：对齐成列 / 中间的宽度给信息不给空气 / 破坏性动作不常驻 / 桌面行高 36–40 放得下更多。

## 改了什么

**概览**
- 删掉项目卡网格、「项目 / 会话」tab、散会话区（那是另外两页的活）
- 新增「最近会话」：跨项目扁平流，按最近活动倒序，**排除已进行动卡的会话**（两层严格互补）
- 桌面：状态条并进页头右端（省一整行）；会话流排成六列 ● / 项目 / 名称 / Agent / **位置** / 时间；12 条（手机 8 条）
- 「位置」= ⎇ 分支，否则工作目录；**与项目目录相同就留空**——那时左边项目列已经说过一遍

**项目**
- 没有会话在跑的项目折成页尾「其他项目」一行一个，不再各占一张空卡
- 栅格 `align-items:start`，卡片不再被同行最高的那张撑出空白
- 排序从「两个裸文字 + 一枚实心蓝块」换成一枚 pill，与左侧筛选同一套控件语言

**会话**
- 两行 67px 压成一行 40，七列：● / 名称 / **项目** / **位置** / 标记 / 时间 / 操作
- 会话 ID 只留尾 4 位；窗口数只在 >1 时显示；创建时间进 title
- 派生 / 关闭 随 `:hover` + `:focus-within` 出现，粗指针档保持常驻

## 一个落地时才发现的坑

两行排法不是「手机专属」，是「**窄 Canvas 专属**」——桌面拉开终端分栏后 Canvas 同样会窄到 900 以下。
所以两行栅格写成基础排法、七列写成 `@container canvas` 覆盖；按视口档位写会在分栏态露馅。

零新后端接口：位置列来自已经在拉的 `/sessions/annotations`。

## 验收

- 1440 / 390 逐档 reload 实测（CDP 改视口不触发 resize/matchMedia change，必须每档重载）
- 分栏态（Canvas <900）回落两行栅格，信息不丢
- hover 实测：只有指针所在行的操作浮出（其余 opacity 0）
- `typecheck` / `i18n:check`（1481 keys）/ `vitest`（88）/ `build` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)
