### PR TITLE
桌面版面板：Git/Worktree 成为 Shell 的第三列（Inspector）

### DIFF
--- a/docs/design/web/14-desktop-workspace/panels-desktop.html
+++ b/docs/design/web/14-desktop-workspace/panels-desktop.html
@@ -1,0 +1,462 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><title>桌面版面板：Git / Worktree 进 Shell</title>
+<style>
+:root{
+  --bg:#0d1117;--card:#161b22;--inset:#0b0f14;--line:#21262d;--line2:#30363d;
+  --tx:#e6edf3;--dim:#8b949e;--dimmer:#6e7681;
+  --acc:#58a6ff;--solid:#4e90dc;--soft:rgba(31,111,235,.14);--accb:rgba(88,166,255,.45);
+  --amber:#d29922;--green:#3fb950;--purple:#a371f7;--cyan:#39c5cf;--red:#f85149;
+  --micro:11px;--meta:12px;--sm:13px;--body:15px;--lg:16px;
+  --r1:6px;--r2:10px;--r3:14px;--rp:999px;
+}
+*{box-sizing:border-box}
+body{margin:0;background:#07090d;color:var(--tx);font:14px/1.6 Inter,-apple-system,"PingFang SC",sans-serif}
+.wrap{max-width:1180px;margin:0 auto;padding:30px 22px 80px}
+h1{font-size:22px;margin:0 0 8px}
+h2{font-size:var(--lg);margin:38px 0 6px;padding-top:24px;border-top:1px solid var(--line)}
+.lede{color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch;margin:0 0 16px}
+.lede b{color:var(--tx)}
+code{font:var(--meta)/1.4 ui-monospace,monospace;color:#c9d5e2;background:rgba(148,163,184,.1);padding:2px 6px;border-radius:4px}
+ul.pts,ol.pts{margin:0 0 20px;padding-left:20px;color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch}
+ul.pts b,ol.pts b{color:var(--tx)}
+ul.pts em,ol.pts em{font-style:normal;color:#f2a6a0}
+ol.sr{margin:0;padding-left:20px;color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch}
+ol.sr li{margin-bottom:10px} ol.sr b{color:var(--tx)} ol.sr em{font-style:normal;color:#f2a6a0}
+.cap{display:flex;align-items:center;gap:8px;margin:0 0 9px;font-size:var(--meta);color:var(--dim)}
+.cap b{color:var(--tx);font-size:var(--sm)}
+.tag{font-size:var(--micro);padding:1px 8px;border-radius:var(--rp);border:1px solid var(--line2);color:var(--dimmer)}
+.tag.bad{color:#f2a6a0;border-color:rgba(248,81,73,.42)}
+.tag.good{color:#7fd18f;border-color:rgba(63,185,80,.42)}
+.note{margin:10px 0 0;font-size:var(--meta);color:var(--dim);line-height:1.8;max-width:520px}
+.note u{text-decoration:none;color:var(--tx)} .note em{font-style:normal;color:#f2a6a0}
+.row{display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
+
+/* 桌面框：真实 1440×620 缩到 .385（两幅并排） */
+.stage{overflow:hidden;border-radius:10px;border:1px solid var(--line2);background:var(--bg)}
+.dk{zoom:.36;width:1440px;height:620px;display:flex;position:relative}
+.dk.wide{zoom:.335;width:1760px}
+.nav{flex:0 0 224px;background:var(--card);border-right:1px solid var(--line);padding:14px 12px}
+.nav .lg{font-size:19px;font-weight:800}
+.nav i{display:block;font-style:normal;font-size:15px;color:var(--dim);padding:9px 10px;border-radius:8px;margin-top:5px}
+.nav i.on{color:var(--acc);background:var(--soft)}
+.main{flex:1;min-width:0;display:flex;flex-direction:column}
+.top{flex:0 0 40px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:center;
+  color:var(--dimmer);font-size:14px;background:var(--card)}
+.cols{flex:1;min-height:0;display:flex;position:relative}
+.canvas{flex:1;min-width:0;padding:16px 18px;overflow:hidden}
+.canvas h3{margin:0 0 4px;font-size:24px}
+.canvas .p{font:var(--meta)/1.4 ui-monospace,monospace;color:var(--dimmer)}
+.lrow{display:flex;align-items:center;gap:10px;height:38px;border-bottom:1px solid var(--line);font-size:14px;color:var(--dim)}
+.lrow b{color:var(--tx);font-size:14px}
+.rail{flex:0 0 8px;background:var(--line);position:relative}
+.rail::after{content:"";position:absolute;left:3px;top:50%;width:2px;height:26px;background:var(--line2);transform:translateY(-50%)}
+.dock{flex:0 0 auto;background:#06090d;padding:12px 14px;font:12px/1.7 ui-monospace,monospace;color:#7fd18f;
+  border-left:1px solid var(--line);overflow:hidden}
+.dock .u{color:#e6edf3}
+.dock .hd{color:var(--dim);font-family:Inter,sans-serif;font-size:13px;margin-bottom:8px}
+.keyrow{position:absolute;left:0;right:0;bottom:0;height:38px;background:var(--card);border-top:1px solid var(--line);
+  display:flex;align-items:center;gap:8px;padding:0 10px;font-size:12px;color:var(--dim)}
+.keyrow span{padding:4px 12px;border-radius:7px;background:var(--inset)}
+
+/* 面板 */
+.panel{background:var(--card);border-left:1px solid var(--line2);display:flex;flex-direction:column;overflow:hidden}
+.panel.float{position:absolute;top:0;bottom:0;right:0;box-shadow:-16px 0 40px rgba(0,0,0,.6);z-index:5}
+.panel .ph{display:flex;align-items:center;gap:8px;padding:10px 12px;border-bottom:1px solid var(--line)}
+.panel .ph b{font-size:14px}
+.panel .ph .sp{flex:1}
+.panel .ph .ic{color:var(--dim);font-size:15px}
+.panel .bd{flex:1;min-height:0;padding:10px 12px;display:flex;flex-direction:column;gap:9px;overflow:hidden}
+.scrim{position:absolute;inset:0;background:rgba(1,4,9,.6);z-index:4}
+.segs{display:flex;gap:2px;background:var(--inset);border-radius:8px;padding:3px}
+.segs span{flex:1;text-align:center;padding:5px 0;font-size:12px;color:var(--dim);border-radius:6px}
+.segs span.on{background:var(--solid);color:#fff}
+.chip{height:24px;padding:0 10px;border-radius:var(--rp);border:1px solid var(--line2);display:inline-flex;align-items:center;
+  gap:6px;font-size:12px;color:var(--dim);white-space:nowrap}
+.chip.br{font-family:ui-monospace,monospace;color:#7ed0d8;border-color:rgba(57,197,207,.4);background:rgba(57,197,207,.08)}
+.frow{display:flex;align-items:center;gap:8px;height:30px;font-size:13px;border-bottom:1px solid var(--line)}
+.frow .st{width:12px;font:11px/1 ui-monospace,monospace}
+.frow .st.m{color:var(--amber)}.frow .st.a{color:var(--green)}.frow .st.d{color:var(--red)}
+.frow .p{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:ui-monospace,monospace;font-size:12px}
+.diffbox{flex:1;min-height:0;border:1px solid var(--line);border-radius:8px;background:var(--inset);
+  font:11px/1.65 ui-monospace,monospace;padding:8px;overflow:hidden}
+.diffbox .add{color:#7fd18f}.diffbox .del{color:#f2a6a0}.diffbox .hu{color:#7ed0d8}
+.wtcard{border:1px solid var(--line);border-radius:8px;background:var(--inset);padding:8px 10px}
+.wtcard b{font:13px/1.4 ui-monospace,monospace;color:#7ed0d8}
+.wtcard .p{font:11px/1.4 ui-monospace,monospace;color:var(--dimmer);margin-top:3px}
+
+/* 量尺 */
+.void{position:absolute;background:repeating-linear-gradient(45deg,rgba(248,81,73,.14),rgba(248,81,73,.14) 6px,transparent 6px,transparent 13px);
+  border:1px dashed rgba(248,81,73,.6);border-radius:5px;display:grid;place-items:center;z-index:8;
+  font:13px/1.35 ui-monospace,monospace;color:#f2a6a0;text-align:center;padding:4px}
+.ok{position:absolute;border:1px dashed rgba(63,185,80,.6);border-radius:5px;background:rgba(63,185,80,.07);z-index:8;
+  display:grid;place-items:center;font:13px/1.35 ui-monospace,monospace;color:#7fd18f;text-align:center;padding:4px}
+table.tt{border-collapse:collapse;width:100%;font-size:var(--sm);margin:8px 0 20px}
+table.tt th,table.tt td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+table.tt th{color:var(--dimmer);font-size:var(--meta);font-weight:600}
+table.tt td{color:var(--dim)} table.tt td b{color:var(--tx)}
+table.tt code{white-space:nowrap}
+</style></head><body><div class="wrap">
+
+<h1>桌面版面板：Git / Worktree 进 Shell</h1>
+<p class="lede">
+手机那轮把 Git/Worktree 收进了全屏二级页（#149），桌面是<b>刻意冻住</b>的——那一轮的验收标准就是「桌面逐像素不变」。
+但桌面本身有问题，而且比手机那份更糙：<b>同一个面板有四种壳</b>，其中一种会<em>把终端盖掉 70%</em>。
+</p>
+<p class="lede" style="margin-bottom:8px">
+根因只有一句：<b>这些面板浮在 Workspace Shell 之上，不参与 Canvas / Dock 的尺寸契约</b>（14 §4.2）。
+浮层只会「盖」，不会「让」。手机上正确答案是整页（已做）；桌面上正确答案是——<b>成为 Shell 的一列</b>。
+</p>
+
+<h2>一、现状：四种壳</h2>
+
+<div class="row">
+  <div>
+    <p class="cap"><b>① 会话页 Git</b><span class="tag bad">420 浮层 · 盖掉终端 70%</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">会话</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas">
+            <h3>会话</h3><div class="p">所有会话，按 Agent、等待状态筛选</div>
+            <div class="lrow" style="margin-top:14px"><b>桌面版页面也出一版优化设计</b></div>
+            <div class="lrow"><b>auth接入第三方</b></div>
+            <div class="lrow"><b>blade-agent-/tmp</b></div>
+            <div class="lrow"><b>roam-bug修复</b></div>
+          </div>
+          <div class="rail"></div>
+          <div class="dock" style="flex:0 0 605px">
+            <div class="hd">● 桌面版页面也出一版优化设计</div>
+            <span class="u">❯</span> npm run build<br>vite v5 building for production…<br>✓ built in 36.74s
+            <div class="keyrow"><span>Enter</span><span>Esc</span><span>Tab</span><span>↑</span><span>↓</span></div>
+          </div>
+          <div class="panel float" style="width:420px">
+            <div class="ph"><b>源代码管理</b><span class="sp"></span><span class="ic">⋯</span><span class="ic">↻</span><span class="ic">✕</span></div>
+            <div class="bd">
+              <span class="chip br" style="align-self:flex-start">⎇ mobile/panels-subpage</span>
+              <div class="segs"><span class="on">改动 14</span><span>提交树</span><span>分支</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/App.tsx</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/GitPanel.tsx</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">shell/AdaptivePanel.tsx</span></div>
+            </div>
+          </div>
+          <div class="void" style="left:610px;top:0;bottom:0;width:186px">终端<br>只剩<br>185px</div>
+          <div class="void" style="left:18px;top:120px;width:560px;height:300px">Canvas 603px 全是空列表<br>——没人用</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">1440 实测：Dock 从 x=835 起、宽 605；Git 面板 x=1020、宽 420、<code>z-index:1200</code>。
+    <u>你打开 Git 恰恰是要对着终端里的改动看，结果终端被盖掉 70%</u>；而左边 603px 的会话列表全程没人看。
+    底部那条快捷键条还从面板下面露出来——因为面板是 fixed 浮层，压根不在 Shell 的布局里。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>② 项目页 Git</b><span class="tag bad">520 + 全屏遮罩（模态）</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">项目</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas">
+            <h3>roam</h3><div class="p">/home/ai/codes/ttmux · ⎇ main</div>
+            <div class="lrow" style="margin-top:14px"><b>任务 2</b></div>
+            <div class="lrow"><b>Worktree 1</b></div>
+          </div>
+          <div class="scrim"></div>
+          <div class="panel float" style="width:520px">
+            <div class="ph"><b>源代码管理</b><span class="sp"></span><span class="ic">⋯</span><span class="ic">↻</span><span class="ic">✕</span></div>
+            <div class="bd">
+              <span class="chip br" style="align-self:flex-start">⎇ main</span>
+              <div class="segs"><span class="on">改动 3</span><span>提交树</span><span>分支</span></div>
+              <div class="frow"><span class="st d">U</span><span class="p">.roam/</span></div>
+              <div class="frow"><span class="st d">U</span><span class="p">ttmux-web.bak-gitpanel</span></div>
+            </div>
+          </div>
+          <div class="void" style="left:18px;top:150px;width:420px;height:120px">全屏压暗<br>= 这是个模态？</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">同一个 <code>&lt;GitPanel&gt;</code>：这里是 <b>520</b> 宽、<b>带全屏遮罩</b>；上一帧是 <b>420</b> 宽、<b>没有遮罩</b>。
+    遮罩意味着「这是模态，先关掉才能干别的」——但 Git 面板<u>恰恰是要边看边干的</u>，它不该是模态。</p>
+  </div>
+</div>
+
+<div class="row" style="margin-top:22px">
+  <div>
+    <p class="cap"><b>③ Worktree</b><span class="tag bad">antd Drawer：第三种遮罩 + 横切进场</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">项目</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas"><h3>roam</h3><div class="p">/home/ai/codes/ttmux</div></div>
+          <div class="scrim" style="background:rgba(0,0,0,.45)"></div>
+          <div class="panel float" style="width:520px">
+            <div class="ph"><b>Worktree 管理</b><span class="sp"></span><span class="ic">✕</span></div>
+            <div class="bd">
+              <div class="wtcard"><b>⎇ feat/web-session-tokens</b><div class="p">…/.worktrees/task-1</div></div>
+              <div class="wtcard"><b>⎇ mobile/panels-subpage</b><div class="p">…/.worktrees/task-2</div></div>
+            </div>
+          </div>
+          <div class="void" style="left:640px;top:8px;width:180px;height:44px">第三种遮罩<br>(antd mask)</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">antd <code>Drawer</code>：自己的遮罩、自己的横切进场、自己的层级基座。
+    <u>和前两种是三套不同的「从右边出来一块」</u>。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>④ diff 详情</b><span class="tag bad">第四种：贴着面板左缘的浮层</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">项目</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas"><h3>roam</h3><div class="p">/home/ai/codes/ttmux</div></div>
+          <div class="panel float" style="width:520px">
+            <div class="ph"><b>源代码管理</b><span class="sp"></span><span class="ic">✕</span></div>
+            <div class="bd">
+              <div class="frow" style="background:var(--soft)"><span class="st m">M</span><span class="p">frontend/src/App.tsx</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/GitPanel.tsx</span></div>
+            </div>
+          </div>
+          <div class="panel float" style="width:520px;right:520px;box-shadow:-16px 0 40px rgba(0,0,0,.5)">
+            <div class="ph"><span class="ic">←</span><b style="font-family:ui-monospace,monospace;font-size:13px">frontend/src/App.tsx</b></div>
+            <div class="bd"><div class="diffbox">
+              <span class="hu">@@ -1738,7 +1738,12 @@</span><br>
+              <span class="del">- &lt;FloatingFileDrawer open={showGit}&gt;</span><br>
+              <span class="add">+ &lt;AdaptivePanel desktop="floating"</span><br>
+              <span class="add">+&nbsp;&nbsp; layer="session" …&gt;</span>
+            </div></div>
+          </div>
+          <div class="void" style="left:18px;top:150px;width:340px;height:110px">页面被两层浮层<br>推到左边一条缝</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">详情按 <code>right: calc(100vw − panelLeft)</code> 定位、宽 <code>min(560, panelLeft−40)</code>：
+    位置随面板算、宽度随剩余空间算，<u>于是它既不是列也不是抽屉</u>。两层浮层叠起来，底下的页面只剩一条缝。</p>
+  </div>
+</div>
+
+<h2>二、新版：Inspector 是 Shell 的第三区</h2>
+<p class="lede">
+把这四种壳收敛成一种：<b>Inspector</b>——和 Dock 同级的一列，走同一套尺寸契约（可拖、双击复位、宽度记忆、有下限）。
+<b>不带遮罩</b>：它不是模态，是工作区的一部分。
+</p>
+<table class="tt">
+  <tr><th style="width:120px">令牌</th><th style="width:120px">值</th><th>理由</th></tr>
+  <tr><td><code>INSPECTOR_MIN</code></td><td>360</td><td>文件行 + 状态字母 + 增删数字的最小可读宽</td></tr>
+  <tr><td><code>INSPECTOR_DEFAULT</code></td><td>420</td><td>沿用今天会话页那份的宽度，改动最小</td></tr>
+  <tr><td><code>INSPECTOR_SPLIT</code></td><td>720</td><td>≥720 时面板内左右分栏（列表 ｜ diff），不再开第二层浮层</td></tr>
+  <tr><td><code>INSPECTOR_MAX</code></td><td>880</td><td>与 Dock 同一个上界，视觉节奏一致</td></tr>
+</table>
+
+<div class="row">
+  <div>
+    <p class="cap"><b>≥1700：三列并存</b><span class="tag good">终端完整可见</span></p>
+    <div class="stage"><div class="dk wide">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">会话</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas">
+            <h3>会话</h3><div class="p">所有会话</div>
+            <div class="lrow" style="margin-top:14px"><b>桌面版页面也出一版优化设计</b></div>
+            <div class="lrow"><b>auth接入第三方</b></div>
+          </div>
+          <div class="rail"></div>
+          <div class="dock" style="flex:0 0 480px">
+            <div class="hd">● 桌面版页面也出一版优化设计</div>
+            <span class="u">❯</span> npm run build<br>✓ built in 36.74s
+            <div class="keyrow"><span>Enter</span><span>Esc</span><span>Tab</span></div>
+          </div>
+          <div class="rail"></div>
+          <div class="panel" style="flex:0 0 420px">
+            <div class="ph"><b>Git</b><span class="chip br" style="height:20px">⎇ mobile/panels-subpage</span><span class="sp"></span><span class="ic">⋯</span><span class="ic">✕</span></div>
+            <div class="bd">
+              <div class="segs"><span class="on">改动 14</span><span>提交树</span><span>分支</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/App.tsx</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/GitPanel.tsx</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">shell/AdaptivePanel.tsx</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">shell/useBackDismiss.ts</span></div>
+            </div>
+          </div>
+          <div class="ok" style="left:566px;bottom:52px;width:480px;height:36px">终端一寸没被盖</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">
+      三列的门槛按<b>实际宽度</b>算，不是一个固定数：<code>224 + 560 + 8 + dock + 8 + inspector</code>。<br>
+      · 全部取下限（dock 480 / inspector 360）＝ <b>1640</b>；<br>
+      · 默认宽度（dock 480 / inspector 420）＝ <b>1700</b>（上图是 1760）；<br>
+      · dock 被拖宽过就按拖过的算——42vw 的默认 dock 在 1680 上是 705，那时<u>三列放不下，Canvas 让位</u>。
+      <em>这一条是实测纠正的：初稿画的是「1680 三列」，算下来 1700 才够，图纸错了、代码是对的。</em></p>
+  </div>
+
+  <div>
+    <p class="cap"><b>1280–1639：Canvas 让位</b><span class="tag good">让的是页面，不是终端</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">会话</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="dock" style="flex:1;border-left:0">
+            <div class="hd">● 桌面版页面也出一版优化设计　<span style="color:var(--acc)">↩ 显示页面</span></div>
+            <span class="u">❯</span> npm run build<br>vite v5 building for production…<br>✓ built in 36.74s<br>
+            <span class="u">❯</span> git status<br>On branch mobile/panels-subpage
+            <div class="keyrow"><span>Enter</span><span>Esc</span><span>Tab</span><span>↑</span><span>↓</span></div>
+          </div>
+          <div class="rail"></div>
+          <div class="panel" style="flex:0 0 420px">
+            <div class="ph"><b>Git</b><span class="chip br" style="height:20px">⎇ mobile/panels…</span><span class="sp"></span><span class="ic">⋯</span><span class="ic">✕</span></div>
+            <div class="bd">
+              <div class="segs"><span class="on">改动 14</span><span>提交树</span><span>分支</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/App.tsx</span></div>
+              <div class="frow"><span class="st m">M</span><span class="p">frontend/src/GitPanel.tsx</span></div>
+              <div class="frow"><span class="st a">A</span><span class="p">shell/AdaptivePanel.tsx</span></div>
+            </div>
+          </div>
+          <div class="ok" style="left:12px;bottom:52px;width:520px;height:36px">终端拿到 748px（原来只剩 185）</div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">
+      1440 上三列要 1640 才够，必须有人让。<b>让 Canvas，不让 Dock</b>——
+      你按下 Git 的那一刻，注意力在终端和改动上，页面是三者里最不需要的那个。
+      让位后终端从 <u>185px 变成 748px</u>，顶栏留「↩ 显示页面」一键回来（和 ⌘⇧J 同一个开关）。</p>
+  </div>
+</div>
+
+<div class="row" style="margin-top:22px">
+  <div>
+    <p class="cap"><b>Inspector ≥720：面板内分栏</b><span class="tag good">取消第四种壳</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">项目</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas"><h3>roam</h3><div class="p">/home/ai/codes/ttmux</div>
+            <div class="lrow" style="margin-top:14px"><b>任务 2</b></div></div>
+          <div class="rail"></div>
+          <div class="panel" style="flex:0 0 760px">
+            <div class="ph"><b>Git</b><span class="chip br" style="height:20px">⎇ main</span><span class="sp"></span><span class="ic">⋯</span><span class="ic">✕</span></div>
+            <div style="flex:1;min-height:0;display:flex">
+              <div class="bd" style="flex:0 0 280px;border-right:1px solid var(--line)">
+                <div class="segs"><span class="on">改动 14</span><span>提交树</span></div>
+                <div class="frow" style="background:var(--soft)"><span class="st m">M</span><span class="p">App.tsx</span></div>
+                <div class="frow"><span class="st m">M</span><span class="p">GitPanel.tsx</span></div>
+                <div class="frow"><span class="st a">A</span><span class="p">AdaptivePanel.tsx</span></div>
+              </div>
+              <div class="bd" style="flex:1;min-width:0">
+                <div style="font:12px/1 ui-monospace,monospace;color:var(--dim)">frontend/src/App.tsx</div>
+                <div class="diffbox">
+                  <span class="hu">@@ -1738,7 +1738,12 @@</span><br>
+                  <span class="del">- &lt;FloatingFileDrawer open={showGit} right={…}&gt;</span><br>
+                  <span class="add">+ &lt;AdaptivePanel desktop="inspector"</span><br>
+                  <span class="add">+&nbsp;&nbsp;&nbsp;title={t('git.title')}</span><br>
+                  <span class="add">+&nbsp;&nbsp;&nbsp;onClose={() =&gt; setShowGit(false)}&gt;</span><br>
+                  &nbsp;&nbsp;&nbsp;&lt;GitPanel dir={cwd} … /&gt;
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">拖到 ≥720 就在<u>面板内部</u>分成「列表 ｜ diff」两栏——这是容器查询，看的是面板自己的宽度。
+    窄于 720 时 diff 仍旧盖成第二层，但那是<b>面板内的</b>覆盖层（手机上已经是这个行为），
+    不再是那个按 <code>100vw − panelLeft</code> 算位置的第四种壳。</p>
+  </div>
+
+  <div>
+    <p class="cap"><b>Worktree 用同一个壳</b><span class="tag good">四种 → 一种</span></p>
+    <div class="stage"><div class="dk">
+      <div class="nav"><div class="lg">Roam</div><i>概览</i><i class="on">项目</i><i>文件</i></div>
+      <div class="main">
+        <div class="top">⌕ 搜索项目、会话和文件</div>
+        <div class="cols">
+          <div class="canvas"><h3>roam</h3><div class="p">/home/ai/codes/ttmux</div>
+            <div class="lrow" style="margin-top:14px"><b>任务 2</b></div>
+            <div class="lrow"><b>Worktree 4</b></div></div>
+          <div class="rail"></div>
+          <div class="panel" style="flex:0 0 520px">
+            <div class="ph"><b>Worktree</b><span class="sp"></span><span class="ic">＋</span><span class="ic">↻</span><span class="ic">✕</span></div>
+            <div class="bd">
+              <div style="display:flex;gap:7px"><span class="chip" style="color:var(--acc);border-color:var(--accb);background:var(--soft)">全部 4</span><span class="chip">在跑 2</span><span class="chip">可清理 1</span></div>
+              <div class="wtcard"><b>⎇ feat/web-session-tokens</b><div class="p">…/.worktrees/task-1</div></div>
+              <div class="wtcard"><b>⎇ mobile/panels-subpage</b><div class="p">…/.worktrees/task-2</div></div>
+              <div class="wtcard" style="opacity:.7"><b>⎇ docs/ba-prompt-analysis</b><div class="p">…/.worktrees/task-3</div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+    <p class="note">同一条 rail、同一套宽度记忆、同一个关闭语义。
+    <u>Worktree 与 Git 现在可以并存吗？不能</u>——同一时刻只有一个 Inspector，后开的替换先开的，
+    就像 Dock 里同时只有一个终端标签在前台。这比「Worktree 抽屉盖在 Git 面板上」清楚。</p>
+  </div>
+</div>
+
+<h2>三、契约</h2>
+<table class="tt">
+  <tr><th style="width:130px">场景</th><th style="width:190px">规则</th><th>理由</th></tr>
+  <tr><td><b>先从 Dock 借</b></td><td>Canvas ｜ Dock(借窄) ｜ Inspector</td>
+      <td>判据用 Dock 的<b>下限</b>：<code>workspace − 480 − inspector − 两条 rail ≥ 560</code>。
+      成立就把 Dock 借到刚好（不低于 480、不超过用户拖出来的宽度）。
+      实测 1920：终端 794 → 688，<u>三列都在</u></td></tr>
+  <tr><td><b>借不够就让 Canvas</b></td><td>Dock ｜ Inspector（页面整个让掉）</td>
+      <td>此时 Dock 用回原宽、<b>终端一寸不变</b>——实测 1440：593 → 593，只是整体左移，
+      所以连 fit/SIGWINCH 都不触发</td></tr>
+  <tr><td><b>无终端</b></td><td>Canvas ｜ Inspector 两列</td><td><code>224+560+8+420 = 1212</code>，1280 就够</td></tr>
+  <tr><td><b>905–1279（expanded）</b></td><td>Inspector 走覆盖式（同 Dock 的 overlay 语义）+ 遮罩</td><td>这一档本来就没有三列的空间，与 13 §13.1 一致</td></tr>
+  <tr><td><b>&lt;905（phone）</b></td><td>全屏二级页（#149 已实现）</td><td>不变</td></tr>
+  <tr><td><b>同时只有一个</b></td><td>Git 与 Worktree 互斥，后开替换先开</td><td>否则又回到「抽屉盖面板」</td></tr>
+  <tr><td><b>不带遮罩</b></td><td>≥1280 的两种形态都不加遮罩</td><td>遮罩 = 模态 = 「先关掉才能干别的」，而 Git 恰恰要边看边干</td></tr>
+</table>
+
+<h2>四、自审：画完之后自己挑的毛病</h2>
+<ol class="sr">
+  <li><b>Inspector 放哪一侧？</b>第一版我画在 Canvas 和 Dock <u>之间</u>（页面｜Git｜终端）。
+      问题是每次开关 Git，<em>终端的起点都会横向平移</em>——终端最忌讳这个，宽度一变就 fit → SIGWINCH →
+      tmux 整屏重排，肉眼是闪一下。放到最右之后，开关 Inspector 只让终端变窄，起点不动。
+      （变窄仍会 fit 一次，但比「被整个盖住」强得多，也比「盖住 + 起点平移」少一次。）</li>
+  <li><b>「Canvas 让位」会不会太粗暴？</b>另一个方案是 Inspector 浮在 Canvas 上、Dock 不动——
+      但那正是<u>今天项目页那份的做法</u>，也就是这一稿要治的病（浮层只会盖）。
+      折中方案是让位后顶栏留一枚「↩ 显示页面」，并且这个让位<b>复用已有的 Focus 态</b>，
+      不新增第五种空间状态——⌘⇧J 本来就是它。</li>
+  <li><b>Git 与 Worktree 互斥，会不会挡住「从 Git 里点 worktree 徽标」这条路？</b>会。
+      今天是 Worktree 抽屉盖在 Git 面板上（1300 盖 1200）。互斥之后那一跳会替换掉 Git 面板，
+      <u>返回时要能回到 Git</u>——所以 Inspector 需要一个「上一个面板」的返回箭头，
+      语义与手机二级页的 ← 一致。这条不做的话，从 Git 跳 Worktree 就是单程票。</li>
+  <li><b>720 这个分栏阈值是拍的吗？</b>不是：<code>280(列表) + 8 + 400(diff 最窄可读) + 32(padding) ≈ 720</code>。
+      低于它硬分栏的话 diff 会窄到每行都折，还不如盖成第二层。</li>
+  <li><b>「不带遮罩」有代价。</b>没有遮罩，用户可能不知道点外面不会关掉它。
+      所以 Inspector 必须<u>常驻一个 ✕ 和 Esc</u>，并且状态记忆——下次打开还在，不需要每次找关闭。</li>
+  <li><b>expanded 档（905–1279）我原本想跳过。</b>但那一档今天也会被 420 浮层盖住终端覆盖面板，
+      问题一模一样。既然 Dock 在那一档已经是 overlay，Inspector 沿用同一套语义即可，
+      <u>不额外发明</u>。</li>
+  <li><b>「↩ 显示页面」那枚按钮是多余的。</b>我在 1280–1639 那帧画了它，想着让位之后总得有路回去。
+      但让位的原因是<u>空间真的不够</u>——按下去除了关掉 Inspector 没有第二种可能，
+      而关闭本来就有 ✕ 和 Esc。<em>删掉，不做。</em></li>
+  <li><b>三列门槛写成一个固定数是错的。</b>初稿写「≥1640 三列并存」并画了 1680 的图，
+      实测 1680 上 Canvas 仍然让位——因为默认 dock 是 42vw（1680 上 = 705），
+      而 1640 那个数假设的是 dock 取下限 480。<u>判据必须按实际宽度算</u>，不是断点。</li>
+  <li><b>「让页面，不让终端」这条我写得太绝对了。</b>照它实现之后实测：<em>1920 上打开 Git，
+      页面照样整个消失</em>——因为默认 Dock 是 42vw（1920 上 806），拿它去判永远凑不齐三列。
+      而在 1920 上「终端窄 13%（794→688）换页面留在原地」显然更划算，那正是买大屏的理由。<br>
+      改成两步：<b>先从 Dock 借宽</b>（不低于 480、不超过用户拖出来的宽度），
+      <b>借不够再让 Canvas</b>——让位时 Dock 用回原宽，终端一寸不变。
+      原来那句话真正想守的是「终端不能被<u>盖住</u>」，不是「终端一像素都不能动」。</li>
+</ol>
+
+<h2>五、分期</h2>
+<ol class="pts">
+  <li><b>P1（本轮）</b>：Inspector 作为 Shell 的第三列落地 —— <code>useWorkspaceLayout</code> 加 inspector 宽度/开关，
+      <code>Workspace</code> 加第三列与第二条 rail，<code>AdaptivePanel</code> 桌面分支从 floating/drawer 改成 inspector；
+      Git 两个调用点 + Worktree 接上；<b>取消遮罩</b>；1280–1639 打开时 Canvas 让位。</li>
+  <li><b>P2</b>：Inspector ≥720 面板内分栏（容器查询），取消 <code>.tt-file-detail</code> 那第四种壳。</li>
+  <li><b>P3</b>：Inspector 的「上一个面板」返回（Git ⇄ Worktree），宽度按面板类型分别记忆。</li>
+</ol>
+
+</div></body></html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,8 @@ import FileBrowser from './FileBrowser'
 import FileWorkspace from './FileWorkspace'
 import FloatingFileDrawer from './FloatingFileDrawer'
 import AdaptivePanel from './shell/AdaptivePanel'
+import { InspectorColumn } from './shell/InspectorColumn'
+import { useInspectorReserved } from './shell/inspector'
 import MobileSubPage from './MobileSubPage'
 import { FileView } from './fileview'
 // 非首屏的重页面（蜂群/Git 面板/浏览器/手机镜像/插件）按路由懒加载：切到对应 tab 才拉 chunk，
@@ -737,10 +739,13 @@ export default function App() {
           // 不是组件树，终端因此不会在开合时被卸载重建。
           <Workspace
             mode={space.mode} canvas={canvasNode} dock={dockNode}
-            dockWidth={space.dockWidth} bounds={space.bounds} splitMax={space.splitMax}
+            dockWidth={space.dockRenderWidth} bounds={space.bounds} splitMax={space.splitMax}
             onResize={space.setDockWidth} onReset={space.resetDockWidth}
             onFocus={() => space.setFocus('dock')}
             onDismiss={() => space.setDockOpen(false)}
+            inspectorWidth={space.inspectorWidth} inspectorBounds={space.inspectorBounds}
+            inspectorOverlay={!space.splitCapable} canvasFitsInspector={space.canvasFitsInspector}
+            onInspectorResize={space.setInspectorWidth} onInspectorReset={space.resetInspectorWidth}
             capsule={space.overlayCapable && space.mode === 'page' ? (
               // 胶囊只有 320px，显示 sessionLabel 而不是 sessionDisplay——后者带
               // 「（会话 id）」后缀，在这个宽度下正好被截在 id 中间，什么也没说清。
@@ -754,7 +759,16 @@ export default function App() {
             ) : null}
           />
         ) : (
-          <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>{canvasNode}</div>
+          // 没有终端时不走 Workspace（不必为空 Dock 撑一套几何），但 Inspector 这一列
+          // 两边都要有——Git 面板在项目页也开得出来。
+          <div style={{ position: 'relative', display: 'flex', flex: 1, minHeight: 0 }}>
+            {canvasNode}
+            {hasSider && (
+              <InspectorColumn width={space.inspectorWidth} bounds={space.inspectorBounds}
+                overlay={!space.splitCapable} onResize={space.setInspectorWidth}
+                onReset={space.resetInspectorWidth} />
+            )}
+          </div>
         )}
       </Layout>
 
@@ -1002,6 +1016,7 @@ function TerminalPane(props: {
   // 编辑器多 tab / 打开的文件 / 拖拽调宽等都下沉到 <FileWorkspace>（左侧停靠时用），这里只保留 showFiles。
   const [showFiles, setShowFiles] = useState(fileDock === 'left')
   const [showGit, setShowGit] = useState(false)
+  const inspectorReserved = useInspectorReserved()
   const [cwd, setCwd] = useState('')
   // 文件栏与 Git 面板可并存：左侧停靠时文件走左栏、Git 走右抽屉，天然并列；
   // 右侧停靠时两者都是右抽屉，Git 抽屉在文件也开着时向左让位（见下方 right 偏移），并排显示而非互相覆盖。
@@ -1744,14 +1759,15 @@ function TerminalPane(props: {
         </div>
       )}
       {fileDock === 'right' && (
-        <FloatingFileDrawer open={showFiles}>
+        // 文件抽屉这一轮仍是浮层（P4 再收），但要按 Inspector 占掉的宽度往左让，
+        // 否则开着 Git 时它会盖住那一列
+        <FloatingFileDrawer open={showFiles} right={inspectorReserved}>
           <FileBrowser dir={cwd} accent="#58a6ff" layout="dock" onClose={() => setShowFiles(false)} />
         </FloatingFileDrawer>
       )}
       {/* 手机走全屏二级页（13 §6）：420 的浮层在 360 屏上盖到 92vw，还压着底栏、不吃安全区。
           桌面维持右缘浮动面板不变。layer="session" —— 这一层是从会话全屏(100)里唤起的。 */}
-      <AdaptivePanel open={showGit} desktop="floating" layer="session" title={t('git.title')}
-        width="min(420px, 92vw)" right={fileDock === 'right' && showFiles ? 'min(420px, 92vw)' : 0}
+      <AdaptivePanel open={showGit} layer="session" title={t('git.title')}
         onClose={() => setShowGit(false)}>
         <Suspense fallback={<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}><Spin /></div>}>
           <GitPanel dir={cwd} accent="#58a6ff" onClose={() => setShowGit(false)} />

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -1745,8 +1745,7 @@ function ProjectHome({ proj, allProjects, loaded, openTerm, closeTerm, refresh, 
           {/* 手机走全屏二级页；桌面仍是右缘面板 + 遮罩。原来这里是一套手搓的
               zIndex:1000 遮罩 + 面板，和会话页那套 FloatingFileDrawer 宽度/层级/阴影全不一样——
               同一个 GitPanel 不该有两套壳（13 §6）。 */}
-          <AdaptivePanel open={!!(gitOpen || gitAt)} desktop="floating" scrim
-            title={t('git.title')} width="min(520px, 94vw)"
+          <AdaptivePanel open={!!(gitOpen || gitAt)} title={t('git.title')}
             onClose={() => { setGitOpen(false); setGitAt(null) }}>
             <GitPanel dir={gitAt?.dir || dir} initialTab={gitAt?.tab} openTerm={openTerm}
               onClose={() => { setGitOpen(false); setGitAt(null) }} />

--- a/frontend/src/WorktreePanel.tsx
+++ b/frontend/src/WorktreePanel.tsx
@@ -421,10 +421,26 @@ export default function WorktreePanel({ open, onClose, openTerm, initialDir }: {
 
   return (
     // 手机走全屏二级页（13 §6）：全宽的 antd Drawer「既不是页也不是 sheet」——
-    // 从右横切进场、右上角一个 ×、返回键不认它。桌面维持 520 抽屉不变。
-    <AdaptivePanel open={open} onClose={onClose} title={t('worktree.title')}
-      desktop="drawer" width={520} zIndex={DRAWER_Z}
-      drawerStyles={{ body: { display: 'flex', flexDirection: 'column', gap: 0, paddingTop: 14 } }}>
+    // 从右横切进场、右上角一个 ×、返回键不认它。
+    // 桌面走 Inspector 列（14 panels-desktop.html）：抽屉的遮罩 + 横切进场是第三种
+    // 「从右边出来一块」，和 Git 面板那两种并列。现在三者同一条 rail、同一套宽度记忆。
+    <AdaptivePanel open={open} onClose={onClose} title={t('worktree.title')}>
+      {/* 桌面档的面板头：抽屉原来提供的标题与关闭，进 Inspector 之后要自己长出来 */}
+      {wide && (
+        <div style={{
+          flex: '0 0 auto', display: 'flex', alignItems: 'center', gap: 8,
+          padding: '10px 12px', borderBottom: '1px solid var(--border-subtle)',
+        }}>
+          <b style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-bright)' }}>{t('worktree.title')}</b>
+          <span style={{ flex: 1 }} />
+          <button type="button" className="tt-file-close" onClick={onClose}
+            title={t('common.close')} aria-label={t('common.close')}>✕</button>
+        </div>
+      )}
+      <div style={{
+        flex: 1, minHeight: 0, overflowY: 'auto', display: 'flex', flexDirection: 'column',
+        gap: 0, padding: '14px 12px 12px',
+      }}>
       {/* 头部：仓库目录（留空 = 跨仓库总览）+ 新建 + 刷新 */}
       <div style={{ display: 'flex', gap: 8 }}>
         <AutoComplete style={{ flex: 1, minWidth: 0 }} value={dir} onChange={setDir} allowClear
@@ -571,6 +587,7 @@ export default function WorktreePanel({ open, onClose, openTerm, initialDir }: {
           </div>
         )}
       </Modal>
+      </div>
     </AdaptivePanel>
   )
 }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -46,6 +46,7 @@ const enUS = {
   'nav.thisDevice': 'This device',
   'nav.terminal': 'Terminal',
   'workspace.resizeDock': 'Resize terminal',
+  'workspace.resizeInspector': 'Drag to resize panel',
   'workspace.focusDock': 'Focus terminal',
   'workspace.terminalPanel': 'Terminal panel',
   'workspace.exitFocus': 'Back to split',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -46,6 +46,7 @@ const zhCN = {
   'nav.thisDevice': '当前设备',
   'nav.terminal': '终端',
   'workspace.resizeDock': '调整终端宽度',
+  'workspace.resizeInspector': '拖动调整面板宽度',
   'workspace.focusDock': '终端聚焦',
   'workspace.terminalPanel': '终端面板',
   'workspace.exitFocus': '返回分栏',

--- a/frontend/src/preferences.ts
+++ b/frontend/src/preferences.ts
@@ -32,6 +32,7 @@ export interface WorkspacePreference {
   navCollapsed: boolean // 桌面侧栏收成 64px 轨
   dockOpen: boolean // 终端区是否展开
   dockWidth: number // 终端区宽度 px；恢复时按当前视口钳制，旧大屏宽度不挤爆新窗口
+  inspectorWidth: number // Git/Worktree 列宽 px；同样按当前几何钳制
   workspaceFocus: 'none' | 'page' | 'dock' // 单区聚焦
   density: 'cozy' | 'compact' // 信息密度，与窗口档正交
   dpadOn: boolean // 手机方向簇
@@ -43,6 +44,7 @@ const WORKSPACE_DEFAULTS: WorkspacePreference = {
   navCollapsed: false,
   dockOpen: true,
   dockWidth: 0, // 0 = 还没拖过，用该档默认（clamp(480, 42vw, 880)）
+  inspectorWidth: 0, // 0 = 还没拖过，用 INSPECTOR_DEFAULT
   workspaceFocus: 'none',
   density: 'cozy',
   dpadOn: true,

--- a/frontend/src/shell/AdaptivePanel.tsx
+++ b/frontend/src/shell/AdaptivePanel.tsx
@@ -1,61 +1,61 @@
-// 一棵组件树，两种容器（13 §6）。
+// 一棵组件树，两种容器（13 §6 手机 / 14 panels-desktop.html 桌面）。
 //
-// Git 面板和 Worktree 在手机上一直是桌面抽屉：420/520 的浮层压在底栏上、不吃安全区、
-// 返回键不认它。但面板本体（GitPanel / WorktreePanel）没有问题，问题全在**容器**——
-// 所以这里只换壳：手机档给 MobileSubPage（整页 + ← + 返回键），桌面维持原样。
+// Git 面板和 Worktree 的问题从来不在面板本体，全在**容器**：
+//   · 手机上是桌面抽屉：420/520 的浮层压在底栏上、不吃安全区、返回键不认它；
+//   · 桌面上是 fixed 浮层：不参与 Shell 的尺寸契约，只会「盖」不会「让」——
+//     实测 1440 会话页开 Git，终端从 605 被盖到只剩 185。
 //
-// 桌面两种形态都要保留，它们的差别是历史形成的、也确实合理：
-//   floating —— 会话页/项目页的 Git，停在右缘，不遮挡左边正在看的内容；
-//   drawer   —— Worktree，antd Drawer，层级要压过 floating 面板（它可以从 Git 里唤起）。
-import { type ReactNode } from 'react'
-import { Drawer } from 'antd'
+// 所以这里只换壳：
+//   手机 → MobileSubPage（整页 + ← + 物理返回键）
+//   桌面 → Inspector 列（Shell 的第三列，可拖、可记忆、不带遮罩）
+//
+// 桌面不带遮罩是有意的：遮罩 = 模态 = 「先关掉才能干别的」，而 Git 面板恰恰要边看边干。
+// 代价是「点外面不会关」，所以面板必须常驻一个关闭入口（GitPanel/WorktreePanel 都有）。
+import { useEffect, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { useLayout } from '../layout'
 import MobileSubPage from '../MobileSubPage'
-import FloatingFileDrawer from '../FloatingFileDrawer'
+import { claimInspector, releaseInspector, useInspectorSlot } from './inspector'
 
-export default function AdaptivePanel({
-  open, title, onClose, desktop, width, right, scrim, zIndex, drawerStyles, layer, children,
-}: {
+export default function AdaptivePanel({ open, title, onClose, layer, children }: {
   open: boolean
-  /** 手机二级页的页头标题；桌面的 floating 形态不用它（面板自带头） */
+  /** 手机二级页的页头标题；桌面由面板自己的头承担 */
   title: ReactNode
   onClose: () => void
-  desktop: 'floating' | 'drawer'
-  width?: number | string
-  /** floating：距右缘的偏移（文件抽屉已经占了右边时往左让） */
-  right?: number | string
-  /** floating：是否带点击关闭的遮罩 */
-  scrim?: boolean
-  zIndex?: number
-  drawerStyles?: Record<string, any>
   /** 'session' = 从会话全屏覆盖层里唤起，手机档要换更高的层 */
   layer?: 'page' | 'session'
   children: ReactNode
 }) {
   const { phone } = useLayout()
-  if (!open) return null
 
+  // 登记槽位：只有栈顶那个可见。从 Git 面板里还能唤起 Worktree（WorktreePanel 就渲染在
+  // GitPanel 的子树里），两个都 portal 进同一个槽会叠在一起——所以非栈顶的**藏起来**。
+  //
+  // 是藏不是卸载：卸载 Git 会连它子树里的 Worktree 一起卸掉 → Worktree 释放槽位 →
+  // Git 又成栈顶重新挂载（wtOpen 已随卸载丢失）→ 看起来就是「点了 Worktree 没反应」。
+  // 藏起来还顺带保住了滚动位置与展开态，**关掉栈顶自然露出下面那个**，
+  // 「从 Git 跳 Worktree 再回来」因此是免费的。
+  const [id, setId] = useState(0)
+  useEffect(() => {
+    if (!open || phone) return
+    const claimed = claimInspector()
+    setId(claimed)
+    return () => { releaseInspector(claimed); setId(0) }
+  }, [open, phone])
+  const { slot, isTop } = useInspectorSlot(id)
+
+  if (!open) return null
   if (phone) {
     return <MobileSubPage title={title} onBack={onClose} layer={layer}>{children}</MobileSubPage>
   }
-
-  if (desktop === 'drawer') {
-    return (
-      <Drawer open={open} onClose={onClose} title={title} width={width} zIndex={zIndex} styles={drawerStyles}>
-        {children}
-      </Drawer>
-    )
-  }
-
-  return (
-    <>
-      {scrim && (
-        <div onClick={onClose} style={{
-          position: 'fixed', inset: 0, background: 'rgba(1,4,9,.6)',
-          zIndex: 'var(--z-scrim)' as unknown as number,
-        }} />
-      )}
-      <FloatingFileDrawer open={open} right={right} width={width}>{children}</FloatingFileDrawer>
-    </>
+  if (!slot) return null
+  return createPortal(
+    <div style={{
+      flex: 1, minHeight: 0, minWidth: 0, flexDirection: 'column',
+      display: isTop ? 'flex' : 'none',
+    }}>
+      {children}
+    </div>,
+    slot,
   )
 }

--- a/frontend/src/shell/InspectorColumn.tsx
+++ b/frontend/src/shell/InspectorColumn.tsx
@@ -1,0 +1,123 @@
+// Inspector 列：Git / Worktree 在桌面档的容身之处（图纸 14-desktop-workspace/panels-desktop.html）。
+//
+// 它是 Shell 的第三列，不是浮层——浮层只会「盖」，不会「让」：实测 1440 上会话页
+// 开 Git，终端从 605 被盖到只剩 185，而左边 603 的页面全程没人看。
+//
+// 单独成组件是因为有终端和没终端走的是**两棵不同的树**（App 里 `terms.length > 0`
+// 才进 Workspace），这一列两边都要有。它自带拖拽与引导线，与 Dock 那条 rail 同款：
+// 拖动期间只移动引导线，pointerup 才提交一次宽度（#139：每帧改宽会让终端反复
+// fit → SIGWINCH → 整屏重排，肉眼就是闪屏）。
+import { useCallback, useEffect, useRef } from 'react'
+import { useI18n } from '../i18n'
+import { PointerResizeShield, usePointerResize } from '../PointerResize'
+import { setInspectorReserved, setInspectorSlot, useInspectorOpen } from './inspector'
+
+export function InspectorColumn({ width, bounds, overlay, onResize, onReset }: {
+  width: number
+  bounds: { min: number; max: number }
+  /** expanded 档：与 Dock 同语义的覆盖式（这一档没有三列的空间） */
+  overlay: boolean
+  onResize: (width: number) => void
+  onReset: () => void
+}) {
+  const { t } = useI18n()
+  const { active, start } = usePointerResize()
+  const railRef = useRef<HTMLDivElement>(null)
+  const guideRef = useRef<HTMLDivElement>(null)
+  const pending = useRef<number | null>(null)
+  const open = useInspectorOpen()
+  const inline = open && !overlay
+  // 文件抽屉这类仍然浮在上面的层要按这个宽度往左让，否则会盖住这一列
+  useEffect(() => {
+    setInspectorReserved(inline ? width : 0)
+    return () => setInspectorReserved(0)
+  }, [inline, width])
+
+  const clamp = useCallback(
+    (w: number) => Math.round(Math.max(bounds.min, Math.min(bounds.max, w))),
+    [bounds],
+  )
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const rail = railRef.current
+    const guide = guideRef.current
+    if (!rail) return
+    const startX = e.clientX
+    const startWidth = width
+    const railCenter = rail.getBoundingClientRect().left + rail.offsetWidth / 2
+    if (guide) { guide.style.display = 'block'; guide.style.left = `${railCenter}px` }
+    start(e, {
+      onMove: (ev) => {
+        // 这一列贴右缘：往左拖 = 变宽，所以是减
+        const next = clamp(startWidth - (ev.clientX - startX))
+        pending.current = next
+        if (guide) guide.style.left = `${railCenter - (next - startWidth)}px`
+      },
+      onEnd: () => {
+        if (guide) guide.style.display = 'none'
+        const next = pending.current
+        pending.current = null
+        if (next != null) onResize(next)
+      },
+    })
+  }, [width, clamp, onResize, start])
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft') onResize(clamp(width + 16))
+    else if (e.key === 'ArrowRight') onResize(clamp(width - 16))
+    else if (e.key === 'Home') onResize(bounds.min)
+    else if (e.key === 'End') onResize(bounds.max)
+    else return
+    e.preventDefault()
+  }, [width, bounds, clamp, onResize])
+
+  return (
+    <>
+      {inline && (
+        <div
+          ref={railRef}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('workspace.resizeInspector')}
+          aria-valuemin={bounds.min}
+          aria-valuemax={bounds.max}
+          aria-valuenow={width}
+          tabIndex={0}
+          onPointerDown={onPointerDown}
+          onDoubleClick={onReset}
+          onKeyDown={onKeyDown}
+          className="tt-split-rail"
+        />
+      )}
+      {open && overlay && <div className="tt-dock-scrim" aria-hidden="true" />}
+      {/* 槽位 DOM 常驻：面板要 portal 进来，挂载点不能随开合出现/消失 */}
+      <div
+        ref={setInspectorSlot}
+        data-inspector-slot
+        style={open && overlay ? {
+          position: 'absolute', top: 0, right: 0, bottom: 0,
+          width: `min(${width}px, 100%)`,
+          zIndex: 'var(--z-sheet)' as unknown as number,
+          boxShadow: '-12px 0 32px rgba(1,4,9,.45)',
+          borderLeft: '1px solid var(--border-subtle)',
+          display: 'flex', flexDirection: 'column', minWidth: 0,
+          background: 'var(--bg-container)',
+          animation: 'ttDockIn .2s cubic-bezier(.2,.85,.3,1)',
+        } : {
+          flex: inline ? `0 0 ${width}px` : '0 0 0px',
+          width: inline ? width : 0,
+          minWidth: 0, height: '100%', minHeight: 0, overflow: 'hidden',
+          display: 'flex', flexDirection: 'column',
+          background: 'var(--bg-container)',
+          borderLeft: inline ? '1px solid var(--border-subtle)' : undefined,
+          transition: active ? 'none' : 'flex-basis .2s, width .2s',
+        }}
+      />
+      <div ref={guideRef} data-dock-resize-guide aria-hidden="true" style={{
+        display: 'none', position: 'fixed', top: 0, bottom: 0, width: 2,
+        zIndex: 1000, pointerEvents: 'none',
+      }} className="tt-dock-guide" />
+      <PointerResizeShield active={active} />
+    </>
+  )
+}

--- a/frontend/src/shell/Workspace.tsx
+++ b/frontend/src/shell/Workspace.tsx
@@ -31,8 +31,13 @@ import { useCallback, useRef, type CSSProperties, type ReactNode } from 'react'
 import { useI18n } from '../i18n'
 import { PointerResizeShield, usePointerResize } from '../PointerResize'
 import { OVERLAY_DOCK, type SpaceMode } from './useWorkspaceLayout'
+import { useInspectorOpen } from './inspector'
+import { InspectorColumn } from './InspectorColumn'
 
-export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onResize, onReset, onFocus, onDismiss, capsule }: {
+export function Workspace({
+  mode, canvas, dock, dockWidth, bounds, splitMax, onResize, onReset, onFocus, onDismiss, capsule,
+  inspectorWidth, inspectorBounds, inspectorOverlay, canvasFitsInspector, onInspectorResize, onInspectorReset,
+}: {
   mode: SpaceMode
   canvas: ReactNode
   dock: ReactNode
@@ -49,6 +54,15 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onR
   onDismiss: () => void
   /** 覆盖态收起时右下角的会话胶囊（13 §13.1）；其余档传 null */
   capsule?: ReactNode
+  /** Inspector（Git / Worktree）列宽与区间 */
+  inspectorWidth: number
+  inspectorBounds: { min: number; max: number }
+  /** expanded 档：Inspector 也走覆盖式（与 Dock 同语义） */
+  inspectorOverlay: boolean
+  /** Inspector 打开后 Canvas 还够不够 560：不够就让位 */
+  canvasFitsInspector: boolean
+  onInspectorResize: (width: number) => void
+  onInspectorReset: () => void
 }) {
   const { t } = useI18n()
   const { active, start } = usePointerResize()
@@ -97,6 +111,7 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onR
     })
   }, [dockWidth, clamp, onResize, onFocus, splitMax, start])
 
+
   // 键盘调宽是一次一档，不存在高频重排，直接提交
   const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'ArrowLeft') {
@@ -112,6 +127,12 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onR
 
   const focus = mode === 'focus'
   const overlay = mode === 'overlay'
+
+  // Inspector 占用与否由槽位登记决定（面板自己 portal 进来），Shell 只管留不留这一列
+  const insOpen = useInspectorOpen()
+  const insInline = insOpen && !inspectorOverlay
+  // 三列摆不下时让 Canvas（图纸 §三：让页面，不让终端）
+  const canvasHidden = focus || (insInline && !canvasFitsInspector)
 
   const dockStyle: CSSProperties = overlay
     ? {
@@ -140,7 +161,7 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onR
     // （终端也跟着多算 40px，最后一行同样看不见）。跟着 Layout 的列走 flex:1 即可。
     <div style={{ position: 'relative', display: 'flex', height: '100%', minHeight: 0, minWidth: 0, flex: 1 }}>
       <div style={{
-        flex: focus ? '0 0 0px' : '1 1 auto', width: focus ? 0 : undefined,
+        flex: canvasHidden ? '0 0 0px' : '1 1 auto', width: canvasHidden ? 0 : undefined,
         minWidth: 0, height: '100%', minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column',
       }}>
         {canvas}
@@ -171,6 +192,11 @@ export function Workspace({ mode, canvas, dock, dockWidth, bounds, splitMax, onR
         aria-label={overlay ? t('workspace.terminalPanel') : undefined}>
         {dock}
       </div>
+
+      {/* Inspector：Git / Worktree 这一列（图纸 panels-desktop.html）。
+          它自带 rail 与拖拽——没有终端时 App 走的是另一棵树，那边也要有同一列。 */}
+      <InspectorColumn width={inspectorWidth} bounds={inspectorBounds}
+        overlay={inspectorOverlay} onResize={onInspectorResize} onReset={onInspectorReset} />
 
       {capsule}
 

--- a/frontend/src/shell/inspector.ts
+++ b/frontend/src/shell/inspector.ts
@@ -1,0 +1,89 @@
+// Inspector 槽位（14 桌面面板稿 panels-desktop.html）。
+//
+// Git / Worktree 这些右侧面板此前是 `position:fixed` 浮层，**不参与 Shell 的尺寸契约**——
+// 浮层只会「盖」，不会「让」。实测 1440 上会话页开 Git：终端从 605 被盖到只剩 185。
+// 现在它们成为 Shell 的第三列，和 Dock 同级。
+//
+// 难点是「谁来渲染」：Git 面板挂在 TerminalPane 里（Dock 深处）、项目页那份挂在页面里，
+// 而列要由 Workspace 画。与其把内容一路 prop 提上去，不如沿用本仓库已有的
+// 模块级小表 + useSyncExternalStore 套路（session-label / session-project / intents）：
+//   · Workspace 提供槽位 DOM，登记到这里；
+//   · AdaptivePanel 在桌面档把自己 portal 进槽位；
+//   · Workspace 订阅「有没有人占用」，决定列的宽度与那条 rail。
+//
+// 栈而不是单值：从 Git 面板里还能唤起 Worktree（GitPanel 内部就渲染着 WorktreePanel）。
+// 只有栈顶那个真正渲染，**关掉栈顶会自然露出下面那个**——「从 Git 跳 Worktree 再回来」
+// 因此是免费的，不需要额外做返回箭头。
+import { useSyncExternalStore } from 'react'
+
+let slot: HTMLElement | null = null
+/** 登记顺序即栈序；只有最后一个渲染 */
+let stack: number[] = []
+let seq = 0
+const listeners = new Set<() => void>()
+
+function emit() { listeners.forEach((fn) => fn()) }
+function subscribe(fn: () => void) {
+  listeners.add(fn)
+  return () => listeners.delete(fn)
+}
+
+/** Workspace 挂载/卸载槽位 DOM */
+export function setInspectorSlot(el: HTMLElement | null) {
+  if (slot === el) return
+  slot = el
+  emit()
+}
+
+export function claimInspector(): number {
+  const id = ++seq
+  stack.push(id)
+  emit()
+  return id
+}
+
+export function releaseInspector(id: number) {
+  const next = stack.filter((x) => x !== id)
+  if (next.length === stack.length) return
+  stack = next
+  emit()
+}
+
+/** 这一列当前实际占掉的宽度（覆盖态算 0）——文件抽屉那类仍然浮着的层要避开它 */
+let reserved = 0
+export function setInspectorReserved(px: number) {
+  if (reserved === px) return
+  reserved = px
+  emit()
+}
+export function useInspectorReserved(): number {
+  return useSyncExternalStore(subscribe, () => reserved, () => 0)
+}
+
+type Snapshot = { slot: HTMLElement | null; top: number }
+let snap: Snapshot = { slot: null, top: 0 }
+function read(): Snapshot {
+  const top = stack.length ? stack[stack.length - 1] : 0
+  if (snap.slot !== slot || snap.top !== top) snap = { slot, top }
+  return snap
+}
+
+/** 面板侧：拿槽位 + 自己是不是栈顶 */
+export function useInspectorSlot(id: number): { slot: HTMLElement | null; isTop: boolean } {
+  const s = useSyncExternalStore(subscribe, read, read)
+  return { slot: s.slot, isTop: s.top === id }
+}
+
+/** Shell 侧：有没有人占着 */
+export function useInspectorOpen(): boolean {
+  return useSyncExternalStore(subscribe, () => stack.length > 0, () => false)
+}
+
+/** 仅供测试 */
+export function resetInspector() {
+  slot = null
+  stack = []
+  seq = 0
+  reserved = 0
+  snap = { slot: null, top: 0 }
+}

--- a/frontend/src/shell/useWorkspaceLayout.ts
+++ b/frontend/src/shell/useWorkspaceLayout.ts
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLayout, type WindowSize } from '../layout'
 import { usePreferences, saveWorkspace } from '../preferences'
+import { useInspectorOpen } from './inspector'
 
 /** 尺寸契约，与 index.css 的 --canvas-min / --dock-* 同源（14 §8.2）。 */
 export const CANVAS_MIN = 560
@@ -19,6 +20,13 @@ export const NAV_WIDTH = 224
 export const NAV_RAIL = 64
 /** expanded 档覆盖式终端面板的宽度（13 §13.1）。 */
 export const OVERLAY_DOCK = 480
+
+/** Inspector（Git / Worktree 列）的尺寸契约，见 14-desktop-workspace/panels-desktop.html */
+export const INSPECTOR_MIN = 360
+export const INSPECTOR_DEFAULT = 420
+export const INSPECTOR_MAX = 880
+/** 面板内左右分栏（列表 ｜ diff）的阈值：280 列表 + 8 + 400 diff + 32 padding */
+export const INSPECTOR_SPLIT = 720
 
 export type SpaceMode = 'page' | 'split' | 'focus' | 'overlay'
 export type FocusTarget = 'none' | 'page' | 'dock'
@@ -64,6 +72,46 @@ export function defaultDockWidth(viewportWidth: number, workspaceWidth: number):
   const wish = Math.min(DOCK_MAX, Math.round(viewportWidth * 0.42))
   const { min, max } = dockBounds(workspaceWidth)
   return Math.max(min, Math.min(max, wish))
+}
+
+/**
+ * Inspector 打开之后，Canvas 还保不保得住 560。
+ *
+ * 判据用 **Dock 的下限**而不是它当前的宽度：宽屏上默认 Dock 是 42vw（1920 上 806），
+ * 拿当前宽度判的话三列永远凑不齐——1920 都要把页面整个让掉，而那正是买大屏要避免的。
+ * 所以顺序是「**先从 Dock 借，借不够再让 Canvas**」，见 effectiveDockWidth。
+ */
+export function canvasFitsWith(o: {
+  workspaceWidth: number; inspectorWidth: number; hasDock: boolean
+}): boolean {
+  const used = (o.hasDock ? DOCK_MIN + SPLIT_RAIL : 0) + o.inspectorWidth + SPLIT_RAIL
+  return o.workspaceWidth - used >= CANVAS_MIN
+}
+
+/**
+ * Inspector 打开时 Dock 实际渲染多宽。
+ *
+ * 保得住 Canvas 就从 Dock 借到刚好（不低于 480、也不超过用户拖出来的宽度）；
+ * 保不住就不折腾终端——Canvas 反正要整个让掉，Dock 用回用户那个宽度。
+ * 借宽会让终端 fit 一次，但「终端窄 13%」远好过「页面整个消失」。
+ */
+export function effectiveDockWidth(o: {
+  workspaceWidth: number; dockWidth: number; inspectorWidth: number; inspectorOpen: boolean
+}): number {
+  if (!o.inspectorOpen) return o.dockWidth
+  if (!canvasFitsWith({ workspaceWidth: o.workspaceWidth, inspectorWidth: o.inspectorWidth, hasDock: true })) {
+    return o.dockWidth
+  }
+  const room = o.workspaceWidth - CANVAS_MIN - SPLIT_RAIL * 2 - o.inspectorWidth
+  return Math.max(DOCK_MIN, Math.min(o.dockWidth, room))
+}
+
+/** Inspector 的拖拽区间：下界 360，上界不能把 Dock 挤破 */
+export function inspectorBounds(o: {
+  workspaceWidth: number; dockWidth: number; hasDock: boolean
+}): { min: number; max: number } {
+  const room = o.workspaceWidth - SPLIT_RAIL - (o.hasDock ? o.dockWidth + SPLIT_RAIL : 0)
+  return { min: INSPECTOR_MIN, max: Math.max(INSPECTOR_MIN, Math.min(INSPECTOR_MAX, room)) }
 }
 
 /** 并排是否成立：Canvas 560 + rail 8 + Dock 480（不含导航）。 */
@@ -116,6 +164,15 @@ export type WorkspaceLayout = {
   bounds: { min: number; max: number }
   /** 超过这个宽度就该落进 Focus（Canvas 会低于 560） */
   splitMax: number
+  /** Inspector 列宽（Git / Worktree），已按当前几何钳过 */
+  inspectorWidth: number
+  inspectorBounds: { min: number; max: number }
+  setInspectorWidth: (width: number) => void
+  resetInspectorWidth: () => void
+  /** Inspector 打开时 Canvas 还够不够 560——不够就让位 */
+  canvasFitsInspector: boolean
+  /** Dock 实际渲染宽度：Inspector 打开时可能被借走一部分 */
+  dockRenderWidth: number
 }
 
 /**
@@ -138,6 +195,7 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   const [focus, setFocusLocal] = useState<FocusTarget>(ws.workspaceFocus)
   const [navCollapsed, setNavCollapsedLocal] = useState(ws.navCollapsed)
   const [width, setWidthLocal] = useState(ws.dockWidth || 0)
+  const [insWidth, setInsWidthLocal] = useState(ws.inspectorWidth || 0)
   const hydrated = useRef(false)
 
   // 偏好从服务端到达后同步一次（首屏时 usePreferences 还是默认值）
@@ -148,7 +206,8 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     setFocusLocal(ws.workspaceFocus)
     setNavCollapsedLocal(ws.navCollapsed)
     setWidthLocal(ws.dockWidth || 0)
-  }, [ws.dockOpen, ws.workspaceFocus, ws.navCollapsed, ws.dockWidth])
+    setInsWidthLocal(ws.inspectorWidth || 0)
+  }, [ws.dockOpen, ws.workspaceFocus, ws.navCollapsed, ws.dockWidth, ws.inspectorWidth])
 
   const splitCapable = layout.size === 'large'
   const navWidth = splitCapable ? (navCollapsed ? NAV_RAIL : NAV_WIDTH) : NAV_RAIL
@@ -164,6 +223,18 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   }, [width, viewport, workspaceWidth])
 
   const mode = resolveMode({ hasTerms, dockOpen, focus, size: layout.size, workspaceWidth })
+
+  // Inspector 宽度同样先钳后用：换到窄窗口不能拿旧大屏的宽度把 Dock 挤破
+  const hasDock = mode === 'split'
+  const inspectorOpen = useInspectorOpen() && splitCapable
+  const insBounds = useMemo(
+    () => inspectorBounds({ workspaceWidth, dockWidth, hasDock }),
+    [workspaceWidth, dockWidth, hasDock],
+  )
+  const inspectorWidth = useMemo(() => {
+    const wish = insWidth || INSPECTOR_DEFAULT
+    return Math.max(insBounds.min, Math.min(insBounds.max, wish))
+  }, [insWidth, insBounds])
 
   const setDockOpen = useCallback((open: boolean) => {
     setDockOpenLocal(open)
@@ -182,6 +253,15 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     saveWorkspace({ dockWidth: clamped })
   }, [workspaceWidth])
 
+  // 打开 Inspector 时先从 Dock 借宽；借不够时 Canvas 让位（此时 Dock 用回原宽）
+  const dockRenderWidth = effectiveDockWidth({ workspaceWidth, dockWidth, inspectorWidth, inspectorOpen: inspectorOpen && hasDock })
+
+  const setInspectorWidth = useCallback((next: number) => {
+    const clamped = Math.round(Math.max(insBounds.min, Math.min(insBounds.max, next)))
+    setInsWidthLocal(clamped)
+    saveWorkspace({ inspectorWidth: clamped })
+  }, [insBounds])
+
   const setNavCollapsed = useCallback((collapsed: boolean) => {
     setNavCollapsedLocal(collapsed)
     saveWorkspace({ navCollapsed: collapsed })
@@ -197,6 +277,12 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     overlayCapable: layout.size === 'expanded',
     bounds,
     splitMax,
+    inspectorWidth,
+    inspectorBounds: insBounds,
+    setInspectorWidth,
+    resetInspectorWidth: () => { setInsWidthLocal(0); saveWorkspace({ inspectorWidth: 0 }) },
+    canvasFitsInspector: canvasFitsWith({ workspaceWidth, inspectorWidth, hasDock }),
+    dockRenderWidth,
     toggleDock: () => setDockOpen(!dockOpen),
     setDockOpen,
     setDockWidth,

--- a/frontend/src/shell/workspace-layout.test.ts
+++ b/frontend/src/shell/workspace-layout.test.ts
@@ -3,7 +3,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   dockBounds, defaultDockWidth, canSplit, resolveMode, dragMaxWidth, shouldFocusAt,
+  canvasFitsWith, effectiveDockWidth, inspectorBounds,
   CANVAS_MIN, DOCK_MIN, DOCK_MAX, SPLIT_RAIL, NAV_WIDTH, NAV_RAIL, OVERLAY_DOCK,
+  INSPECTOR_MIN, INSPECTOR_DEFAULT, INSPECTOR_MAX,
 } from './useWorkspaceLayout'
 
 /** 工作区宽 = 视口 - 导航（导航展开与否影响很大，1280 档尤其） */
@@ -121,5 +123,57 @@ describe('四态判定', () => {
     // 这一档 Canvas 最窄是 905-64=841，扣掉 480 还剩 361 的可见页面 —— 遮罩下仍看得见上下文
     expect(OVERLAY_DOCK).toBe(DOCK_MIN)
     expect(905 - NAV_RAIL - OVERLAY_DOCK).toBeGreaterThan(0)
+  })
+})
+
+
+// Inspector（Git / Worktree 列）的让位次序，见 14-desktop-workspace/panels-desktop.html。
+// 规则是两步：**先从 Dock 借宽，借不够再让 Canvas**。初版写死「让页面不让终端」，
+// 实测 1920 上页面照样整个消失——因为默认 Dock 是 42vw，拿它去判永远凑不齐三列。
+describe('Inspector 让位次序', () => {
+  const ins = INSPECTOR_DEFAULT
+
+  it('宽屏：从 Dock 借宽，三列都在，页面保住 560', () => {
+    const w = workspace(1920) // 1696
+    expect(canvasFitsWith({ workspaceWidth: w, inspectorWidth: ins, hasDock: true })).toBe(true)
+    const dock = effectiveDockWidth({
+      workspaceWidth: w, dockWidth: defaultDockWidth(1920, w), inspectorWidth: ins, inspectorOpen: true,
+    })
+    expect(dock).toBeGreaterThanOrEqual(DOCK_MIN)
+    expect(w - dock - SPLIT_RAIL * 2 - ins).toBeGreaterThanOrEqual(CANVAS_MIN)
+  })
+
+  it('1440：借不够，Canvas 让位，且 Dock 用回原宽（终端一寸不变）', () => {
+    const w = workspace(1440) // 1216
+    expect(canvasFitsWith({ workspaceWidth: w, inspectorWidth: ins, hasDock: true })).toBe(false)
+    const mine = defaultDockWidth(1440, w)
+    expect(effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true }))
+      .toBe(mine)
+  })
+
+  it('借宽绝不越过用户拖出来的宽度，也绝不低于 480', () => {
+    for (const viewport of [1280, 1440, 1680, 1920, 2560]) {
+      const w = workspace(viewport)
+      for (const mine of [DOCK_MIN, 600, 880]) {
+        const got = effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true })
+        expect(got).toBeLessThanOrEqual(mine)
+        expect(got).toBeGreaterThanOrEqual(DOCK_MIN)
+      }
+    }
+  })
+
+  it('没开 Inspector 时 Dock 宽度原样返回', () => {
+    expect(effectiveDockWidth({ workspaceWidth: 1216, dockWidth: 605, inspectorWidth: ins, inspectorOpen: false }))
+      .toBe(605)
+  })
+
+  it('Inspector 区间：下界 360、上界不越过 Dock 的地盘', () => {
+    for (const viewport of [1280, 1440, 1920]) {
+      const w = workspace(viewport)
+      const b = inspectorBounds({ workspaceWidth: w, dockWidth: defaultDockWidth(viewport, w), hasDock: true })
+      expect(b.min).toBe(INSPECTOR_MIN)
+      expect(b.max).toBeLessThanOrEqual(INSPECTOR_MAX)
+      expect(b.max).toBeGreaterThanOrEqual(INSPECTOR_MIN)
+    }
   })
 })


### PR DESCRIPTION
> 叠在 #149 之上（base 指向 `mobile/panels-subpage`）。#149 合入 main 后 GitHub 会自动把 base 改到 main，届时本 PR 只剩一个提交的 diff。

## 为什么

#149 把 Git/Worktree 在**手机**上收进了全屏二级页，桌面是**刻意冻住**的（那轮的验收标准就是「桌面逐像素不变」）。但桌面本身更糙：**同一个面板有四种壳**，其中一种会把终端盖掉 70%。

1440 实测：

| | 位置 | 问题 |
|---|---|---|
| ① 会话页 Git | `fixed` 420, z=1200 | Dock 在 x=835 宽 605，面板 x=1020 宽 420 → **终端只剩 185px**；而你打开 Git 恰恰是要对着终端里的改动看。左边 603px 的会话列表全程没人看 |
| ② 项目页 Git | 520 + **全屏遮罩** | 同一个 `<GitPanel>`，宽度、有没有遮罩全不一样。遮罩 = 模态 = 「先关掉才能干别的」，而 Git 恰恰要边看边干 |
| ③ Worktree | antd `Drawer` | 第三种遮罩、第三种进场动画 |
| ④ diff 详情 | `right: calc(100vw − panelLeft)` | 位置随面板算、宽度随剩余空间算，既不是列也不是抽屉 |

根因一句话：**这些面板浮在 Workspace Shell 之上，不参与 Canvas/Dock 的尺寸契约**（14 §4.2）。浮层只会「盖」，不会「让」。手机上正确答案是整页（#149 已做）；桌面上正确答案是——**成为 Shell 的一列**。

## 图纸

[`14-desktop-workspace/panels-desktop.html`](docs/design/web/14-desktop-workspace/panels-desktop.html)：现状四帧 / 新版四帧 / 契约表 / **自审 8 条** / 分期。

## Inspector：Shell 的第三列

- **`shell/inspector.ts`** — 槽位登记（模块级栈 + `useSyncExternalStore`，与 `session-label` 同套路）。面板挂在 TerminalPane、页面深处，列由 Shell 画，中间靠 portal 接，不用把内容一路 prop 提上去。
- **`shell/InspectorColumn.tsx`** — 列 + rail + 拖拽。拖动期间只移动引导线、`pointerup` 才提交（沿用 #139：每帧改宽会让终端反复 fit → SIGWINCH → 闪屏）。单独成组件是因为有终端/没终端走的是两棵不同的树。
- **`AdaptivePanel`** 桌面分支改成 portal 进槽位，三个调用点的 `width/right/scrim/zIndex` 参数全部消失——宽度归 Shell 管。
- **非栈顶的面板藏起来而不是卸载**：`WorktreePanel` 就渲染在 `GitPanel` 子树里，卸载 Git 会连它一起卸掉 → 释放槽位 → Git 又成栈顶重挂，表现为「点了 Worktree 没反应」（实测踩到）。藏起来还让「从 Git 跳 Worktree 再回来」变成免费的。

## 让位次序：先从 Dock 借宽，借不够再让 Canvas

图纸初版写死「让页面，不让终端」，**实测发现这条太绝对**：1920 上打开 Git 页面照样整个消失——默认 Dock 是 42vw（1920 上 806），拿它去判永远凑不齐三列。而「终端窄 13%」显然比「页面整个消失」划算，那正是买大屏的理由。

改成两步（判据用 Dock 的**下限**）：

| 屏宽 | 结果 |
|---|---|
| 1920 | canvas **560** / 终端 794 → **688** / inspector 420 —— **三列都在** |
| 1440 | 借不够 → canvas 让位；**终端 593 → 593 一寸不变**（只是整体左移），连 fit 都不触发 |
| 1100 (expanded) | 沿用 Dock 的 overlay 语义 + 遮罩，canvas 宽度不受影响 |
| 390 | 不变，仍是 #149 的全屏二级页 |

## 其他

- **桌面不再有遮罩**；宽度可拖、双击复位、写进 `preferences.inspectorWidth`，恢复时按当前几何钳制
- `WorktreePanel` 长出自己的面板头（抽屉原来提供的标题与关闭）
- 文件抽屉这一轮仍是浮层（P4 再收），但按 Inspector 占宽往左让，不再盖住那一列
- 契约进单测：借宽绝不越过用户拖出来的宽度、绝不低于 480

## 验收

1920 / 1680 / 1440 / 1100 / 390 逐档 reload 实测（CDP 改视口不触发 matchMedia）；Git↔Worktree 叠放与返回、拖宽与双击复位、各档均无横向溢出；手机仍是 z=90 的全屏二级页，槽位在手机上根本不存在。

门禁：`typecheck` / `i18n:check`（1478 keys）/ `vitest`（100）/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
