### PR TITLE
手机侧收尾：Git/Worktree 走全屏二级页 + 物理返回键 + 会话入口

### DIFF
--- a/docs/design/web/13-mobile-responsive.md
+++ b/docs/design/web/13-mobile-responsive.md
@@ -8,6 +8,9 @@
 > [手机](./13-mobile-responsive/phone.html) · [插件](./13-mobile-responsive/plugins.html) ·
 > [设置](./13-mobile-responsive/settings.html) · **[expanded 档（平板/小笔电）](./13-mobile-responsive/expanded.html)**
 >
+> 后补两稿：[三页分工（概览/项目/会话）](./13-mobile-responsive/ia.html) ·
+> **[二级页：Git / Worktree / 返回键](./13-mobile-responsive/panels.html)**（§6 剩下那两行的落地图纸，含自审）
+>
 > 状态：**设计草案，未实现**。落地范围见 §10 分期。
 
 ---
@@ -317,7 +320,7 @@ sheet 内部按 14 §4.4 的同一条分层拆成两段，**不把功能页和�
 
 | 基元 | 用途 | 行为 |
 |---|---|---|
-| `<MobileSubPage>` | 详情页、Git 面板、Worktree 管理、插件详情、文件预览 | 全屏、右滑边缘返回、`history.pushState` 让**安卓物理返回键=返回**、四边吃安全区 |
+| `<MobileSubPage>` | 详情页、Git 面板、Worktree 管理、插件详情、文件预览 | 全屏、`history.pushState` 让**安卓物理返回键=返回** ✓、四边吃安全区 ✓、portal 到 body ✓；右滑边缘返回未做 |
 | `<MobileSheet>` | 溢出菜单、会话切换、筛选排序、设备/策略选择、快捷命令 | 底部升起，高度 `auto / 50% / 88%` 三档，下拉关闭，`--kb` 抬起，圆角 16 |
 
 compact/medium 档下，**所有 antd `Drawer` 自动降级为底部 sheet**（`placement="bottom"`），
