### PR TITLE
桌面页头：页名并进工具条，概览去掉重复计数

### DIFF
--- a/docs/design/web/14-desktop-workspace/pagehead.html
+++ b/docs/design/web/14-desktop-workspace/pagehead.html
@@ -1,0 +1,299 @@
+<!doctype html>
+<html lang="zh-CN"><head><meta charset="utf-8"><title>桌面页头：标题与工具条合并成一行</title>
+<style>
+:root{
+  --bg:#0d1117;--card:#161b22;--inset:#0b0f14;--line:#21262d;--line2:#30363d;
+  --tx:#e6edf3;--dim:#8b949e;--dimmer:#6e7681;
+  --acc:#58a6ff;--solid:#4e90dc;--soft:rgba(31,111,235,.14);--accb:rgba(88,166,255,.45);
+  --amber:#d29922;--green:#3fb950;--cyan:#39c5cf;--red:#f85149;
+  --micro:11px;--meta:12px;--sm:13px;--body:15px;--lg:16px;
+  --rp:999px;
+}
+*{box-sizing:border-box}
+body{margin:0;background:#07090d;color:var(--tx);font:14px/1.6 Inter,-apple-system,"PingFang SC",sans-serif}
+.wrap{max-width:1120px;margin:0 auto;padding:30px 22px 80px}
+h1{font-size:22px;margin:0 0 8px}
+h2{font-size:var(--lg);margin:36px 0 6px;padding-top:22px;border-top:1px solid var(--line)}
+.lede{color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch;margin:0 0 14px}
+.lede b{color:var(--tx)}
+code{font:var(--meta)/1.4 ui-monospace,monospace;color:#c9d5e2;background:rgba(148,163,184,.1);padding:2px 6px;border-radius:4px}
+ul.meas{margin:0 0 20px;padding-left:19px;color:var(--dim);font-size:var(--sm);line-height:1.9;max-width:80ch}
+ul.meas b{color:#f2a6a0;font:600 var(--sm)/1 ui-monospace,monospace}
+ol.sr{margin:0;padding-left:20px;color:var(--dim);font-size:var(--sm);line-height:1.85;max-width:80ch}
+ol.sr li{margin-bottom:10px} ol.sr b{color:var(--tx)} ol.sr em{font-style:normal;color:#f2a6a0}
+.cap{display:flex;align-items:center;gap:8px;margin:18px 0 8px;font-size:var(--meta);color:var(--dim)}
+.cap b{color:var(--tx);font-size:var(--sm)}
+.tag{font-size:var(--micro);padding:1px 8px;border-radius:var(--rp);border:1px solid var(--line2);color:var(--dimmer)}
+.tag.bad{color:#f2a6a0;border-color:rgba(248,81,73,.42)}
+.tag.good{color:#7fd18f;border-color:rgba(63,185,80,.42)}
+.note{margin:10px 0 0;font-size:var(--meta);color:var(--dim);line-height:1.8;max-width:80ch}
+.note u{text-decoration:none;color:var(--tx)} .note em{font-style:normal;color:#f2a6a0}
+
+/* 画布：真实 1440 宽（侧栏 224 + Canvas 1216），缩到 .72 */
+.stage{overflow:hidden;border-radius:10px;border:1px solid var(--line2);background:var(--bg)}
+.dk{zoom:.72;width:1440px;display:flex}
+.side{flex:0 0 224px;background:var(--card);border-right:1px solid var(--line);padding:12px 10px}
+.side .lg{font-size:17px;font-weight:800;margin-bottom:10px}
+.side .grp{font-size:11px;color:var(--dimmer);margin:10px 0 4px;padding-left:8px}
+.side i{display:block;font-style:normal;font-size:14px;color:var(--dim);padding:8px 10px;border-radius:8px}
+.side i.on{color:var(--acc);background:var(--soft);position:relative}
+.side i.on::before{content:"";position:absolute;left:0;top:8px;bottom:8px;width:3px;border-radius:2px;background:var(--acc)}
+.cv{flex:1;min-width:0;padding:16px}
+
+.kick{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--dimmer);font-weight:700}
+.ttl{font-size:26px;font-weight:700;letter-spacing:-.02em;margin:4px 0 0}
+.sub{font-size:13px;color:var(--dim);margin:7px 0 0}
+.bar{display:flex;align-items:center;gap:9px;height:44px;margin-top:14px}
+.bar .sp{flex:1}
+.srch{height:30px;flex:0 0 200px;border:1px solid var(--line2);border-radius:10px;background:var(--card);
+  display:flex;align-items:center;padding:0 11px;color:var(--dimmer);font-size:12px;gap:7px}
+.chip{height:28px;padding:0 13px;border-radius:var(--rp);border:1px solid var(--line2);
+  display:inline-flex;align-items:center;gap:7px;font-size:12px;color:var(--dim);white-space:nowrap}
+.chip.on{color:var(--acc);border-color:var(--accb);background:var(--soft)}
+.chip .n{font:11px/1 ui-monospace,monospace;color:var(--dimmer)}
+.cards{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:16px}
+.pc{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:13px 14px}
+.pc b{font-size:15px}
+.pc .p{font:11px/1.3 ui-monospace,monospace;color:var(--dimmer);margin-top:4px}
+.pc .m{font-size:12px;color:var(--dim);margin-top:8px}
+.pc .t{background:var(--inset);border-radius:6px;padding:7px 9px;margin-top:9px;display:flex;align-items:center;gap:8px;font-size:13px}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--green);flex:0 0 auto}
+.pc .t .tm{margin-left:auto;font-size:12px;color:var(--dimmer)}
+
+/* 一行式页头 */
+.head1{display:flex;align-items:center;gap:12px;height:44px}
+.head1 .h{font-size:19px;font-weight:700;letter-spacing:-.01em;flex:0 0 auto}
+.head1 .cnt{font:12px/1 ui-monospace,monospace;color:var(--dimmer)}
+.head1 .div{width:1px;height:18px;background:var(--line2);flex:0 0 auto}
+.head1 .sp{flex:1}
+
+.void{background:repeating-linear-gradient(45deg,rgba(248,81,73,.14),rgba(248,81,73,.14) 6px,transparent 6px,transparent 13px);
+  border:1px dashed rgba(248,81,73,.6);border-radius:5px;display:grid;place-items:center;
+  font:12px/1.35 ui-monospace,monospace;color:#f2a6a0;text-align:center}
+.ok{border:1px dashed rgba(63,185,80,.55);border-radius:5px;background:rgba(63,185,80,.07);
+  display:grid;place-items:center;font:12px/1.35 ui-monospace,monospace;color:#7fd18f}
+table.tt{border-collapse:collapse;width:100%;font-size:var(--sm);margin:8px 0 18px}
+table.tt th,table.tt td{text-align:left;padding:8px 11px;border-bottom:1px solid var(--line);vertical-align:top}
+table.tt th{color:var(--dimmer);font-size:var(--meta);font-weight:600}
+table.tt td{color:var(--dim)} table.tt td b{color:var(--tx)}
+</style></head><body><div class="wrap">
+
+<h1>桌面页头：标题与工具条合并成一行</h1>
+<p class="lede">
+项目页在第一张卡片之前要花掉 <b>147px</b>，而这段里绝大部分在重复左边侧栏刚说过的话——
+侧栏此刻正高亮着<b>「工作区 › 项目」</b>，页面又写一遍眉标「工作区」、大标题「项目」，
+再加一句功能清单。1440×900 实测：
+</p>
+<ul class="meas">
+  <li>页头（眉标 + 标题 + 说明）<b>91px</b>；工具条 <b>44px</b>；第一张卡片在 <b>y=203</b></li>
+  <li>视口 900 高 → <b>16%</b> 的首屏在说「你在项目页」，而侧栏已经用高亮说过了</li>
+  <li>工具条自己也空：搜索 200px 贴左（x=240），排序甩到 x≈1330，中间 <b>≈700px</b> 什么都没有</li>
+</ul>
+
+<h2>一、现状</h2>
+<p class="cap"><b>项目页</b><span class="tag bad">147px chrome · 三层重复 · 工具条中间空 700</span></p>
+<div class="stage"><div class="dk">
+  <div class="side">
+    <div class="lg">Roam</div>
+    <div class="grp">工作区</div>
+    <i>概览</i><i class="on">项目</i><i>会话</i><i>文件</i>
+    <div class="grp">工具</div><i>浏览器</i>
+  </div>
+  <div class="cv">
+    <div style="display:flex;gap:10px;align-items:flex-start">
+      <div style="flex:1;min-width:0">
+        <div class="kick">工作区</div>
+        <div class="ttl">项目</div>
+        <div class="sub">从仓库进入任务、文件、Git、Worktree 与蜂群</div>
+      </div>
+      <div class="void" style="width:210px;height:74px">侧栏已经写着<br>「工作区 › 项目」</div>
+    </div>
+    <div class="bar">
+      <span class="srch">⌕ 搜索项目或路径</span>
+      <span class="chip on">全部 <span class="n">12</span></span>
+      <span class="chip">活跃 <span class="n">8</span></span>
+      <span class="chip">待收尾 <span class="n">0</span></span>
+      <span class="void" style="flex:1;height:22px;margin:0 8px">≈700px</span>
+      <span class="chip">最近活跃 ⌄</span>
+    </div>
+    <div class="cards">
+      <div class="pc"><b>blade-oauth</b><div class="p">/home/ai/codes/blade-oauth</div>
+        <div class="m"><b>1</b> 任务 · <b>4</b> worktree</div>
+        <div class="t"><i class="dot"></i>auth接入第三方<span class="tm">7 分钟前</span></div></div>
+      <div class="pc"><b>roam</b><div class="p">/home/ai/codes/ttmux</div>
+        <div class="m"><b>2</b> 任务 · <b>1</b> worktree</div>
+        <div class="t"><i class="dot"></i>桌面版页面也出一版<span class="tm">刚刚</span></div></div>
+      <div class="pc"><b>临时</b><div class="p">/home/ai/codes/tmp</div>
+        <div class="m"><b>2</b> 任务</div>
+        <div class="t"><i class="dot"></i>ds4双机部署<span class="tm">4 分钟前</span></div></div>
+    </div>
+  </div>
+</div></div>
+<p class="note">
+三层各自看都没错，<u>叠在一起才是问题</u>：眉标说分组、标题说页名、说明句列功能——
+而这三件事左边那条高亮的导航项一次全说完了。说明句尤其：
+「从仓库进入任务、文件、Git、Worktree 与蜂群」是功能清单，<b>第二次打开这一页就不再需要</b>。
+</p>
+
+<h2>二、新版：一行页头</h2>
+<p class="cap"><b>项目页（新）</b><span class="tag good">147 → 60px · 首屏多出 143px</span></p>
+<div class="stage"><div class="dk">
+  <div class="side">
+    <div class="lg">Roam</div>
+    <div class="grp">工作区</div>
+    <i>概览</i><i class="on">项目</i><i>会话</i><i>文件</i>
+    <div class="grp">工具</div><i>浏览器</i>
+  </div>
+  <div class="cv">
+    <div class="head1">
+      <span class="h">项目</span>
+      <span class="div"></span>
+      <span class="chip on">全部 <span class="n">12</span></span>
+      <span class="chip">活跃 <span class="n">8</span></span>
+      <span class="chip">待收尾 <span class="n">0</span></span>
+      <span class="sp"></span>
+      <span class="srch">⌕ 搜索项目或路径</span>
+      <span class="chip">最近活跃 ⌄</span>
+    </div>
+    <div class="cards" style="margin-top:14px">
+      <div class="pc"><b>blade-oauth</b><div class="p">/home/ai/codes/blade-oauth</div>
+        <div class="m"><b>1</b> 任务 · <b>4</b> worktree</div>
+        <div class="t"><i class="dot"></i>auth接入第三方<span class="tm">7 分钟前</span></div></div>
+      <div class="pc"><b>roam</b><div class="p">/home/ai/codes/ttmux</div>
+        <div class="m"><b>2</b> 任务 · <b>1</b> worktree</div>
+        <div class="t"><i class="dot"></i>桌面版页面也出一版<span class="tm">刚刚</span></div>
+        <div class="t"><i class="dot"></i>roam-bug修复<span class="tm">11 小时前</span></div></div>
+      <div class="pc"><b>临时</b><div class="p">/home/ai/codes/tmp</div>
+        <div class="m"><b>2</b> 任务</div>
+        <div class="t"><i class="dot"></i>ds4双机部署<span class="tm">4 分钟前</span></div>
+        <div class="t"><i class="dot"></i>你看看-jetson@192<span class="tm">12 小时前</span></div></div>
+    </div>
+    <div class="cards" style="margin-top:18px">
+      <div class="pc"><b>xiaohui-app</b><div class="p">/home/ai/codes/ybz/xh/XiaoHui</div>
+        <div class="m"><b>2</b> 任务 · <b>2</b> worktree</div></div>
+      <div class="pc"><b>blade-agent</b><div class="p">/home/ai/codes/blade-agent</div>
+        <div class="m"><b>1</b> 任务 · <b>1</b> worktree</div></div>
+      <div class="pc"><b>blade-service-deployer</b><div class="p">/home/ai/codes/…</div>
+        <div class="m"><b>1</b> 任务</div></div>
+    </div>
+  </div>
+</div></div>
+<p class="note">
+一行 44：<b>页名 + 总数 ｜ 筛选</b> 贴左，<b>搜索 + 排序</b> 贴右。<br>
+· 眉标删掉——侧栏的分组标题就是它；<br>
+· 说明句删掉——功能清单进 <code>title</code>，鼠标停在页名上还能看到；<br>
+· 页名保留但降到 19px：<u>它仍然是「我在哪」的锚点</u>，滚动时这条是 sticky 的，
+  只有它跟着走才知道这些卡片属于哪一页（会话页尤其，两页的卡片长得不一样但都是卡片）；<br>
+· 搜索从最左挪到最右，与排序作伴——<b>左端回答「看什么」，右端放「怎么找」</b>，
+  中间那 700px 的空白也就没有了。
+</p>
+
+<h2>三、概览页：另一个毛病</h2>
+<p class="lede">
+概览的 h2 是<b>内容</b>（「早上好，当前没有待处理事项」）不是页名，所以不并行——但它有另一处重复。
+1440 实测：眉标 <b>y=56</b>、标题 <b>y=78</b>、副句 <b>y=112</b>、状态条 <b>y=109</b>，内容从 <b>y=149</b> 开始。
+</p>
+<div class="cap"><b>现状</b><span class="tag bad">同一个「12」写两遍 · 中间空 800</span></div>
+<div class="stage"><div class="dk">
+  <div class="side">
+    <div class="lg">Roam</div><div class="grp">工作区</div>
+    <i class="on">概览</i><i>项目</i><i>会话</i><i>文件</i>
+  </div>
+  <div class="cv">
+    <div class="kick">8月4日星期二</div>
+    <div class="ttl" style="font-size:24px">早上好，当前没有待处理事项</div>
+    <div style="display:flex;align-items:center;margin-top:7px">
+      <div class="sub" style="margin:0"><b style="color:#f2a6a0">12</b> 个任务正在运行，最近一次活动在刚刚</div>
+      <div class="void" style="flex:1;height:20px;margin:0 10px">≈800px</div>
+      <div style="font-size:12px;color:var(--dim)"><i class="dot" style="display:inline-block"></i>
+        <b style="font-family:ui-monospace,monospace;color:#f2a6a0">12</b> 运行中</div>
+    </div>
+    <div style="display:flex;align-items:center;gap:9px;margin-top:20px;font-size:13px;font-weight:600">最近会话
+      <span style="flex:1"></span><span style="color:var(--acc);font-weight:400;font-size:12px">全部会话 ›</span></div>
+    <div class="pc" style="margin-top:8px;background:none;border:0;padding:0">
+      <div class="t" style="background:none;border-bottom:1px solid var(--line);border-radius:0">
+        <i class="dot"></i><span style="color:var(--dimmer);font-size:12px">blade-oauth</span>
+        <b style="font-size:13px">auth接入第三方</b><span class="tm">刚刚</span></div>
+    </div>
+  </div>
+</div></div>
+<p class="note">
+副句里的「<b>12</b> 个任务正在运行」与右端状态条的「<b>12</b> 运行中」是<u>同一个数</u>——
+这正是手机版 IA 图纸自审里挑掉的那条，桌面这份没治。而且两者一左一右钉在同一条基线上，
+中间 800px 是空的。眉标是日期，单独占一行：日期有定位价值，<u>但不值一整行</u>。
+</p>
+
+<div class="cap"><b>新版</b><span class="tag good">三行 → 两行 · 数字只说一次</span></div>
+<div class="stage"><div class="dk">
+  <div class="side">
+    <div class="lg">Roam</div><div class="grp">工作区</div>
+    <i class="on">概览</i><i>项目</i><i>会话</i><i>文件</i>
+  </div>
+  <div class="cv">
+    <div style="display:flex;align-items:flex-end;gap:16px">
+      <div style="flex:1;min-width:0">
+        <div class="ttl" style="font-size:24px">早上好，当前没有待处理事项</div>
+        <div class="sub" style="margin-top:6px">8月4日星期二 · 最近活动 刚刚</div>
+      </div>
+      <div style="font-size:12px;color:var(--dim);display:flex;gap:18px;padding-bottom:3px">
+        <span><i class="dot" style="display:inline-block"></i>
+          <b style="font-family:ui-monospace,monospace;color:var(--tx)">12</b> 运行中</span>
+        <span><i class="dot" style="display:inline-block;background:var(--amber)"></i>
+          <b style="font-family:ui-monospace,monospace;color:var(--tx)">1</b> 待收尾</span>
+      </div>
+    </div>
+    <div style="display:flex;align-items:center;gap:9px;margin-top:18px;font-size:13px;font-weight:600">最近会话
+      <span style="flex:1"></span><span style="color:var(--acc);font-weight:400;font-size:12px">全部会话 ›</span></div>
+    <div class="pc" style="margin-top:8px;background:none;border:0;padding:0">
+      <div class="t" style="background:none;border-bottom:1px solid var(--line);border-radius:0">
+        <i class="dot"></i><span style="color:var(--dimmer);font-size:12px">blade-oauth</span>
+        <b style="font-size:13px">auth接入第三方</b><span class="tm">刚刚</span></div>
+      <div class="t" style="background:none;border-bottom:1px solid var(--line);border-radius:0">
+        <i class="dot"></i><span style="color:var(--dimmer);font-size:12px">roam</span>
+        <b style="font-size:13px">桌面版页面也出一版优化设计</b><span class="tm">刚刚</span></div>
+    </div>
+  </div>
+</div></div>
+<p class="note">
+① 副句里的计数删掉——<u>数字归状态条，一个数只说一次</u>；<br>
+② 眉标（日期）从标题<b>上方</b>挪到<b>下方</b>，与「最近活动 刚刚」合成一行小字：
+   先说事、再说时间；而且 项目/会话 的眉标这一稿已经删了，概览再单留一个上眉标就成了孤例；<br>
+③ 标题与状态条底对齐成一个块，中间那 800px 的空白随之消失。
+</p>
+
+<h2>四、哪些页面适用</h2>
+<table class="tt">
+  <tr><th style="width:90px">页面</th><th style="width:120px">页头</th><th>理由</th></tr>
+  <tr><td><b>项目</b></td><td>合并成一行</td><td>h2 就是页名，与侧栏高亮重复</td></tr>
+  <tr><td><b>会话</b></td><td>合并成一行</td><td>同上；「所有会话，按 Agent、等待状态与最近响应筛选」也是功能清单</td></tr>
+  <tr><td><b>概览</b></td><td>标题不动，<b>副句与眉标重排</b></td>
+      <td>它的 h2 是<u>内容</u>——「晚上好，今天有 1 件事需要你」，不是页名，所以不并进工具条。
+      但副句与状态条重复了同一个数，见 §三</td></tr>
+  <tr><td><b>手机档</b></td><td>本来就不渲染</td><td>13 §6 已经砍过一轮，这次只补桌面</td></tr>
+</table>
+
+<h2>五、自审</h2>
+<ol class="sr">
+  <li><b>页名到底留不留？</b>第一版我把「项目」也删了，只留筛选条——毕竟侧栏在高亮。
+      但工具条是 <code>sticky</code> 的，往下滚之后<u>屏幕上就再没有任何字说明这是哪一页</u>；
+      而项目卡和会话卡在余光里长得很像。<em>留，但降到 19px 并入同一行</em>——
+      它的作用从「标题」变成「sticky 的锚点」。</li>
+  <li><b>总数放在页名后面会不会和「全部 12」重复？</b>会，实测就是同一个数。
+      <em>去掉页名后面的计数</em>，「全部 12」那枚 chip 已经是它。（这一条在图纸里就改掉了。）</li>
+  <li><b>搜索挪到右边，会不会不好找？</b>桌面用户找搜索的顺序是「先看右上角工具区」，
+      而且 <code>⌘K</code> 全局搜索本来就在顶栏正中。左端留给筛选是因为
+      <u>筛选是「在看什么」，属于内容；搜索是「怎么找」，属于工具</u>。</li>
+  <li><b>说明句真的能删吗？</b>它对第一次打开的人有用。折中：<u>进页名的 title</u>，
+      鼠标悬停可见；真要做新手引导，那是引导的事，不该常驻占一行。</li>
+  <li><b>会不会和刚做完的 Inspector 抢宽度？</b>不会——页头是 Canvas 内部的一行，
+      Canvas 变窄时筛选 chip 先横向滚动（手机档已经是这个行为），
+      再窄就是 Canvas 让位，那时整页都不在了。</li>
+  <li><b>概览把日期挪到标题下面，会不会显得日期不重要了？</b>本来就不重要——
+      它是定位信息不是行动信息。真正的判据是：<u>删掉它用户会不会缺什么</u>。
+      答案是「大概不会，但保留成本只有半行」，所以合进 meta 行而不是删掉。</li>
+  <li><b>状态条全为零时，概览的 meta 行会不会变空？</b>会。所以 meta 行在没有任务时
+      退回「还没有任务在跑」那句（<code>overview.sublineIdle</code> 已有），
+      <em>不能只写个日期在那儿</em>——那时首屏就真的什么都没说。</li>
+</ol>
+
+</div></body></html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2692,24 +2692,21 @@ function Sessions({ openTerm, closeTerm, activeTerm, embedded }: {
     // 不再套 Card：嵌在概览「会话」tab 里时，卡片边框 + 「会话 13」标题与外面的 tab
     // 完全重复——一层壳里套一层同名的壳。独立页则用与概览/项目同一套页头。
     <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-      {!embedded && (
-        <header className="tt-pagehead" style={{ marginBottom: 14 }}>
-          <div className="ttl">
-            <div className="kicker">{t('nav.groupWorkspace')}</div>
-            <h2>{t('nav.sessions')}</h2>
-            <p>{t('session.subtitle')}</p>
-          </div>
-          {!isPhone && <div className="acts">{sessionActions}</div>}
-        </header>
-      )}
-      {/* 手机才需要自己占一行（横向放不下）；桌面嵌入态并进下面搜索那一行，
+      {/* 手机才需要自己占一行（横向放不下）；桌面并进下面搜索那一行，
           否则「Worktree 管理 / ＋新建会话」白占一整行 */}
       {isPhone && (
         <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>{sessionActions}</div>
       )}
-      {/* 工具条：搜索 + 排序同一行，类型筛选另起一行 */}
+      {/* 工具条：页名 + 搜索 + 排序同一行，类型筛选另起一行。
+          页名并进这一行而不是单独的 .tt-pagehead（图纸 14-desktop-workspace/pagehead.html）：
+          眉标「工作区」+ 大标题「会话」+ 一句「所有会话，按 Agent、等待状态与最近响应筛选」
+          三层 91px，说的全是侧栏那条高亮导航项已经说完的事。 */}
       <div style={{ marginBottom: 14, display: 'flex', flexDirection: 'column', gap: 'var(--sp-3)' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {!embedded && !isPhone && (<>
+            <span className="tt-pagename" title={t('session.subtitle')}>{t('nav.sessions')}</span>
+            <span className="tt-pagedivider" aria-hidden="true" />
+          </>)}
           <Input allowClear value={q} onChange={(e) => setQ(e.target.value)} placeholder={t('session.searchPlaceholder')}
             style={{ flex: 1, minWidth: 0 }}
             prefix={svg(<><circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></>)} />
@@ -2723,7 +2720,7 @@ function Sessions({ openTerm, closeTerm, activeTerm, embedded }: {
             title={sortAsc ? t('session.sortAsc') : t('session.sortDesc')}>
             {sortAsc ? '↑' : '↓'}
           </Button>
-          {embedded && !isPhone && sessionActions}
+          {!isPhone && sessionActions}
         </div>
         {/* 一律按内容宽：block 在手机上把 6 项等分成 ~60px、标签全截成「全部…」；
             在桌面上又把 6 个标签摊到 1200px，中间空出大片，读起来是散的。

--- a/frontend/src/Overview.tsx
+++ b/frontend/src/Overview.tsx
@@ -415,12 +415,15 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
             ② 状态概况挂在页头的 .acts 槽里：桌面并到标题右端（省一行），窄档换行成一条横条。 */}
         <header className="tt-pagehead ov-in">
           <div className="ttl">
-            <div className="kicker">{kicker}</div>
             <h2>{greet}{cards.length > 0
               ? t('overview.headlineNeeds', { count: cards.length })
               : t('overview.headlineQuiet')}</h2>
-            <p>{stats.running > 0
-              ? t('overview.sublineRunning', { count: stats.running, time: relTime(lastAt, t) })
+            {/* 日期从标题上方挪到下方，与「最近活动」合成一行小字（图纸 pagehead.html §三）：
+                先说事、再说时间。副句里原本还写着「12 个任务正在运行」——和右端状态条的
+                「12 运行中」是同一个数，一左一右钉在同一条基线上、中间空 800px。
+                数字归状态条，一个数只说一次。 */}
+            <p>{kicker}{' · '}{stats.running > 0
+              ? t('overview.metaActivity', { time: relTime(lastAt, t) })
               : t('overview.sublineIdle')}</p>
           </div>
           {(stats.running + stats.waiting + stats.unfinished + stats.swarms) > 0 && (

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -139,7 +139,7 @@ html[data-size="compact"] .prj-filters>*{flex:0 0 auto}
 html[data-size="compact"] .prj-filters .sp,
 /* 手机：排序走右侧钉住的 ⇅ 图标 + 底部 sheet，筛选带里那枚排序控件是重复的 */
 html[data-size="compact"] .prj-filters .ant-segmented,
-html[data-size="compact"] .prj-filters .prj-sortpill{display:none}
+html[data-size="compact"] .prj-subbar .prj-sortpill{display:none}
 /* 图标按钮：不描边——右边两个方框和左边的圆角 chip 不是一套语言。命中区靠伪元素撑到 44 */
 .prj-iconbtn{position:relative;flex:0 0 auto;width:32px;height:32px;display:none;place-items:center;
   border:0;border-radius:var(--r-sm);background:transparent;color:var(--text-dim);cursor:pointer}
@@ -453,26 +453,11 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
     // 参照系，而这一层并不真的滚动（真正滚的是 .tt-canvas），于是页头永远粘不住。
     <div>
       <div className="prj-wrap-wide">
-        {/* 页头与概览共用一套（.tt-pagehead）：眉标 + 标题 + 一句话。原来这里只有一个
-            16px 的「项目」挤在搜索框左边，和概览那页完全不像同一个产品。 */}
-        {/* 手机上整块不渲染：底栏已高亮「项目」，筛选带里的「全部 12」又说明了总量，
-            再写一遍大号页名等于用 100px 说一句用户已经知道的话。桌面保留。 */}
-        {!isPhone && (
-          <header className="tt-pagehead" style={{ marginBottom: 14 }}>
-            <div className="ttl">
-              <div className="kicker">{t('nav.groupWorkspace')}</div>
-              <h2>{t('project.title')}</h2>
-              <p>{t('project.subtitle')}</p>
-            </div>
-          </header>
-        )}
-
         {/* sticky subheader（14 §6.1）：搜索 / 筛选 / 排序。滚到项目列表深处时这一条还在——
             筛选条件跟着内容滚走，等于要滚回顶部才能改。 */}
         <div className={`prj-subbar${searching ? ' searching' : ''}`}>
-          <Input allowClear size="small" value={q} onChange={(e) => setQ(e.target.value)}
-            ref={searchRef} className="prj-search" onBlur={() => { if (!q) setSearching(false) }}
-            placeholder={t('project.searchPlaceholder')} style={{ width: isPhone ? undefined : 200 }} />
+          <span className="tt-pagename" title={t('project.subtitle')}>{t('project.title')}</span>
+          <span className="tt-pagedivider" aria-hidden="true" />
           {/* 筛选与排序合成一条横滑带：手机上它俩各自换行，加上搜索框一共占了 5 行，
               第一张卡片被推到屏幕 26% 处。现在一行装下，滑得到即可。 */}
           <div className="prj-filters">
@@ -485,18 +470,21 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
                 onClick={() => setFilter(k)}>{label}<span className="n">{n}</span></button>
             ))}
             <span className="sp" />
-            {/* 排序与筛选同一套控件语言：原来左边是 pill 筛选、右边是「两个裸文字 + 一枚实心
-                蓝块」的 Segmented，一条工具带上两种语言（图纸 desktop-ia.html §二）。 */}
-            <Dropdown trigger={['click']} menu={{
-              selectable: true, selectedKeys: [sortBy],
-              items: SORTS.map((k) => ({ key: k, label: t(`project.sort.${k}`) })),
-              onClick: ({ key }) => changeSort(key as ProjSort),
-            }}>
-              <button type="button" className="prj-chip prj-sortpill" aria-label={t('project.sortBy')}>
-                {t(`project.sort.${sortBy}`)}{ICON_CHEVRON}
-              </button>
-            </Dropdown>
           </div>
+          {/* 搜索与排序贴右：左端回答「看什么」（筛选，属于内容），右端放「怎么找」（工具）。
+              原来搜索在最左、排序甩到最右，中间空掉 ~700px。 */}
+          <Input allowClear size="small" value={q} onChange={(e) => setQ(e.target.value)}
+            ref={searchRef} className="prj-search" onBlur={() => { if (!q) setSearching(false) }}
+            placeholder={t('project.searchPlaceholder')} style={{ width: isPhone ? undefined : 200 }} />
+          <Dropdown trigger={['click']} menu={{
+            selectable: true, selectedKeys: [sortBy],
+            items: SORTS.map((k) => ({ key: k, label: t(`project.sort.${k}`) })),
+            onClick: ({ key }) => changeSort(key as ProjSort),
+          }}>
+            <button type="button" className="prj-chip prj-sortpill" aria-label={t('project.sortBy')}>
+              {t(`project.sort.${sortBy}`)}{ICON_CHEVRON}
+            </button>
+          </Dropdown>
           {/* 手机：搜索原地展开、排序进 sheet。两枚图标钉在右侧，不随筛选带横滑跑掉 */}
           <button type="button" className="prj-iconbtn find" aria-label={t('project.searchPlaceholder')}
             onClick={() => { setSearching(true); setTimeout(() => searchRef.current?.focus(), 0) }}>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1492,6 +1492,7 @@ const enUS = {
   'overview.headlineQuiet': 'nothing needs you right now',
   'overview.sublineRunning': '{count} task(s) running · last activity {time}',
   'overview.sublineIdle': 'No tasks running — a good time to start something new',
+  'overview.metaActivity': 'Last activity {time}',
   'overview.sumRunning': 'running',
   'overview.sumWaiting': 'awaiting input',
   'overview.sumUnfinished': 'to finish',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1493,6 +1493,7 @@ const zhCN = {
   'overview.headlineQuiet': '当前没有待处理事项',
   'overview.sublineRunning': '{count} 个任务正在运行，最近一次活动在{time}',
   'overview.sublineIdle': '没有正在运行的任务，随时可以开始新的工作',
+  'overview.metaActivity': '最近活动 {time}',
   // 状态概况的四个数（14 §5.1）
   'overview.sumRunning': '运行中',
   'overview.sumWaiting': '等待输入',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -315,6 +315,8 @@ body {
 
 /* ── 页头（14 §5.1 / §6.1）：一级页面共用一套——眉标 + 标题 + 一句话说明 ──
    概览先做出来的这套，项目页照它对齐；再有新页面也照抄这三行，不要各写各的标题行。 */
+/* 页头：现在只剩概览在用——它的 h2 是内容（「早上好，今天有 N 件事需要你」）不是页名。
+   项目/会话的页名已并进各自的工具条（见下面的 .tt-pagename 与 pagehead.html）。 */
 .tt-pagehead { display: flex; align-items: flex-start; gap: var(--sp-4); flex-wrap: wrap; }
 .tt-pagehead .ttl { min-width: 0; flex: 1 1 320px; }
 .tt-pagehead .kicker {
@@ -337,6 +339,18 @@ html[data-size="compact"] .tt-pagehead h2 { margin: 0; font-size: var(--fs-lg); 
 html[data-size="compact"] .ov .tt-pagehead h2 { font-size: 20px; line-height: 1.3; }
 html[data-size="compact"] .tt-pagehead { gap: var(--sp-2); }
 .tt-pagehead .acts { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+/* 页名并进工具条（图纸 14-desktop-workspace/pagehead.html）。
+   项目页原来是眉标「工作区」+ 大标题「项目」+ 一句功能清单三层 91px，第一张卡片要到
+   y=203 才出现（900 高的屏 = 16% 首屏）；而左边侧栏此刻正高亮着「工作区 › 项目」——
+   这三件事它一次全说完了。
+   页名保留、只降到 19px 并入工具条：工具条是 sticky 的，滚下去之后屏幕上总得有个字
+   说明这是哪一页（项目卡与会话卡在余光里长得很像）。说明句进 title，鼠标停上去还在。
+   概览页不适用——它的 h2 是内容（「晚上好，今天有 N 件事需要你」），不是页名。 */
+.tt-pagename { flex: 0 0 auto; font-size: 19px; font-weight: 700; letter-spacing: -.01em; color: var(--text-bright); }
+.tt-pagedivider { flex: 0 0 auto; width: 1px; height: 18px; background: var(--border); }
+html[data-size="compact"] .tt-pagename,
+html[data-size="compact"] .tt-pagedivider { display: none; }
 
 /* ── 页面骨架：所有一级页面从同一个左上角起笔，卡片和工具区间距一致 ── */
 .tt-page {


### PR DESCRIPTION
## 为什么

项目页在第一张卡片之前要花掉 **147px**（1440×900 实测：页头 91 + 工具条 44，第一张卡在 `y=203`，900 高的屏 = **16% 首屏**）。而这段里绝大部分在重复左边侧栏刚说过的话——侧栏此刻正高亮着**「工作区 › 项目」**，页面又写一遍：

- 眉标「工作区」
- 大标题「项目」
- 一句「从仓库进入任务、文件、Git、Worktree 与蜂群」——功能清单，第二次打开这一页就不需要了

工具条自己也犯了刚治过的病：搜索 200px 贴左（x=240），排序甩到 x≈1330，**中间约 700px 什么都没有**。

图纸：[`14-desktop-workspace/pagehead.html`](docs/design/web/14-desktop-workspace/pagehead.html)（含自审 8 条）。

## 项目 / 会话：页名并进工具条

```
项目 │ [全部 12] [活跃 8] [待收尾 0] ·········· [⌕ 搜索项目或路径] [最近活跃 ⌄]
```

- 眉标删掉、说明句进页名的 `title`
- **页名保留但降到 19px**：工具条是 `sticky` 的，滚下去之后屏幕上总得有个字说明这是哪一页（项目卡与会话卡在余光里长得很像）。它的作用从「标题」变成「锚点」
- **搜索挪到右端与排序作伴**：左端回答「看什么」（筛选，属于内容），右端放「怎么找」（工具）
- 会话页的「Worktree 管理 / ＋新建会话」也并进这一行（原来独占页头右侧）
- 手机档不受影响：`.tt-pagename` 在 compact 下不显示，13 §6 早就砍过一轮

## 概览：标题不动，但治另一处重复

它的 h2 是**内容**（「早上好，今天有 N 件事需要你」）不是页名，所以不并进工具条。但：

- 副句「**12** 个任务正在运行」与右端状态条「**12** 运行中」是同一个数，一左一右钉在同一条基线上、中间空 800px——手机版 IA 图纸自审里挑掉过这条，桌面这份没治。**数字归状态条，一个数只说一次**
- 眉标（日期）从标题上方挪到下方，与「最近活动 刚刚」合成一行小字：先说事、再说时间；而且项目/会话的上眉标这一稿已经删了，概览再单留一个就成了孤例
- 状态条全为零时 meta 行退回「没有正在运行的任务…」，不会只剩一个日期

## 实测（1440×900）

| 页面 | 首屏内容起点 |
|---|---|
| 项目 | `y=203` → **`y=112`** |
| 会话 | 列表首行 ~240 → **~145** |
| 概览 | 页头 77 → 59，内容 `y=149` → **`y=131`** |

三档均无横向溢出；390 上页名与排序 pill 不渲染、搜索仍收成图标。

门禁：`typecheck` / `i18n:check`（1483 keys）/ `vitest`（100）/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
