### PR TITLE
新建项目：选完目录自动填名字（取路径最后一段）

### DIFF
--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -11,6 +11,7 @@ import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { App as AntApp, AutoComplete, Button, Dropdown, Input, Modal, Popconfirm, Segmented, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd'
 import type { InputRef, MenuProps } from 'antd'
 import { sessionLabel } from './session-label'
+import { dirTailName } from './dir-name'
 import { api, upload, makeClipboardImageFile } from './api'
 import { useI18n } from './i18n'
 import { usePreferences } from './preferences'
@@ -287,7 +288,17 @@ function NewProjectModal({ open, onClose }: { open: boolean; onClose: () => void
   const [name, setName] = useState('')
   const [pick, setPick] = useState(false)
   const [creating, setCreating] = useState(false)
-  useEffect(() => { if (open) { setDir(''); setName('') } }, [open])
+  // 名字是不是用户自己写过：写过就不再被目录覆盖，否则改一次目录就把他写的名字冲掉
+  const [nameTouched, setNameTouched] = useState(false)
+  useEffect(() => { if (open) { setDir(''); setName(''); setNameTouched(false) } }, [open])
+
+  /** 目录定下来就把名字填成路径最后一段（/home/ai/codes/ttmux → ttmux）。
+   *  只在「选完」时填——选目录、选历史项、离开输入框，不跟着每次按键跳。 */
+  const fillNameFromDir = (p: string) => {
+    if (nameTouched) return
+    const seg = dirTailName(p)
+    if (seg) setName(seg)
+  }
   const ok = async () => {
     if (!dir.trim()) { message.error(t('session.dirPlaceholder')); return }
     try {
@@ -307,16 +318,20 @@ function NewProjectModal({ open, onClose }: { open: boolean; onClose: () => void
         <Space direction="vertical" style={{ width: '100%' }}>
           <Space.Compact style={{ width: '100%' }}>
             <AutoComplete style={{ flex: 1 }} value={dir} onChange={setDir} autoFocus
+              onSelect={(v) => fillNameFromDir(String(v))}
+              onBlur={() => fillNameFromDir(dir)}
               options={recentDirs().map((d) => ({ value: d }))}
               filterOption={(input, opt) => String(opt?.value).toLowerCase().includes(input.toLowerCase())}
               placeholder={t('session.dirPlaceholder')} />
             <Button onClick={() => setPick(true)}>{t('common.browse')}</Button>
           </Space.Compact>
-          <Input placeholder={t('project.displayName')} value={name} onChange={(e) => setName(e.target.value)} />
+          <Input placeholder={t('project.displayName')} value={name}
+            onChange={(e) => { setName(e.target.value); setNameTouched(true) }} />
           <div style={{ fontSize: 'var(--fs-meta)', color: 'var(--text-dimmer)' }}>{t('project.newHint')}</div>
         </Space>
       </Modal>
-      <DirPicker open={pick} start={dir} onPick={(p) => { setDir(p); setPick(false) }} onClose={() => setPick(false)} />
+      <DirPicker open={pick} start={dir}
+        onPick={(p) => { setDir(p); fillNameFromDir(p); setPick(false) }} onClose={() => setPick(false)} />
     </>
   )
 }

--- a/frontend/src/dir-name.test.ts
+++ b/frontend/src/dir-name.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { dirTailName } from './dir-name'
+
+describe('dirTailName', () => {
+  it('取最后一段', () => {
+    expect(dirTailName('/home/ai/codes/ttmux')).toBe('ttmux')
+    expect(dirTailName('~/codes/blade-agent')).toBe('blade-agent')
+  })
+  it('结尾斜杠、连续斜杠都不影响', () => {
+    expect(dirTailName('/home/ai/codes/ttmux/')).toBe('ttmux')
+    expect(dirTailName('/home/ai/codes/ttmux///')).toBe('ttmux')
+    expect(dirTailName('/home//ai//codes//ttmux')).toBe('ttmux')
+  })
+  it('Windows 反斜杠', () => {
+    expect(dirTailName('C:\\Users\\ai\\codes\\ttmux')).toBe('ttmux')
+  })
+  it('根目录与空串给空——调用方保持原样，不会写进一个奇怪的名字', () => {
+    expect(dirTailName('/')).toBe('')
+    expect(dirTailName('   ')).toBe('')
+    expect(dirTailName('')).toBe('')
+  })
+  it('单段路径就是它自己', () => {
+    expect(dirTailName('ttmux')).toBe('ttmux')
+  })
+})

--- a/frontend/src/dir-name.ts
+++ b/frontend/src/dir-name.ts
@@ -1,0 +1,7 @@
+// 目录 → 默认项目名：取路径最后一段。
+//
+// 单独成文件是为了能测边界：结尾斜杠、连续斜杠、Windows 反斜杠、根目录、`~`。
+// 「以最后的为名字」这条规则本身很简单，错也只会错在这些边界上。
+export function dirTailName(path: string): string {
+  return path.trim().replace(/[\\/]+$/, '').split(/[\\/]/).filter(Boolean).pop() || ''
+}


### PR DESCRIPTION
新项目弹窗里「工作目录」和「项目名」是两个独立输入框，选完目录还得自己再敲一遍名字——而绝大多数时候名字就是目录的最后一段。

## 规则

- **目录定下来时才填**：选完目录选择器、选中历史目录、离开目录输入框这三处。不跟着每次按键跳——边打边改名字会一直闪
- **用户自己写过名字就不再覆盖**：否则改一次目录就把他写的名字冲掉
- 尾段提取抽成 `dir-name.ts` + 单测：结尾斜杠 / 连续斜杠 / Windows 反斜杠 / 根目录 / 空串。规则本身很简单，错也只会错在这些边界上。根目录与空串返回空时**保持原样**，不会写进一个奇怪的名字

## 实测（1440）

| 操作 | 名字 |
|---|---|
| 输入 `/home/ai/codes/blade-agent/` 后失焦 | `blade-agent`（结尾斜杠吃掉） |
| 改成 `/home/ai/codes/ttmux` | `ttmux`（跟着变） |
| 手动改名后再换目录 | 保持手写的名字，**不被覆盖** |

门禁：`typecheck` / `i18n:check` / `vitest`（105，新增 5 条）/ `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