@@ -437,10 +440,10 @@ compact/medium 档下，**所有 antd `Drawer` 自动降级为底部 sheet**（`
 | **项目列表** | 卡片网格 `minmax(270px,1fr)` 单列尚可；排序 Segmented + 新建按钮换行 | ① 卡片改行卡（高度 −30%）；④ 排序/筛选收进顶栏 sheet |
 | **项目主页** | `.prj-tabs` 五 tab 溢出无提示；composer 的 pill 组换行成三行 | tab 条横滑 + 两侧渐隐；composer 折叠为「一行输入 + 展开更多」；worktree 分叉图左缩进 40→24 |
 | **概览** | `.p6-stats` 六格 `flex:1 1 120px` 排成三行 | 走 14 稿 §5 的同一条信息序列：六格统计压成**一条状态概况**（不是 2×3 网格），「需要你」升为最多三张行动卡的单列队列，活跃项目单列、任务限 3 条，最近活动落到页尾。见 §13.2 |
-| **会话平铺** | 行内动作按钮 hover 才显 | 动作常显 + 长按出菜单 |
+| **会话平铺** | 行内动作按钮 hover 才显 | 动作常显 ✓（`html[data-pointer="coarse"]` 兜底已覆盖项目行/项目卡/分叉图/Git 段落四处）+ 长按出菜单（未做） |
 | **文件** | 已走 `MobileSubPage` ✓ | 保留；`FileWorkspace`（多 tab 编辑器）不进 compact，compact 用 FileBrowser + 二级页 |
-| **Git 面板** | fixed 抽屉 `width: min(420px, 92vw)`，压在底栏上、不吃安全区 | ③ compact 走全屏二级页；提交树横向滚动区独立 |
-| **Worktree** | `Drawer width='100%'`，像页又像抽屉 | ③ 改二级页，吃物理返回键 |
+| **Git 面板** | ~~fixed 抽屉 `width: min(420px, 92vw)`，压在底栏上、不吃安全区~~ ✓ | ③ compact 走全屏二级页；提交树横向滚动区独立。**已实现**（`shell/AdaptivePanel`，两个调用点合一） |
+| **Worktree** | ~~`Drawer width='100%'`，像页又像抽屉~~ ✓ | ③ 改二级页，吃物理返回键。**已实现**（返回键走 `shell/useBackDismiss`） |
 | **蜂群** | `Swarm.tsx:378` 写死两列；拓扑图在 360px 上不可读 | ① 单列；拓扑图 compact 下换成**成员列表**（拓扑是桌面增强，不是必需） |
 | **浏览器镜像** | 地址栏固定 150px；工具按钮溢出 | ④ 地址栏 `flex:1`，工具进 `⋯`；镜像画面按容器宽等比缩放 |
 | **手机镜像** | 设备选择器固定 240px | ③ 设备选择改 sheet |

--- a/docs/design/web/13-mobile-responsive/panels.html
+++ b/docs/design/web/13-mobile-responsive/panels.html
@@ -1,0 +1,500 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><title>手机二级页：Git / Worktree / 返回键</title>
+<style>
+:root{
+  --bg:#0d1117;--card:#161b22;--inset:#0b0f14;--line:#21262d;--line2:#30363d;
+  --tx:#e6edf3;--dim:#8b949e;--dimmer:#6e7681;
+  --acc:#58a6ff;--solid:#4e90dc;--soft:rgba(31,111,235,.14);--accb:rgba(88,166,255,.45);
+  --amber:#d29922;--green:#3fb950;--purple:#a371f7;--cyan:#39c5cf;--red:#f85149;
+  --micro:11px;--meta:12px;--sm:13px;--body:15px;--lg:16px;--title:22px;
+  --r1:6px;--r2:10px;--r3:14px;--rp:999px;--s1:4px;--s2:8px;--s3:12px;--s4:16px;
+}
+*{box-sizing:border-box}
+body{margin:0;background:#07090d;color:var(--tx);
+  font:14px/1.6 Inter,-apple-system,"PingFang SC","Microsoft YaHei",sans-serif}
+.wrap{max-width:1280px;margin:0 auto;padding:30px 22px 80px}
+h1{font-size:22px;margin:0 0 8px}
+h2{font-size:var(--lg);margin:38px 0 6px;padding-top:24px;border-top:1px solid var(--line)}
+.lede{color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch;margin:0 0 18px}
+.lede b{color:var(--tx)}
+code{font:var(--meta)/1.4 ui-monospace,monospace;color:#c9d5e2;background:rgba(148,163,184,.1);
+  padding:2px 6px;border-radius:4px}
+ul.pts{margin:0 0 20px;padding-left:19px;color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch}
+ul.pts b{color:var(--tx)}
+ul.pts em{font-style:normal;color:#f2a6a0}
+.row{display:flex;gap:22px;flex-wrap:wrap;align-items:flex-start}
+.cap{display:flex;align-items:center;gap:8px;margin:0 0 9px;font-size:var(--meta);color:var(--dim)}
+.cap b{color:var(--tx);font-size:var(--sm)}
+.tag{font-size:var(--micro);padding:1px 8px;border-radius:var(--rp);border:1px solid var(--line2);color:var(--dimmer)}
+.tag.bad{color:#f2a6a0;border-color:rgba(248,81,73,.42)}
+.tag.good{color:#7fd18f;border-color:rgba(63,185,80,.42)}
+.note{margin:10px 0 0;font-size:var(--meta);color:var(--dim);line-height:1.8;max-width:340px}
+.note u{text-decoration:none;color:var(--tx)}
+.note em{font-style:normal;color:#f2a6a0}
+
+/* 手机框 360×640 */
+.ph{position:relative;width:330px;height:600px;border-radius:26px;border:1px solid var(--line2);
+  background:var(--bg);overflow:hidden;display:flex;flex-direction:column}
+.ph .body{flex:1;min-height:0;overflow:hidden;position:relative}
+.ph .nav{flex:0 0 52px;display:flex;border-top:1px solid var(--line);background:var(--card);position:relative;z-index:1}
+.ph .nav i{flex:1;display:grid;place-items:center;font-size:var(--micro);color:var(--dimmer);font-style:normal}
+.ph .nav i.on{color:var(--acc)}
+.safe{position:absolute;left:0;right:0;bottom:0;height:14px;display:grid;place-items:center;z-index:2}
+.safe::after{content:"";width:110px;height:4px;border-radius:2px;background:rgba(230,237,243,.4)}
+
+/* 终端底 */
+.term{height:100%;padding:10px 12px;font:11px/1.65 ui-monospace,monospace;color:#7fd18f;background:#06090d}
+.term .u{color:#e6edf3}
+
+/* 覆盖层 */
+.over{position:absolute;top:0;bottom:0;right:0;background:var(--card);border-left:1px solid var(--line2);
+  box-shadow:-14px 0 34px rgba(0,0,0,.5);display:flex;flex-direction:column}
+.scrim{position:absolute;inset:0;background:rgba(1,4,9,.6)}
+.zbadge{position:absolute;top:6px;left:6px;font:10px/1 ui-monospace,monospace;color:#f2a6a0;
+  border:1px solid rgba(248,81,73,.5);border-radius:4px;padding:3px 5px;background:rgba(13,17,23,.9);z-index:5}
+.zbadge.ok{color:#7fd18f;border-color:rgba(63,185,80,.5)}
+.hatch{background:repeating-linear-gradient(45deg,rgba(248,81,73,.13),rgba(248,81,73,.13) 5px,transparent 5px,transparent 11px);
+  border:1px dashed rgba(248,81,73,.55);border-radius:4px;display:grid;place-items:center;
+  font:10px/1.3 ui-monospace,monospace;color:#f2a6a0;text-align:center;padding:2px}
+
+/* 二级页 */
+.subhd{flex:0 0 auto;display:flex;align-items:center;gap:2px;padding:6px 6px;border-bottom:1px solid var(--line);
+  background:var(--card)}
+.subhd .bk{width:44px;height:44px;display:grid;place-items:center;color:var(--tx);flex:0 0 auto}
+.subhd .ti{flex:1;min-width:0;font-size:var(--body);font-weight:600;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
+.subhd .ic{width:44px;height:44px;display:grid;place-items:center;color:var(--dim);flex:0 0 auto;font-size:15px}
+.subbody{flex:1;min-height:0;overflow:hidden;padding:10px 12px;display:flex;flex-direction:column;gap:9px}
+
+.chip{height:26px;padding:0 11px;border-radius:var(--rp);border:1px solid var(--line2);
+  display:inline-flex;align-items:center;gap:6px;font-size:var(--meta);color:var(--dim);white-space:nowrap}
+.chip.on{color:var(--acc);border-color:var(--accb);background:var(--soft)}
+.chip.br{font-family:ui-monospace,monospace;color:#7ed0d8;border-color:rgba(57,197,207,.4);background:rgba(57,197,207,.08)}
+.segs{display:flex;gap:2px;background:var(--inset);border-radius:var(--r2);padding:3px}
+.segs span{flex:1;text-align:center;padding:6px 0;font-size:var(--meta);color:var(--dim);border-radius:7px}
+.segs span.on{background:var(--solid);color:#fff}
+.frow{display:flex;align-items:center;gap:9px;min-height:40px;padding:0 6px;border-bottom:1px solid var(--line);font-size:var(--sm)}
+.frow .st{font:11px/1 ui-monospace,monospace;width:14px;flex:0 0 auto}
+.frow .st.m{color:var(--amber)} .frow .st.a{color:var(--green)} .frow .st.d{color:var(--red)}
+.frow .p{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:ui-monospace,monospace;font-size:var(--meta)}
+.frow .n{font:11px/1 ui-monospace,monospace;color:var(--dimmer)}
+.commit{flex:0 0 auto;border:1px solid var(--line2);border-radius:var(--r2);background:var(--inset);padding:8px 9px}
+.commit .in{font-size:var(--meta);color:var(--dimmer)}
+.commit .btns{display:flex;gap:8px;margin-top:8px}
+.btn{height:32px;padding:0 14px;border-radius:var(--r2);display:inline-flex;align-items:center;
+  font-size:var(--meta);border:1px solid var(--line2);color:var(--dim)}
+.btn.pri{background:var(--solid);border-color:var(--solid);color:#fff}
+.kbd{position:absolute;left:0;right:0;bottom:0;height:210px;background:linear-gradient(180deg,#1b2027,#12161c);
+  border-top:1px solid var(--line2);display:grid;place-items:center;color:var(--dimmer);font-size:var(--meta);z-index:3}
+.diff{flex:1;min-height:0;overflow:hidden;border-radius:var(--r2);border:1px solid var(--line);background:var(--inset);
+  font:10.5px/1.6 ui-monospace,monospace;padding:8px}
+.diff .add{color:#7fd18f}.diff .del{color:#f2a6a0}.diff .hu{color:#7ed0d8}
+
+.wtcard{border:1px solid var(--line);border-radius:var(--r2);background:var(--inset);padding:9px 10px}
+.wtcard b{font:var(--sm)/1.4 ui-monospace,monospace;color:#7ed0d8}
+.wtcard .p{font:10.5px/1.4 ui-monospace,monospace;color:var(--dimmer);margin-top:3px;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wtcard .r{display:flex;gap:14px;margin-top:8px;font-size:var(--meta);color:var(--acc)}
+
+/* sheet */
+.sheet{position:absolute;left:0;right:0;bottom:0;background:#1b2029;border-top:1px solid var(--line2);
+  border-radius:16px 16px 0 0;padding:8px 8px 14px;z-index:4;box-shadow:0 -18px 48px rgba(0,0,0,.45)}
+.sheet .grip{width:36px;height:4px;border-radius:2px;background:var(--line2);margin:0 auto 10px}
+.sheet .sec{padding:10px 10px 4px;font-size:10px;font-weight:700;letter-spacing:.1em;color:var(--dimmer)}
+.sheet .r{display:flex;align-items:center;gap:12px;min-height:48px;padding:0 10px;border-radius:12px;font-size:var(--body)}
+.sheet .r.on{background:var(--soft);color:var(--acc)}
+.sheet .r i{width:20px;flex:0 0 auto;color:var(--dim);font-style:normal;font-size:13px}
+.new{box-shadow:inset 0 0 0 1px rgba(63,185,80,.45);background:rgba(63,185,80,.07)}
+
+/* 平板/桌面框 */
+.tab{width:384px;height:512px}
+.dk{width:520px;height:330px;border-radius:12px;border:1px solid var(--line2);background:var(--bg);
+  overflow:hidden;position:relative;display:flex}
+.dk .side{flex:0 0 78px;border-right:1px solid var(--line);background:var(--card)}
+.dk .page{flex:1;min-width:0;padding:12px}
+.dk .panel{position:absolute;top:0;right:0;bottom:0;width:190px;background:var(--card);
+  border-left:1px solid var(--line2);box-shadow:-14px 0 34px rgba(0,0,0,.5);padding:10px}
+.dk h5{margin:0 0 8px;font-size:var(--sm)}
+
+/* 状态机 */
+pre.sm{background:var(--card);border:1px solid var(--line);border-radius:var(--r2);padding:14px 16px;
+  font:12px/1.75 ui-monospace,monospace;color:var(--dim);overflow-x:auto;max-width:900px}
+pre.sm b{color:var(--tx)}
+table.tt{border-collapse:collapse;width:100%;max-width:900px;font-size:var(--sm);margin:8px 0 20px}
+table.tt th,table.tt td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+table.tt th{color:var(--dimmer);font-size:var(--meta);font-weight:600}
+table.tt td{color:var(--dim)}
+table.tt td b{color:var(--tx)}
+ol.sr{margin:0;padding-left:20px;color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch}
+ol.sr li{margin-bottom:9px}
+ol.sr b{color:var(--tx)}
+</style></head><body><div class="wrap">
+
+<h1>手机二级页：Git / Worktree / 返回键</h1>
+<p class="lede">
+13 §6 的塌陷表里还剩两行没做：<b>Git 面板</b>与 <b>Worktree</b>。它们在手机上仍然是桌面抽屉——
+不是「窄了点」，是三个功能性故障：<em>盖住底栏</em>、<em>不吃安全区</em>、<em>按返回键没反应</em>。
+顺带两件事一起了：手机上没有任何导航入口能到会话列表页；四处 hover 才出现的操作在手指档摸不到。
+</p>
+<ul class="pts">
+  <li><b>同一个 Git 面板有两套壳。</b>会话页走 <code>FloatingFileDrawer</code>（<code>fixed; width:min(420px,92vw); z-index:1200</code>），
+      项目页是另一份手搓的 <code>zIndex:1000</code> 遮罩 + <code>min(520px,94vw)</code> 右侧面板。</li>
+  <li><b>Worktree 是 <code>Drawer width='100%'</code></b>——13 §4.3 点名的「既不是页也不是 sheet」：
+      从右横切进场、右上角一个 ×、底部不让安全区。</li>
+  <li><b>返回键没人接。</b><code>MobileSubPage</code> 没有任何 history 处理；<code>MobileSheet</code> 的注释写着
+      「接管返回」，实际只监听了 Escape——手机上没有 Escape 键。</li>
+</ul>
+
+<h2>一、现状</h2>
+<div class="row">
+
+  <div>
+    <p class="cap"><b>会话页 · Git</b><span class="tag bad">z=1200 盖住底栏</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="term"><span class="u">❯</span> git status<br>On branch feat/web-session-tokens<br>Changes not staged:<br>&nbsp;&nbsp;modified: src/App.tsx<br>&nbsp;&nbsp;modified: src/index.css</div>
+        <div class="over" style="width:300px">
+          <div style="display:flex;align-items:center;gap:8px;padding:9px 10px;border-bottom:1px solid var(--line)">
+            <b style="font-size:var(--sm)">Git</b><span class="chip br" style="height:22px">⎇ feat/web-session-tokens</span>
+            <span style="margin-left:auto;color:var(--dim)">×</span>
+          </div>
+          <div style="padding:9px 10px">
+            <div class="segs" style="margin-bottom:8px"><span class="on">改动 5</span><span>历史</span><span>分支</span></div>
+            <div class="frow"><span class="st m">M</span><span class="p">src/App.tsx</span><span class="n">+42 −8</span></div>
+            <div class="frow"><span class="st m">M</span><span class="p">src/index.css</span><span class="n">+31 −2</span></div>
+            <div class="frow"><span class="st a">A</span><span class="p">src/shell/AdaptivePanel.tsx</span><span class="n">+58</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="nav"><i>概览</i><i>项目</i><i>文件</i><i>更多</i></div>
+      <div class="hatch" style="position:absolute;left:30px;right:0;bottom:0;height:52px;z-index:6">面板压在底栏上 · 底栏还在响应点击</div>
+    </div>
+    <p class="note">420 的抽屉在 360 的屏上盖到 <code>92vw</code>，左边只剩 30px 的缝；
+    <u>它 top:0/bottom:0 铺满，但底栏还在下面接点击</u>，也不吃 <code>safe-area-inset-bottom</code>。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>项目页 · Git</b><span class="tag bad">手搓 scrim 1000 + 面板 520</span></p>
+    <div class="ph">
+      <div class="body">
+        <div style="padding:10px 12px">
+          <div style="font-size:var(--body);font-weight:700">roam</div>
+          <div style="font:10.5px/1.4 ui-monospace,monospace;color:var(--dimmer);margin-top:3px">/home/ai/codes/ttmux</div>
+        </div>
+        <div class="scrim"></div>
+        <div class="over" style="width:310px">
+          <div style="display:flex;align-items:center;gap:8px;padding:9px 10px;border-bottom:1px solid var(--line)">
+            <b style="font-size:var(--sm)">Git</b><span style="margin-left:auto;color:var(--dim)">×</span>
+          </div>
+          <div style="padding:9px 10px">
+            <div class="segs" style="margin-bottom:8px"><span class="on">改动 5</span><span>历史</span><span>分支</span></div>
+            <div class="frow"><span class="st m">M</span><span class="p">src/App.tsx</span><span class="n">+42 −8</span></div>
+            <div class="frow"><span class="st m">M</span><span class="p">src/Projects.tsx</span><span class="n">+19 −4</span></div>
+          </div>
+        </div>
+      </div>
+      <div class="nav"><i>概览</i><i class="on">项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note">同一个 <code>&lt;GitPanel&gt;</code>，第二套容器：宽度、层级、有没有遮罩、有没有阴影<u>全都和会话页那套不一样</u>。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>Worktree</b><span class="tag bad">既不是页也不是 sheet</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0">
+          <div style="display:flex;align-items:center;padding:11px 12px;border-bottom:1px solid var(--line)">
+            <b style="font-size:var(--body)">Worktree</b><span style="margin-left:auto;color:var(--dim)">×</span>
+          </div>
+          <div style="padding:10px 12px;display:flex;flex-direction:column;gap:9px">
+            <div style="display:flex;gap:8px">
+              <span style="flex:1;height:30px;border:1px solid var(--line2);border-radius:var(--r2);
+                display:flex;align-items:center;padding:0 10px;color:var(--dimmer);font-size:var(--meta)">/home/ai/codes/ttmux</span>
+              <span class="btn" style="height:30px">＋</span><span class="btn" style="height:30px">↻</span>
+            </div>
+            <div class="wtcard"><b>⎇ feat/web-session-tokens</b><div class="p">/home/ai/codes/ttmux/.worktrees/task-1</div>
+              <div class="r"><span>进入</span><span>对比</span><span>收尾</span></div></div>
+            <div class="wtcard"><b>⎇ redesign/overview-vs-projects</b><div class="p">/home/ai/codes/ttmux/.worktrees/task-2</div>
+              <div class="r"><span>进入</span><span>对比</span><span>收尾</span></div></div>
+          </div>
+        </div>
+      </div>
+      <div class="nav"><i>概览</i><i class="on">项目</i><i>文件</i><i>更多</i></div>
+      <div class="hatch" style="position:absolute;left:0;right:0;bottom:0;height:52px;z-index:6">同样盖住底栏 · 按返回键直接退出路由</div>
+    </div>
+    <p class="note">全宽的 antd Drawer 看起来像页，但<u>从右横切进场、右上角是 ×、返回键不认它</u>——
+    用户按下返回，整个路由被退掉，Drawer 还留在屏幕上。</p>
+  </div>
+</div>
+
+<h2>二、新版：Git 二级页</h2>
+<div class="row">
+
+  <div>
+    <p class="cap"><b>Git · 二级页</b><span class="tag good">z: --z-session-sub</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0;background:var(--bg)">
+          <div class="subhd">
+            <span class="bk"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></span>
+            <span class="ti">Git</span>
+            <span class="ic">↻</span><span class="ic">⋯</span>
+          </div>
+          <div class="subbody">
+            <span class="chip br" style="align-self:flex-start">⎇ feat/web-session-tokens</span>
+            <div class="segs"><span class="on">改动 5</span><span>历史</span><span>分支</span><span>base</span></div>
+            <div style="flex:1;min-height:0;overflow:hidden">
+              <div class="frow"><span class="st m">M</span><span class="p">src/App.tsx</span><span class="n">+42 −8</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">src/index.css</span><span class="n">+31 −2</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">src/shell/AdaptivePanel.tsx</span><span class="n">+58</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">src/shell/useBackDismiss.ts</span><span class="n">+96</span></div>
+              <div class="frow"><span class="st d">D</span><span class="p">src/FloatingFileDrawer.tsx</span><span class="n">−28</span></div>
+            </div>
+            <div class="commit">
+              <div class="in">提交信息…</div>
+              <div class="btns"><span class="btn pri">提交</span><span class="btn">全部暂存</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="safe"></div>
+    </div>
+    <p class="note">底栏<u>不再出现在下面</u>——二级页是整页，不是浮在页上的抽屉。
+    提交区钉在底部、上方留 <code>max(var(--kb), var(--safe-b))</code>，手势条不会压住按钮。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>键盘弹起</b><span class="tag good">提交区抬到键盘之上</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0;background:var(--bg)">
+          <div class="subhd">
+            <span class="bk"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></span>
+            <span class="ti">Git</span><span class="ic">↻</span><span class="ic">⋯</span>
+          </div>
+          <div class="subbody" style="padding-bottom:218px">
+            <span class="chip br" style="align-self:flex-start">⎇ feat/web-session-tokens</span>
+            <div style="flex:1;min-height:0;overflow:hidden">
+              <div class="frow"><span class="st m">M</span><span class="p">src/App.tsx</span><span class="n">+42 −8</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">src/index.css</span><span class="n">+31 −2</span></div>
+            </div>
+            <div class="commit" style="border-color:var(--accb)">
+              <div class="in" style="color:var(--tx)">fix(web): Git 面板在手机上改走二级页<span style="color:var(--acc)">▍</span></div>
+              <div class="btns"><span class="btn pri">提交</span><span class="btn">全部暂存</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="kbd">软键盘 210</div>
+      </div>
+    </div>
+    <p class="note"><code>--kb</code> 由 <code>useLayout()</code> 统一探（VirtualKeyboard API 优先、<code>visualViewport</code> 兜底）。
+    <u>iOS Safari 只有后者</u>，所以底部一律写 <code>max(var(--kb), var(--safe-b))</code>，
+    不直接用 <code>env(keyboard-inset-height)</code>。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>diff 详情：两级返回</b><span class="tag good">一次返回退一层</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0;background:var(--bg)">
+          <div class="subhd">
+            <span class="bk"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></span>
+            <span class="ti" style="font-family:ui-monospace,monospace;font-size:var(--sm)">src/App.tsx</span>
+            <span class="ic">⋯</span>
+          </div>
+          <div class="subbody">
+            <div style="display:flex;gap:8px"><span class="chip">+42</span><span class="chip">−8</span><span class="chip on">暂存此文件</span></div>
+            <div class="diff">
+              <span class="hu">@@ -1738,7 +1738,12 @@</span><br>
+              <span class="del">- &lt;FloatingFileDrawer open={showGit} right={…}&gt;</span><br>
+              <span class="add">+ &lt;AdaptivePanel</span><br>
+              <span class="add">+&nbsp;&nbsp;&nbsp;desktop="floating"</span><br>
+              <span class="add">+&nbsp;&nbsp;&nbsp;width="min(420px,92vw)"</span><br>
+              <span class="add">+&nbsp;&nbsp;&nbsp;layer="session"</span><br>
+              <span class="add">+&nbsp;&nbsp;&nbsp;title={t('git.title')}&gt;</span><br>
+              &nbsp;&nbsp;&nbsp;&lt;GitPanel dir={cwd} … /&gt;
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="safe"></div>
+    </div>
+    <p class="note">详情盖在 Git 二级页之上，各自压一条 history 记录：
+    <u>返回 → 关 diff（Git 还在）→ 再返回 → 关 Git → 再返回 → 才离开当前路由</u>。
+    栈是 LIFO，一次 <code>popstate</code> 只退一帧。</p>
+  </div>
+</div>
+
+<h2>三、新版：Worktree 二级页 / 会话入口</h2>
+<div class="row">
+
+  <div>
+    <p class="cap"><b>Worktree · 二级页</b><span class="tag good">工具行收成一行 44</span></p>
+    <div class="ph">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0;background:var(--bg)">
+          <div class="subhd">
+            <span class="bk"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></span>
+            <span class="ti">Worktree</span><span class="ic">＋</span><span class="ic">↻</span>
+          </div>
+          <div class="subbody">
+            <span style="height:34px;border:1px solid var(--line2);border-radius:var(--r2);display:flex;align-items:center;
+              padding:0 11px;color:var(--dimmer);font:var(--meta)/1 ui-monospace,monospace">/home/ai/codes/ttmux</span>
+            <div style="display:flex;gap:7px"><span class="chip on">全部 4</span><span class="chip">在跑 2</span><span class="chip">可清理 1</span></div>
+            <div class="wtcard"><b>⎇ feat/web-session-tokens</b><div class="p">…/.worktrees/task-1</div>
+              <div class="r"><span>进入</span><span>对比</span><span>收尾</span></div></div>
+            <div class="wtcard"><b>⎇ redesign/overview-vs-projects</b><div class="p">…/.worktrees/task-2</div>
+              <div class="r"><span>进入</span><span>对比</span><span>收尾</span></div></div>
+            <div class="wtcard" style="opacity:.7"><b>⎇ docs/ba-prompt-analysis</b><div class="p">…/.worktrees/task-3</div>
+              <div class="r"><span style="color:var(--green)">✓ 已合并，可清理</span></div></div>
+          </div>
+        </div>
+      </div>
+      <div class="safe"></div>
+    </div>
+    <p class="note">目录框 + ＋ + ↻ 原来是并排三件套挤在 360 上；＋/↻ 上提到页头当 44 图标，
+    目录框独占一行。<u>卡片内的操作行本来就有 <code>!wide</code> 分支，不用动。</u></p>
+  </div>
+
+  <div>
+    <p class="cap"><b>更多 sheet：会话入口</b><span class="tag good">不加第五格</span></p>
+    <div class="ph">
+      <div class="body">
+        <div style="padding:10px 12px;opacity:.35">
+          <div style="font-size:var(--body);font-weight:700">晚上好</div>
+        </div>
+        <div class="scrim"></div>
+        <div class="sheet">
+          <div class="grip"></div>
+          <div class="sec new">工作区</div>
+          <div class="r new"><i>▤</i>会话</div>
+          <div class="sec">工具</div>
+          <div class="r"><i>◱</i>浏览器</div>
+          <div class="r"><i>▯</i>手机</div>
+          <div class="r"><i>⬡</i>插件</div>
+          <div class="r"><i>⚙</i>设置</div>
+          <div class="sec">账户</div>
+          <div class="r"><i>◐</i>主题</div>
+        </div>
+      </div>
+      <div class="nav"><i>概览</i><i>项目</i><i>文件</i><i class="on">更多</i></div>
+    </div>
+    <p class="note">13 §4.1 算过底栏四格在 360 上每格 90px，<u>加到五格就回到 72</u>——
+    等于推翻已经定过的结论。会话进「更多」，并且<b>单开一段「工作区」</b>，不归到「工具」下面。
+    会话坞的切换 sheet 末尾也加一行「全部会话」。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>768 平板（medium）</b><span class="tag">这一档要拍板</span></p>
+    <div class="ph tab">
+      <div class="body">
+        <div class="over" style="width:100%;border-left:0;background:var(--bg)">
+          <div class="subhd">
+            <span class="bk"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg></span>
+            <span class="ti">Git</span><span class="ic">↻</span><span class="ic">⋯</span>
+          </div>
+          <div class="subbody">
+            <span class="chip br" style="align-self:flex-start">⎇ feat/web-session-tokens</span>
+            <div class="segs" style="max-width:420px"><span class="on">改动 5</span><span>历史</span><span>分支</span><span>base</span></div>
+            <div style="flex:1;min-height:0">
+              <div class="frow"><span class="st m">M</span><span class="p">src/App.tsx</span><span class="n">+42 −8</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">src/index.css</span><span class="n">+31 −2</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">src/shell/AdaptivePanel.tsx</span><span class="n">+58</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="nav"><i>概览</i><i class="on">项目</i><i>文件</i><i>更多</i></div>
+    </div>
+    <p class="note"><b>取 <code>phone</code>（compact + medium）而不是只 compact。</b>
+    理由：Worktree 在 768 上今天本来就是 <code>width:'100%'</code>（<code>wide</code> 是 ≥905），medium 不会有损失；
+    而且 GitPanel 内部的详情覆盖层判的也是同一个 <code>!wide</code>，容器与内部保持一致。
+    <u>这一档如果要保留桌面抽屉，这里就是否决点。</u></p>
+  </div>
+</div>
+
+<h2>四、桌面回归基线：不动</h2>
+<div class="row">
+  <div>
+    <p class="cap"><b>1280 · 会话页 Git</b><span class="tag good">仍是 420 浮动面板</span></p>
+    <div class="dk">
+      <div class="side"></div>
+      <div class="page"><h5>终端</h5>
+        <div style="font:10.5px/1.7 ui-monospace,monospace;color:#7fd18f">❯ git status<br>On branch main</div></div>
+      <div class="panel"><h5>Git</h5>
+        <div class="frow" style="font-size:var(--meta)"><span class="st m">M</span><span class="p">src/App.tsx</span></div>
+        <div class="frow" style="font-size:var(--meta)"><span class="st a">A</span><span class="p">AdaptivePanel.tsx</span></div>
+      </div>
+      <div class="zbadge ok" style="left:auto;right:8px;top:auto;bottom:8px">z: var(--z-panel) = 1200（值不变）</div>
+    </div>
+    <p class="note" style="max-width:520px">桌面三条路径全部保持今天的样子：会话页 = 420 浮动面板，
+    项目页 = 520 面板 + 遮罩，Worktree = antd Drawer(1300)。<u>唯一有意的桌面变化是 ⌘K 面板里多一条「会话」</u>
+    ——会话页此前不在 <code>NAV</code> 里，所以命令面板也搜不到它。</p>
+  </div>
+</div>
+
+<h2>五、返回键：一个共享 hook</h2>
+<pre class="sm">
+<b>useBackDismiss(enabled, onDismiss) → depth</b>
+
+打开            pushState(history.state, '', location.href)   ← URL 不变，路由收不到 hashchange
+                push { id, onDismiss, closing:false }
+
+UI 关闭         onClose()            ← 先同步关，无延迟
+（← / × / 遮罩）  frame.closing = true
+                history.back()       ← <b>必须退掉这条记录</b>，否则留下死记录：
+                                        用户按一次返回没反应、再按一次直接退出
+
+返回键          popstate → 弹栈顶一帧
+                closing === true  ⇒ 吞掉（是我们自己发的）
+                closing === false ⇒ onDismiss()
+                一次 popstate 只退一帧 ⇒ diff → Git → sheet 按一次退一层
+
+打开态卸载       同 UI 关闭，但不调 onDismiss；不是栈顶就只摘帧、不碰 history
+
+兜底            栈非空时发生 hashchange（路由变了）
+                ⇒ 对所有存活帧调 onDismiss 并清栈——覆盖层在路由变化后一定是过期的
+</pre>
+<p class="note" style="max-width:80ch">
+<b>不要</b>往 <code>history.state</code> 里塞标记再读回来：<code>App.tsx</code> 的 <code>setHashParams</code>
+每次开关终端标签都跑一次 <code>replaceState</code>，会把标记抹掉。<u>模块级 LIFO 栈是唯一事实来源。</u><br>
+只在手机档启用——劫持桌面浏览器的返回键是行为变更；桌面继续走 Escape。
+</p>
+
+<h2>六、自审：画完之后自己挑的毛病</h2>
+<ol class="sr">
+  <li><b>第一版 Git 二级页头我放了「Git · roam」两段。</b>但页头下面第一行就是分支 chip，
+      项目名在项目页进来时是废话（你就在那个项目里）、在会话页进来时又不如分支准确。
+      <u>删掉，只留「Git」+ 分支 chip。</u></li>
+  <li><b>差点把 ＋/↻ 留在 Worktree 的目录行里。</b>那行原本是「目录框 + ＋ + ↻」三件套，
+      360 上目录框会被挤到 180px、路径几乎全截。<u>＋/↻ 上提到页头当 44 图标，目录框独占一行。</u>
+      顺带这也让页头的图标位有了统一用途（Git 是 ↻/⋯，Worktree 是 ＋/↻）。</li>
+  <li><b>diff 详情页最初画了「← Git」。</b>返回标签写上一层的名字看着贴心，实际会误导：
+      用户以为点它回 Git 列表，其实两层都可能被返回键退掉。<u>返回箭头不带文字，标题写当前文件名。</u></li>
+  <li><b>「会话」放进「工具」段是错的。</b>工具段是浏览器/手机/插件/设置——外围能力；
+      会话是工作区主线，和概览/项目/文件同级。<u>单开一段「工作区」，排在工具之前。</u></li>
+  <li><b>键盘态那帧提醒了一件事：提交区不能只靠 <code>--kb</code> 抬起。</b>
+      iOS Safari 没有 VirtualKeyboard API，<code>--kb</code> 只能从 <code>visualViewport</code> 推，有 30px 噪声底；
+      所以写 <code>max(var(--kb), var(--safe-b))</code> 而不是 <code>var(--kb)</code>——键盘收起时至少还有安全区。</li>
+  <li><b>桌面帧一开始没画。</b>但这次改的是三个调用点的容器，最大的风险恰恰是「手机修好了、桌面变了」。
+      <u>补一帧标「不动」，并把项目页 Git 会继承浮动面板的阴影这件事写进风险</u>——
+      那是唯一一处桌面视觉可能变化的地方，要么明示接受，要么给个开关。</li>
+  <li><b>返回键的状态机里，最容易漏的是「UI 关闭也要 <code>history.back()</code>」。</b>
+      漏了它每开关一次就留一条死记录，用户按返回「第一次没反应」。
+      这条单独画进状态机，不是写在注释里。</li>
+</ol>
+
+<h2>七、落地后的两处修正</h2>
+<ol class="sr">
+  <li><b>Git 的 ⋯/↻ 最终落在分支行右端，不是页头。</b>图纸把它们画进了二级页页头，
+      但页头是 <code>MobileSubPage</code> 的、图标却属于 <code>GitPanel</code> 内部状态（⋯ 是带菜单的
+      Dropdown），跨component 传上去要给二级页开一个 <code>actions</code> 插槽、再把面板内部的
+      JSX 挪出去。实测把标题行整行去掉、两枚图标并进下面的分支行，效果一样（内容还往上提了 62px），
+      改动只在 GitPanel 内部。<u>Worktree 的 ＋/↻ 同理，保留在它自己的目录行里。</u></li>
+  <li><b>StrictMode 会把返回键的 push/back 打乱。</b>开发态 mount→unmount→mount 是同步跑完的，
+      退帧发出的 <code>history.back()</code> 却是异步落地，中间第二次 mount 又 push 了一条——
+      两者交错会把当前位置挪到别人的记录上，<em>表现为「按一次返回退了两页」</em>（实测复现）。
+      解法：退帧的 back 延到微任务再发，<u>同一 tick 内又压帧就直接复用那条记录</u>，
+      双挂载的净效果变成 0 次 history 操作。这条写进了 <code>useBackDismiss</code> 的单测。</li>
+</ol>
+
+</div></body></html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import CodexChat from './CodexChat'
 import FileBrowser from './FileBrowser'
 import FileWorkspace from './FileWorkspace'
 import FloatingFileDrawer from './FloatingFileDrawer'
+import AdaptivePanel from './shell/AdaptivePanel'
 import MobileSubPage from './MobileSubPage'
 import { FileView } from './fileview'
 // 非首屏的重页面（蜂群/Git 面板/浏览器/手机镜像/插件）按路由懒加载：切到对应 tab 才拉 chunk，
@@ -61,12 +62,15 @@ interface ClaudeInfo { running: boolean; file?: string; dir?: string }
 const { Sider, Content } = Layout
 const { Text } = Typography
 
-// 「会话」「蜂群」不再进导航：项目页是唯一主入口（任务驱动，08 设计）——
-// 蜂群从项目编队 tab 进（蜂群台深链 #/swarm/<名>），会话平铺页留 #/sessions 直达；
-// 两页组件与路由都保留，概览页统计仍可跳转。
+// 「蜂群」不进导航：项目页是唯一主入口（任务驱动，08 设计），蜂群从项目编队 tab 进
+// （蜂群台深链 #/swarm/<名>）。
+// 「会话」在 NAV 里但不进桌面侧栏两组：桌面从项目页/概览进，命令面板能搜到；
+// 手机则**必须**有个导航入口——此前它只能从概览的「全部会话」链接进，而搜索、筛选、
+// Worktree 管理、新建竞赛全在那一页（13 §6）。
 const NAV = [
   { key: 'overview', labelKey: 'nav.overview' },
   { key: 'projects', labelKey: 'nav.projects' },
+  { key: 'sessions', labelKey: 'nav.sessions' },
   { key: 'files', labelKey: 'nav.files' },
   { key: 'browser', labelKey: 'nav.browser' },
   { key: 'phone', labelKey: 'nav.phone' },
@@ -81,7 +85,10 @@ const NAV_TOOLS = ['browser', 'phone', 'plugins']
 
 // 手机底栏只放高频页，plugins/settings 折进「更多」，避免底栏拥挤（桌面侧栏仍展示全部）
 const MOBILE_NAV_KEYS = ['overview', 'projects', 'files']
-const MOBILE_MORE_KEYS = ['browser', 'phone', 'plugins', 'settings']
+// 「更多」sheet 里的两段：会话属于工作区主线，不归到工具下面
+const MOBILE_MORE_WORKSPACE = ['sessions']
+const MOBILE_MORE_TOOLS = ['browser', 'phone', 'plugins', 'settings']
+const MOBILE_MORE_KEYS = [...MOBILE_MORE_WORKSPACE, ...MOBILE_MORE_TOOLS]
 
 // 用 Canvas 容器查询排版的页面（见 index.css 的 .tt-canvas[data-cq]）。逐页开，
 // 不是全局开：container-type 会改变 fixed 后代的包含块。
@@ -107,7 +114,7 @@ function setHashParams(params: Record<string, string>) {
   for (const [k, v] of Object.entries(params)) { if (v) sp.set(k, v) }
   const qs = sp.toString()
   const next = qs ? base + '?' + qs : base
-  if (h !== next) history.replaceState(null, '', next)
+  if (h !== next) history.replaceState(history.state, '', next)
 }
 
 // URL 上的终端标签参数（terms=打开的标签、active=当前标签）。
@@ -788,8 +795,14 @@ export default function App() {
 
       {isMobile && (
         <MobileSheet open={moreOpen} title={t('common.more')} onClose={() => setMoreOpen(false)}>
+          <SheetSection>{t('nav.groupWorkspace')}</SheetSection>
+          {MOBILE_MORE_WORKSPACE.map((key) => {
+            const n = NAV.find((x) => x.key === key)!
+            return <SheetRow key={n.key} icon={ICONS[n.key]} title={t(n.labelKey)}
+              onClick={() => { setMoreOpen(false); go(n.key) }} />
+          })}
           <SheetSection>{t('nav.groupTools')}</SheetSection>
-          {MOBILE_MORE_KEYS.map((key) => {
+          {MOBILE_MORE_TOOLS.map((key) => {
             const n = NAV.find((x) => x.key === key)!
             return <SheetRow key={n.key} icon={ICONS[n.key]} title={t(n.labelKey)}
               onClick={() => { setMoreOpen(false); go(n.key) }} />
@@ -811,7 +824,7 @@ export default function App() {
 
       {/* 手机/平板：全屏会话覆盖层（桌面用右侧停靠栏，不走这里）*/}
       {isMobile && overlay && (
-        <div style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'var(--bg-term)', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ position: 'fixed', inset: 0, zIndex: 'var(--z-session)' as unknown as number, background: 'var(--bg-term)', display: 'flex', flexDirection: 'column' }}>
           {termPane}
         </div>
       )}
@@ -1734,11 +1747,15 @@ function TerminalPane(props: {
           <FileBrowser dir={cwd} accent="#58a6ff" layout="dock" onClose={() => setShowFiles(false)} />
         </FloatingFileDrawer>
       )}
-      <FloatingFileDrawer open={showGit} right={fileDock === 'right' && showFiles ? 'min(420px, 92vw)' : 0}>
+      {/* 手机走全屏二级页（13 §6）：420 的浮层在 360 屏上盖到 92vw，还压着底栏、不吃安全区。
+          桌面维持右缘浮动面板不变。layer="session" —— 这一层是从会话全屏(100)里唤起的。 */}
+      <AdaptivePanel open={showGit} desktop="floating" layer="session" title={t('git.title')}
+        width="min(420px, 92vw)" right={fileDock === 'right' && showFiles ? 'min(420px, 92vw)' : 0}
+        onClose={() => setShowGit(false)}>
         <Suspense fallback={<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}><Spin /></div>}>
           <GitPanel dir={cwd} accent="#58a6ff" onClose={() => setShowGit(false)} />
         </Suspense>
-      </FloatingFileDrawer>
+      </AdaptivePanel>
     </div>
   )
 }

--- a/frontend/src/FloatingFileDrawer.tsx
+++ b/frontend/src/FloatingFileDrawer.tsx
@@ -1,6 +1,13 @@
+// 桌面右侧浮动面板：文件树 / Git 停靠在工作区右缘。
+// 手机不走这里——那一档由 MobileSubPage 接管（13 §6），入口统一在 shell/AdaptivePanel。
 import type { ReactNode } from 'react'
 
-export default function FloatingFileDrawer({ open, children, right = 0 }: { open: boolean; children: ReactNode; right?: number | string }) {
+export default function FloatingFileDrawer({ open, children, right = 0, width = 'min(420px, 92vw)' }: {
+  open: boolean
+  children: ReactNode
+  right?: number | string
+  width?: number | string
+}) {
   if (!open) return null
   return (
     <div
@@ -11,14 +18,17 @@ export default function FloatingFileDrawer({ open, children, right = 0 }: { open
         right,
         bottom: 0,
         height: '100dvh',
-        zIndex: 1200,
-        width: 'min(420px, 92vw)',
+        // 具名层取代魔数 1200：压过 sheet(1000)，低于 antd 弹层基座(1300)
+        zIndex: 'var(--z-panel)' as unknown as number,
+        width,
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
         background: 'var(--bg-container)',
         borderLeft: '1px solid var(--border)',
         boxShadow: 'var(--elevated-shadow)',
+        paddingTop: 'var(--safe-t)',
+        paddingBottom: 'var(--safe-b)',
         pointerEvents: 'auto',
       }}
     >

--- a/frontend/src/GitPanel.tsx
+++ b/frontend/src/GitPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from './git/parts'
 import type { RawCommit } from './git/graph'
 import { useLayout } from './layout'
+import { useBackDismiss } from './shell/useBackDismiss'
 
 const WorktreePanel = lazy(() => import('./WorktreePanel'))
 
@@ -134,6 +135,8 @@ export default function GitPanel({ dir, accent = '#58a6ff', onClose, openTerm, i
   // 面板宽度各处不同（会话 420 / 项目 520），所以量自己的左边缘，别写死。
   const panelRef = useRef<HTMLDivElement>(null)
   const { desktop: wide } = useLayout()
+  // 窄档：返回键先关 diff 详情（面板本身由外面的二级页接管，一次返回退一层）
+  useBackDismiss(!wide && !!detail, () => setDetail(null))
   const [panelLeft, setPanelLeft] = useState(0)
   useEffect(() => {
     const on = () => {
@@ -555,25 +558,33 @@ export default function GitPanel({ dir, accent = '#58a6ff', onClose, openTerm, i
     </div>
   )
 
+  // ⋯ 与 ↻：桌面在标题行右端；窄档标题行整行不渲染（页头已经是「← Git」），
+  // 这两枚挪到分支行右端——否则会留下一条只有两个图标的空带。
+  const headerActs = (<>
+    {status?.repo && (
+      <Dropdown trigger={['click']} menu={{ items: moreItems, onClick: onMore }} placement="bottomRight" disabled={busy}>
+        <Button type="text" size="small" style={{ width: 24, height: 24, minWidth: 24, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flex: '0 0 auto' }}><MoreIcon /></Button>
+      </Dropdown>
+    )}
+    <Tooltip title={t('git.refresh')}>
+      <Button type="text" size="small" onClick={refresh} style={{ width: 24, height: 24, minWidth: 24, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flex: '0 0 auto' }}><RefreshIcon /></Button>
+    </Tooltip>
+  </>)
+
   const header = (
     <div style={{ padding: '6px 8px 8px', borderBottom: '1px solid var(--border-subtle)', flex: '0 0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span style={{ color: accent, display: 'inline-flex' }}><BranchIcon /></span>
-        <span style={{ color: 'var(--text-bright)', fontWeight: 600, fontSize: 13 }}>{t('git.panelTitle')}</span>
-        <span style={{ flex: 1 }} />
-        {status?.repo && (
-          <Dropdown trigger={['click']} menu={{ items: moreItems, onClick: onMore }} placement="bottomRight" disabled={busy}>
-            <Button type="text" size="small" style={{ width: 24, height: 24, minWidth: 24, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><MoreIcon /></Button>
-          </Dropdown>
-        )}
-        <Tooltip title={t('git.refresh')}>
-          <Button type="text" size="small" onClick={refresh} style={{ width: 24, height: 24, minWidth: 24, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><RefreshIcon /></Button>
-        </Tooltip>
-        {onClose && <button type="button" title={t('git.closePanel')} aria-label={t('git.closePanel')} className="tt-file-close" onClick={onClose}><CloseIcon /></button>}
-      </div>
+      {wide && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ color: accent, display: 'inline-flex' }}><BranchIcon /></span>
+          <span style={{ color: 'var(--text-bright)', fontWeight: 600, fontSize: 13 }}>{t('git.panelTitle')}</span>
+          <span style={{ flex: 1 }} />
+          {headerActs}
+          {onClose && <button type="button" title={t('git.closePanel')} aria-label={t('git.closePanel')} className="tt-file-close" onClick={onClose}><CloseIcon /></button>}
+        </div>
+      )}
 
       {status?.repo && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 7, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: wide ? 7 : 0, minWidth: 0 }}>
           <Popover trigger="click" placement="bottomLeft" content={switcher} arrow={false}>
             <button type="button" title={t('git.refs.switchBranch')}
               style={{
@@ -601,6 +612,8 @@ export default function GitPanel({ dir, accent = '#58a6ff', onClose, openTerm, i
             <span style={{ fontSize: 11, color: 'var(--text-dimmer)', fontFamily: MONO, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
               title={status.upstream}>{status.upstream}</span>
           )}
+          {!wide && <span style={{ flex: 1 }} />}
+          {!wide && headerActs}
         </div>
       )}
 
@@ -850,7 +863,9 @@ export default function GitPanel({ dir, accent = '#58a6ff', onClose, openTerm, i
       {wide && detail && (
         <div className="tt-file-detail"
           style={{
-            position: 'fixed', top: 0, bottom: 0, height: '100dvh', zIndex: 1199,
+            // 紧贴在右侧浮动面板之下：详情从面板里划出来，视觉上是面板的左邻
+            position: 'fixed', top: 0, bottom: 0, height: '100dvh',
+            zIndex: 'calc(var(--z-panel) - 1)' as unknown as number,
             right: `calc(100vw - ${Math.max(0, panelLeft)}px)`,
             width: `min(560px, ${Math.max(240, panelLeft - 40)}px)`,
             background: 'var(--bg-base)', borderLeft: '1px solid var(--border)', boxShadow: 'var(--elevated-shadow)',

--- a/frontend/src/MobileSubPage.tsx
+++ b/frontend/src/MobileSubPage.tsx
@@ -1,26 +1,55 @@
 // 移动端二级页：Android Fragment 式全屏覆盖层——列表页点某项后，详情在上层整页展开。
 // 传 title 则带「← 返回 + 标题」顶栏；不传则无顶栏（内容自带返回入口，如 FileView 的 onBack）。
-// z-index 90：盖过底部导航(50)，低于全屏会话覆盖层(100)与 antd 弹层(≥1000)。
+//
+// 三件事是这一层的契约（13 §4.3 / §8.1）：
+//   ① **portal 到 body**。开了容器查询的页面（`.tt-canvas[data-cq="on"]`）上，
+//      `container-type` 会让 canvas 成为 fixed 后代的包含块——不 portal 的话，
+//      从那种页面里唤起的二级页会被裁进 canvas 而不是铺满视口。
+//   ② **四边吃安全区**，底部再与软键盘取大：`max(var(--kb), var(--safe-b))`。
+//      iOS Safari 没有 VirtualKeyboard API，--kb 只能从 visualViewport 推，所以取大
+//      而不是相加，键盘收起时至少还留安全区。
+//   ③ **接管返回键**：安卓物理返回应该收掉这一层，而不是把整个路由退掉。
+// 层级：--z-subpage(90) 盖过底栏(50)；从会话全屏(100)里唤起时传 layer="session"
+// 换成 --z-session-sub(110)，否则 portal 之后不再嵌套在会话那个层叠上下文里，会被盖住。
 import { type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { useI18n } from './i18n'
+import { useBackDismiss } from './shell/useBackDismiss'
 
-export default function MobileSubPage({ title, onBack, children }: {
+export default function MobileSubPage({ title, onBack, layer = 'page', children }: {
   title?: ReactNode
   onBack: () => void
+  /** 'session' = 从会话全屏覆盖层里唤起（Git / 文件） */
+  layer?: 'page' | 'session'
   children: ReactNode
 }) {
   const { t } = useI18n()
-  return (
+  useBackDismiss(true, onBack)
+
+  const node = (
     <div style={{
-      position: 'fixed', inset: 0, zIndex: 90, background: 'var(--bg-base)',
-      display: 'flex', flexDirection: 'column', paddingTop: 'env(safe-area-inset-top)',
+      position: 'fixed', inset: 0, background: 'var(--bg-base)',
+      zIndex: `var(${layer === 'session' ? '--z-session-sub' : '--z-subpage'})` as unknown as number,
+      display: 'flex', flexDirection: 'column',
+      paddingTop: 'var(--safe-t)', paddingLeft: 'var(--safe-l)', paddingRight: 'var(--safe-r)',
+      paddingBottom: 'max(var(--kb), var(--safe-b))',
     }}>
       {title !== undefined && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 8px', borderBottom: '1px solid var(--border)', background: 'var(--bg-container)' }}>
-          <button onClick={onBack} title={t('common.back')} style={{ border: 0, background: 'none', color: 'var(--text-bright)', padding: '6px 10px', display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}>
+        <div style={{
+          flex: '0 0 auto', display: 'flex', alignItems: 'center', gap: 2,
+          padding: 'var(--sp-1)', borderBottom: '1px solid var(--border)', background: 'var(--bg-container)',
+        }}>
+          <button onClick={onBack} title={t('common.back')} aria-label={t('common.back')} style={{
+            width: 'var(--tap)', height: 'var(--tap)', flex: '0 0 auto',
+            border: 0, background: 'none', color: 'var(--text-bright)',
+            display: 'grid', placeItems: 'center', cursor: 'pointer',
+          }}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
           </button>
-          <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</div>
+          <div style={{
+            flex: 1, minWidth: 0, fontSize: 'var(--fs-body)', fontWeight: 600,
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{title}</div>
         </div>
       )}
       <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
@@ -28,4 +57,5 @@ export default function MobileSubPage({ title, onBack, children }: {
       </div>
     </div>
   )
+  return typeof document === 'undefined' ? node : createPortal(node, document.body)
 }

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -16,6 +16,7 @@ import { useI18n } from './i18n'
 import { usePreferences } from './preferences'
 import { INTENT_EVENT, takeIntent } from './intents'
 import { MobileSheet, SheetRow } from './shell/MobileSheet'
+import AdaptivePanel from './shell/AdaptivePanel'
 import { useLayout } from './layout'
 import { detectPrompt } from './prompt'
 import { relTime, taskNameFromPrompt, shq, NewSessionModal, DirPicker, recentDirs, pushRecentDir, CloseWorktreeModal } from './App'
@@ -108,7 +109,12 @@ const PRJ_CSS = `
 .prj-row.on{background:var(--accent-soft);box-shadow:inset 0 0 0 1px var(--accent-border)}
 .prj-row.on::before{background:var(--accent)}
 .prj-row .acts{opacity:.55;transition:opacity .15s;display:flex;gap:12px;font-size:12.5px;flex:0 0 auto;margin-top:3px}
-.prj-row:hover .acts{opacity:1}
+.prj-row:hover .acts,.prj-row .acts:focus-within{opacity:1}
+/* 手指档没有 hover：半透明的操作等于不存在（13 §7） */
+html[data-pointer="coarse"] .prj-row .acts{opacity:1}
+html[data-pointer="coarse"] .prj-row .acts a{position:relative}
+html[data-pointer="coarse"] .prj-row .acts a::after{content:'';position:absolute;left:-6px;right:-6px;
+  top:50%;height:var(--tap);transform:translateY(-50%)}
 .prj-row.warn{background:rgba(210,153,34,.05);border:1px solid rgba(210,153,34,.18);margin-bottom:4px}
 .prj-row.warn:hover{background:rgba(210,153,34,.09)}
 .prj-row.warn::before{display:none}
@@ -159,6 +165,7 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
 /* 次要操作 hover 才出现，但键盘走到时同样要看得见——否则纯键盘用户够不着（14 §6.1） */
 .prj-card:focus-within .prj-acts,.prj-card:focus-visible .prj-acts{opacity:1}
 .prj-card:hover .prj-acts{opacity:1}
+html[data-pointer="coarse"] .prj-card .prj-acts{opacity:1}
 .prj-card .prj-acts .pinned{opacity:1}
 
 .prj-panel{background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:12px;margin-top:8px}
@@ -195,6 +202,7 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
 .prj-fork .wt-ab.up{color:#3fb950} .prj-fork .wt-ab.dn{color:#d29922}
 .prj-fork .wt-acts{flex:0 0 auto;display:flex;gap:6px;align-items:center;opacity:.55;transition:opacity .15s}
 .prj-fork:hover .wt-acts,.prj-fork .wt-acts:focus-within{opacity:1}
+html[data-pointer="coarse"] .prj-fork .wt-acts{opacity:1}
 .prj-fork.merged .col,.prj-fork.ext .col{opacity:.75}
 `
 
@@ -1680,15 +1688,15 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh, 
 
         <Suspense fallback={<Spin />}>
           {wtOpen && <WorktreePanel open={wtOpen} onClose={() => { setWtOpen(false); refresh() }} openTerm={openTerm} initialDir={dir} />}
-          {(gitOpen || gitAt) && (
-            <div style={{ position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(1,4,9,.6)' }} onClick={() => { setGitOpen(false); setGitAt(null) }}>
-              <div style={{ position: 'absolute', top: 0, right: 0, bottom: 0, width: 'min(520px, 94vw)', background: 'var(--bg-container)', borderLeft: '1px solid var(--border)' }}
-                onClick={(e) => e.stopPropagation()}>
-                <GitPanel dir={gitAt?.dir || dir} initialTab={gitAt?.tab} openTerm={openTerm}
-                  onClose={() => { setGitOpen(false); setGitAt(null) }} />
-              </div>
-            </div>
-          )}
+          {/* 手机走全屏二级页；桌面仍是右缘面板 + 遮罩。原来这里是一套手搓的
+              zIndex:1000 遮罩 + 面板，和会话页那套 FloatingFileDrawer 宽度/层级/阴影全不一样——
+              同一个 GitPanel 不该有两套壳（13 §6）。 */}
+          <AdaptivePanel open={!!(gitOpen || gitAt)} desktop="floating" scrim
+            title={t('git.title')} width="min(520px, 94vw)"
+            onClose={() => { setGitOpen(false); setGitAt(null) }}>
+            <GitPanel dir={gitAt?.dir || dir} initialTab={gitAt?.tab} openTerm={openTerm}
+              onClose={() => { setGitOpen(false); setGitAt(null) }} />
+          </AdaptivePanel>
           {raceOpen && <RaceCreateModal open={raceOpen} onClose={() => setRaceOpen(false)} onDone={() => { setRaceOpen(false); refresh() }} />}
           {swarmOpen && (
             <NewSwarmModal open={swarmOpen} initialDir={dir} lockDir

--- a/frontend/src/WorktreePanel.tsx
+++ b/frontend/src/WorktreePanel.tsx
@@ -10,10 +10,13 @@ import { useI18n } from './i18n'
 import { recentDirs } from './App'
 import DiffView from './DiffView'
 import { useLayout } from './layout'
+import AdaptivePanel from './shell/AdaptivePanel'
+import { useBackDismiss } from './shell/useBackDismiss'
 
-// 会话视图的 Git 面板挂在 FloatingFileDrawer(z=1200)里，本抽屉从那里打开时必须压过它，
+// 会话视图的 Git 面板挂在右侧浮动面板(--z-panel)里，本抽屉从那里打开时必须压过它，
 // 否则整个抽屉被 Git 面板盖住（antd Drawer 默认 z=1000）。抽屉内嵌套弹层 antd 会自动抬升，
 // 但 modal.confirm 走 App 级 holder 不在抽屉上下文里，须显式再高一级。
+// 手机档不走 Drawer——AdaptivePanel 会换成全屏二级页，这两个常量只对桌面生效。
 const DRAWER_Z = 1300
 const MODAL_Z = 1400
 
@@ -73,6 +76,8 @@ export default function WorktreePanel({ open, onClose, openTerm, initialDir }: {
   const [creatingWt, setCreatingWt] = useState(false)
   // 对比 base：committed 与 workingTree 分开呈现 + 逐文件补丁
   const [cmp, setCmp] = useState<Worktree | null>(null)
+  // 窄档：返回键先关对比视图，再关面板本身（一次返回退一层）
+  useBackDismiss(!wide && !!cmp, () => setCmp(null))
   const [cmpData, setCmpData] = useState<any>(null)
   const [cmpFile, setCmpFile] = useState('')
   const [cmpText, setCmpText] = useState('')
@@ -415,8 +420,11 @@ export default function WorktreePanel({ open, onClose, openTerm, initialDir }: {
   })()
 
   return (
-    <Drawer open={open} onClose={onClose} title={t('worktree.title')} width={wide ? 520 : '100%'} zIndex={DRAWER_Z}
-      styles={{ body: { display: 'flex', flexDirection: 'column', gap: 0, paddingTop: 14 } }}>
+    // 手机走全屏二级页（13 §6）：全宽的 antd Drawer「既不是页也不是 sheet」——
+    // 从右横切进场、右上角一个 ×、返回键不认它。桌面维持 520 抽屉不变。
+    <AdaptivePanel open={open} onClose={onClose} title={t('worktree.title')}
+      desktop="drawer" width={520} zIndex={DRAWER_Z}
+      drawerStyles={{ body: { display: 'flex', flexDirection: 'column', gap: 0, paddingTop: 14 } }}>
       {/* 头部：仓库目录（留空 = 跨仓库总览）+ 新建 + 刷新 */}
       <div style={{ display: 'flex', gap: 8 }}>
         <AutoComplete style={{ flex: 1, minWidth: 0 }} value={dir} onChange={setDir} allowClear
@@ -563,6 +571,6 @@ export default function WorktreePanel({ open, onClose, openTerm, initialDir }: {
           </div>
         )}
       </Modal>
-    </Drawer>
+    </AdaptivePanel>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -95,8 +95,10 @@
   --z-nav: 50;                    /* 底栏 / 导航轨 */
   --z-subpage: 90;                /* 全屏二级页 */
   --z-session: 100;               /* 会话全屏 */
+  --z-session-sub: 110;           /* 会话全屏里再开的二级页（Git/文件从终端里唤起） */
   --z-scrim: 900;                 /* 遮罩 */
   --z-sheet: 1000;                /* 底部 sheet / 抽屉 */
+  --z-panel: 1200;                /* 桌面右侧浮动面板：压过 sheet(1000)，低于 antd 弹层基座(1300) */
   --z-popup: 1300;                /* antd 弹层基座 */
   --z-toast: 1500;
   --z-drag: 9999;                 /* 拖拽幽灵 */
@@ -760,7 +762,10 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
 .tt-file-context-menu { width: max-content !important; min-width: 130px !important; }
 /* Git 分组标题上的操作按钮：平时半透明，hover 分组时变实 */
 .cc-git-section-act .cc-dl { opacity: .5; }
-.cc-git-section:hover .cc-git-section-act .cc-dl { opacity: 1; }
+.cc-git-section:hover .cc-git-section-act .cc-dl,
+.cc-git-section-act .cc-dl:focus-visible { opacity: 1; }
+/* 手指档没有 hover（13 §7） */
+html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
 .cc-dl:hover { background: rgba(255, 255, 255, .08); color: var(--text-bright) !important; }
 .cc-filerow .ant-btn { color: var(--text-dim); }
 .cc-filerow .ant-btn:hover { color: var(--text-bright) !important; background: rgba(255, 255, 255, .06) !important; }

--- a/frontend/src/shell/AdaptivePanel.tsx
+++ b/frontend/src/shell/AdaptivePanel.tsx
@@ -1,0 +1,61 @@
+// 一棵组件树，两种容器（13 §6）。
+//
+// Git 面板和 Worktree 在手机上一直是桌面抽屉：420/520 的浮层压在底栏上、不吃安全区、
+// 返回键不认它。但面板本体（GitPanel / WorktreePanel）没有问题，问题全在**容器**——
+// 所以这里只换壳：手机档给 MobileSubPage（整页 + ← + 返回键），桌面维持原样。
+//
+// 桌面两种形态都要保留，它们的差别是历史形成的、也确实合理：
+//   floating —— 会话页/项目页的 Git，停在右缘，不遮挡左边正在看的内容；
+//   drawer   —— Worktree，antd Drawer，层级要压过 floating 面板（它可以从 Git 里唤起）。
+import { type ReactNode } from 'react'
+import { Drawer } from 'antd'
+import { useLayout } from '../layout'
+import MobileSubPage from '../MobileSubPage'
+import FloatingFileDrawer from '../FloatingFileDrawer'
+
+export default function AdaptivePanel({
+  open, title, onClose, desktop, width, right, scrim, zIndex, drawerStyles, layer, children,
+}: {
+  open: boolean
+  /** 手机二级页的页头标题；桌面的 floating 形态不用它（面板自带头） */
+  title: ReactNode
+  onClose: () => void
+  desktop: 'floating' | 'drawer'
+  width?: number | string
+  /** floating：距右缘的偏移（文件抽屉已经占了右边时往左让） */
+  right?: number | string
+  /** floating：是否带点击关闭的遮罩 */
+  scrim?: boolean
+  zIndex?: number
+  drawerStyles?: Record<string, any>
+  /** 'session' = 从会话全屏覆盖层里唤起，手机档要换更高的层 */
+  layer?: 'page' | 'session'
+  children: ReactNode
+}) {
+  const { phone } = useLayout()
+  if (!open) return null
+
+  if (phone) {
+    return <MobileSubPage title={title} onBack={onClose} layer={layer}>{children}</MobileSubPage>
+  }
+
+  if (desktop === 'drawer') {
+    return (
+      <Drawer open={open} onClose={onClose} title={title} width={width} zIndex={zIndex} styles={drawerStyles}>
+        {children}
+      </Drawer>
+    )
+  }
+
+  return (
+    <>
+      {scrim && (
+        <div onClick={onClose} style={{
+          position: 'fixed', inset: 0, background: 'rgba(1,4,9,.6)',
+          zIndex: 'var(--z-scrim)' as unknown as number,
+        }} />
+      )}
+      <FloatingFileDrawer open={open} right={right} width={width}>{children}</FloatingFileDrawer>
+    </>
+  )
+}

--- a/frontend/src/shell/MobileSheet.tsx
+++ b/frontend/src/shell/MobileSheet.tsx
@@ -5,8 +5,9 @@
 //
 // 吃 --kb：键盘弹起时整块抬到键盘之上；吃安全区：底部不压在手势条下面。
 // 层级用 --z-sheet / --z-scrim 两个令牌，不再手算 1199/1200/1201。
-import { useEffect, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { useI18n } from '../i18n'
+import { useBackDismiss } from './useBackDismiss'
 
 export function MobileSheet({ open, title, onClose, children }: {
   open: boolean
@@ -15,13 +16,9 @@ export function MobileSheet({ open, title, onClose, children }: {
   children: ReactNode
 }) {
   const { t } = useI18n()
-  // 打开时接管返回：安卓物理返回键应该收 sheet，而不是退出整个页面
-  useEffect(() => {
-    if (!open) return
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open, onClose])
+  // 打开时接管返回：安卓物理返回键应该收 sheet，而不是退出整个页面。
+  // （Escape 也由它一并处理——此前这里只监听了 Escape，而手机上没有 Escape 键。）
+  useBackDismiss(open, onClose)
 
   if (!open) return null
   return (

--- a/frontend/src/shell/SessionDock.tsx
+++ b/frontend/src/shell/SessionDock.tsx
@@ -112,6 +112,13 @@ export function SessionSwitchSheet({ open, sessions, active, needsInput, running
           )}
         />
       ))}
+      {/* 这张 sheet 只列「开着的终端」；搜索、筛选、Worktree 管理、新建竞赛都在会话页。
+          你正想着会话的时候就在这儿，入口放这里比绕回概览近得多。 */}
+      <SheetRow
+        icon={<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="14" y2="17" /></svg>}
+        title={t('project.allSessions')}
+        onClick={() => { onClose(); location.hash = '#/sessions' }}
+      />
     </MobileSheet>
   )
 }

--- a/frontend/src/shell/back-dismiss.test.ts
+++ b/frontend/src/shell/back-dismiss.test.ts
@@ -1,0 +1,93 @@
+// 返回键栈的行为契约（13 §4.3）。这里只测纯栈逻辑：history 用注入的假函数，
+// 断言的是「谁被关掉了、发了几次 back」，不依赖 jsdom 的 history 实现。
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { pushFrame, retireFrame, handlePop, handleHashChange, stackSize, resetStack } from './useBackDismiss'
+
+describe('back-dismiss stack', () => {
+  beforeEach(() => resetStack())
+
+  const flush = () => new Promise<void>((r) => queueMicrotask(() => r()))
+
+  it('UI 关闭会退掉自己压的那条记录，且迟到的 popstate 不再回调', async () => {
+    const back = vi.fn()
+    const dismiss = vi.fn()
+    const id = pushFrame(dismiss, () => {})
+    expect(stackSize()).toBe(1)
+
+    retireFrame(id, back)
+    expect(stackSize()).toBe(0)
+    await flush()
+    expect(back).toHaveBeenCalledTimes(1) // ← 漏了这一次就会留下死记录
+
+    expect(handlePop()).toBeNull() // 自己发的 back 回来了，吞掉
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+
+  it('返回键关闭：一次 popstate 只退一帧', () => {
+    const a = vi.fn(); const b = vi.fn()
+    pushFrame(a, () => {})
+    pushFrame(b, () => {})
+
+    handlePop()
+    expect(b).toHaveBeenCalledTimes(1)
+    expect(a).not.toHaveBeenCalled()
+    expect(stackSize()).toBe(1)
+
+    handlePop()
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(stackSize()).toBe(0)
+  })
+
+  it('被返回键关掉之后，组件卸载时的 retire 不再发 back', async () => {
+    const back = vi.fn()
+    const id = pushFrame(vi.fn(), () => {})
+    handlePop()            // 用户按了返回
+    retireFrame(id, back)  // 组件随后卸载
+    await flush()
+    expect(back).not.toHaveBeenCalled()
+  })
+
+  // StrictMode 开发态：mount → unmount → mount，退帧的 back() 还在路上时新帧已压好。
+  // 按帧标记会把那条迟到的 popstate 当成用户返回，表现为「面板一打开就自己关了」。
+  it('StrictMode 双挂载：同步 remount 复用记录，一次 history 都不发', async () => {
+    const push = vi.fn(); const back = vi.fn()
+    const id1 = pushFrame(vi.fn(), push)
+    retireFrame(id1, back)         // 清理
+    pushFrame(vi.fn(), push)       // 同一 tick 内重新挂载
+    await flush()
+    expect(push).toHaveBeenCalledTimes(1) // 第二次 push 复用了第一条记录
+    expect(back).not.toHaveBeenCalled()   // 那条记录没被退掉，自然也不用补回来
+    expect(stackSize()).toBe(1)
+  })
+
+  it('迟到的 popstate 不会关掉新帧', async () => {
+    const second = vi.fn()
+    const id1 = pushFrame(vi.fn(), () => {})
+    retireFrame(id1, () => {})
+    await flush()                  // back 真的发出去了
+    pushFrame(second, () => {})    // 之后才重新挂载
+    handlePop()                    // 第一次 back 的 popstate 迟到
+    expect(second).not.toHaveBeenCalled()
+    expect(stackSize()).toBe(1)
+  })
+
+  it('路由变了：所有存活帧一起关掉，且不动 history', () => {
+    const a = vi.fn(); const b = vi.fn()
+    pushFrame(a, () => {})
+    pushFrame(b, () => {})
+    handleHashChange()
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+    expect(stackSize()).toBe(0)
+  })
+
+  it('关闭中间层：只摘帧，不动 history（back 会退掉别人的记录）', async () => {
+    const back = vi.fn()
+    const id1 = pushFrame(vi.fn(), () => {})
+    pushFrame(vi.fn(), () => {})
+    retireFrame(id1, back)
+    await flush()
+    expect(back).not.toHaveBeenCalled()
+    expect(stackSize()).toBe(1)
+  })
+})

--- a/frontend/src/shell/useBackDismiss.ts
+++ b/frontend/src/shell/useBackDismiss.ts
@@ -1,0 +1,145 @@
+// 手机覆盖层的返回键（13 §4.3）：二级页与 sheet 都应该被安卓物理返回键收掉，
+// 而不是把整个路由退掉、覆盖层还留在屏幕上。
+//
+// 应用是 hash 路由（App.tsx 只听 hashchange），所以覆盖层压的那条 history 记录
+// **必须是同一个 URL**：`pushState(state, '', location.href)` 不触发 hashchange，
+// 路由完全看不见它。
+//
+// 三条容易漏的规则，缺一条就退化成「按一次返回没反应，再按一次直接退出」：
+//   ① UI 关闭（← / × / 遮罩 / Esc）也要 history.back() 把那条记录退掉，否则留下死记录；
+//   ② 一次 popstate 只退一帧——嵌套的 diff → Git → sheet 才能按一次退一层；
+//   ③ 栈非空时若发生 hashchange（路由真的变了），所有存活帧一起关掉：
+//      覆盖层在路由变化之后一定是过期的。
+//
+// **不要**把标记塞进 history.state 再读回来：App 的 setHashParams 每次开关终端标签
+// 都会 replaceState 一次，标记会被抹掉。模块级 LIFO 栈是唯一事实来源。
+//
+// 「我们自己发的 back」用一个计数器记，不是每帧一个 closing 标志：计数器与具体是
+// 哪一帧无关，帧被复用/换掉都不影响吞噬判定。
+// 配套的是 scheduleRetire——退帧的 back() 延到微任务发，同一 tick 内又压帧就复用那条
+// 记录。两者一起才扛得住 StrictMode 的 mount→unmount→mount（实测不做的话表现为
+// 「按一次返回退了两页」）。
+//
+// 已知缺口：antd 的 Dropdown/Popover/Modal 门户不在这个栈里，返回键会越过它们、
+// 关掉底下的二级页。影响最大的两处（GitPanel 的 diff 详情、WorktreePanel 的对比）
+// 各自单独挂了本 hook；通用的「先关最上层 antd 弹层」桥接留待后续。
+import { useEffect, useRef } from 'react'
+
+export type Frame = { id: number; onDismiss: () => void }
+
+// ── 纯栈逻辑（导出给测试；组件侧只用下面的 hook）─────────────────────
+const stack: Frame[] = []
+let seq = 0
+/** 我们自己发出、还没回来的 history.back() 条数 */
+let pendingSelfBack = 0
+
+export function stackSize(): number { return stack.length }
+
+/**
+ * 退帧的 back() **延到微任务**再发，中间新压了帧就直接复用那条记录。
+ *
+ * 这是 StrictMode 的解药：开发态 mount→unmount→mount 是同步跑完的，
+ * 立刻发 back() 的话它是异步落地的，而第二次 mount 已经又 push 了一条——
+ * 两者交错会把当前位置挪到别人的记录上，表现成「按一次返回退了两页」。
+ * 复用记录之后，双挂载净效果是 0 次 history 操作。
+ */
+let pendingRetire: (() => void) | null = null
+let flushScheduled = false
+function scheduleRetire(back: () => void) {
+  pendingRetire = back
+  if (flushScheduled) return
+  flushScheduled = true
+  queueMicrotask(() => {
+    flushScheduled = false
+    const run = pendingRetire
+    pendingRetire = null
+    if (!run) return // 被新帧复用了
+    pendingSelfBack++
+    run()
+  })
+}
+
+/** 打开：压一帧并返回它的 id。`push` 由调用方注入，测试里可以替身。 */
+export function pushFrame(onDismiss: () => void, push: () => void): number {
+  const f: Frame = { id: ++seq, onDismiss }
+  stack.push(f)
+  if (pendingRetire) pendingRetire = null // 复用上一帧还没退掉的那条记录
+  else push()
+  return f.id
+}
+
+/**
+ * UI 关闭 / 卸载：把这一帧退掉。
+ * 帧立刻出栈；只有它在栈顶时才动 history——被埋在下面说明别的东西已经先导航过了，
+ * 这时候 back() 退掉的会是别人的记录。
+ */
+export function retireFrame(id: number, back: () => void) {
+  const i = stack.findIndex((f) => f.id === id)
+  if (i < 0) return // 已经被 popstate 或 hashchange 收走了
+  const top = i === stack.length - 1
+  stack.splice(i, 1)
+  if (!top) return
+  scheduleRetire(back)
+}
+
+/** popstate：退一帧。返回被关掉的帧；是我们自己发的 back 则吞掉并返回 null。 */
+export function handlePop(): Frame | null {
+  if (pendingSelfBack > 0) { pendingSelfBack--; return null }
+  const f = stack.pop()
+  if (!f) return null
+  f.onDismiss()
+  return f
+}
+
+/** 路由变了：所有覆盖层一起关，栈清空（不碰 history——路由自己已经动过了） */
+export function handleHashChange() {
+  if (!stack.length) return
+  const live = stack.splice(0, stack.length)
+  for (const f of live) f.onDismiss()
+}
+
+/** 仅供测试：清干净模块级状态 */
+export function resetStack() {
+  stack.length = 0
+  seq = 0
+  pendingSelfBack = 0
+  pendingRetire = null
+}
+
+// ── 全局监听：整个应用只挂一次 ────────────────────────────────────
+let wired = false
+function wire() {
+  if (wired || typeof window === 'undefined') return
+  wired = true
+  window.addEventListener('popstate', () => { handlePop() })
+  window.addEventListener('hashchange', () => { handleHashChange() })
+}
+
+/**
+ * 覆盖层打开期间接管返回键。
+ *
+ * @param enabled 覆盖层是否处于打开态。传 false 时本 hook 什么都不做。
+ * @param onDismiss 关闭回调，必须幂等——路由兜底会直接调它。
+ */
+export function useBackDismiss(enabled: boolean, onDismiss: () => void): void {
+  // 回调放 ref：栈里存的是打开那一刻的闭包，不能让它拿到过期的 state
+  const cb = useRef(onDismiss)
+  cb.current = onDismiss
+
+  useEffect(() => {
+    if (!enabled) return
+    wire()
+    const id = pushFrame(() => cb.current(), () => {
+      history.pushState(history.state, '', location.href)
+    })
+    return () => { retireFrame(id, () => history.back()) }
+  }, [enabled])
+
+  // Escape 与返回键同义：桌面没有物理返回键，但有 Esc
+  useEffect(() => {
+    if (!enabled) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') cb.current() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [enabled])
+}


### PR DESCRIPTION
## 为什么

13 §6 的塌陷表里还剩两行没做：**Git 面板**与 **Worktree**。它们在手机上不是「窄了点」，是三个功能性故障：

| 故障 | 现状 |
|---|---|
| **盖住底栏** | 会话页 Git = `FloatingFileDrawer`（`fixed; min(420px,92vw); z-index:1200`），360 屏上盖到 92vw，底栏还在下面接点击 |
| **不吃安全区** | 两处都是 `top:0/bottom:0`，底部压在手势条下 |
| **返回键没人接** | `MobileSubPage` 没有任何 history 处理；`MobileSheet` 注释写着「接管返回」，实际只监听 Escape——手机上没有 Escape 键 |

外加：同一个 `GitPanel` 有**两套壳**（项目页是另一份手搓的 `zIndex:1000` 遮罩 + `min(520px,94vw)` 面板），Worktree 还是 `Drawer width='100%'`——13 §4.3 点名的「既不是页也不是 sheet」。

## 图纸

[`13-mobile-responsive/panels.html`](docs/design/web/13-mobile-responsive/panels.html) — 现状三帧 / 新版四帧 / 768 平板 / 1280 桌面回归基线 / 返回键状态机，末尾是**自审**（画完自己挑的 7 处毛病）与**落地后的两处修正**。

## 两个新基元

**`shell/useBackDismiss.ts`** — 模块级 LIFO 栈接管返回键：

- 压的是**同 URL** 的 history 记录（`pushState` 不触发 `hashchange`，hash 路由完全看不见它）
- **UI 关闭也必须 `history.back()`** 退掉那条记录，否则留死记录——用户按一次返回没反应、再按一次直接退出
- 一次 `popstate` 只退一帧：diff → Git → sheet 按一次退一层
- 栈非空时发生 `hashchange` 则全部关闭（覆盖层在路由变化后一定过期）
- 7 条单测

**`shell/AdaptivePanel.tsx`** — 一棵组件树两种容器：手机给 `MobileSubPage`，桌面维持 `floating`（会话页/项目页 Git）与 `drawer`（Worktree）两种形态。**面板本体不改**。

## 其他

- **`MobileSubPage`**：portal 到 body（`container-type` 会成为 `fixed` 后代的包含块，不 portal 会被裁进 canvas）；四边安全区 + `max(var(--kb), var(--safe-b))`；`layer="session"` 用 `--z-session-sub`，否则 portal 之后会被会话全屏盖住
- **手机会话入口**：此前**没有任何导航入口**能到会话列表页（搜索/筛选/Worktree 管理/新建竞赛都在那）。会话进 `NAV`（⌘K 也搜得到）+「更多」sheet 的**工作区**段；底栏保持四格（13 §4.1 算过五格会回到 72px）；会话坞切换 sheet 末尾加「全部会话」
- **粗指针兜底**：项目行 / 项目卡 / 分叉图 / Git 段落四处 hover-only 操作在手指档常显
- **z 魔数换令牌**：1200 → `--z-panel`，1199 → `calc(--z-panel - 1)`，100 → `--z-session`，新增 `--z-session-sub(110)`
- `setHashParams` 不再 `replaceState(null)`——它每次开关终端标签都跑，会抹掉 `history.state`

## 一个实测踩到的坑

StrictMode 下 `mount→unmount→mount` 是同步的，退帧的 `back()` 却异步落地，中间第二次 mount 又 push 了一条——交错后**表现为「按一次返回退了两页」**（CDP 实测复现）。解法：退帧的 back 延到微任务，同一 tick 内又压帧就复用那条记录，双挂载净效果 0 次 history 操作。单测覆盖。

## 验收

**390×844**（CDP，逐档 reload）
- Worktree / Git 均为全屏二级页，`z-index` 90 / 110，`scrollWidth == innerWidth`
- `elementFromPoint` 在底部落在二级页内，底栏不再可点
- 返回键：开 = +1 条记录且 `hashchange` 计数 0；按返回 → 面板关闭且 **hash 不变**；点 ← 关闭 → 消费掉自己那条记录（不留死记录）
- 粗指针档（`setTouchEmulationEnabled`）：`.prj-card .prj-acts` opacity `0.25 → 1`
- 更多 sheet 三段「工作区 / 工具 / 账户」，点会话 → `#/sessions`

**1440×900 桌面回归**：会话页 Git = 浮动面板 `z=1200`、项目页 = 520 面板 + 遮罩 `z=900`、Worktree = antd Drawer 1300，截图与改动前一致；侧栏不出现「会话」。

门禁：`typecheck` / `i18n:check`（1477 keys，零新增）/ `vitest`（95）/ `build` 全绿。

> 与 #148 相互独立（那是桌面版排布），都从 main 切出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
