### PR TITLE
chore: 把本机噪声加进 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@
 /backend/roam
 /backend/internal/webui/site/*
 !/backend/internal/webui/site/.gitkeep
+
+# 本机噪声：工具缓存、运行态、手工备份。都不入库，但一直挂在 git status 里当噪声，
+# 让人以为「还有东西没提交」。
+/.vite/
+/.roam/
+*.bak-gitpanel
+/frontend/dist.bak-*/


### PR DESCRIPTION
这四样一直挂在 `git status` 里，让人以为「还有代码没提交」，但它们都不该入库：

| 路径 | 是什么 |
|---|---|
| `.vite/` | vitest 缓存 |
| `.roam/` | 运行态目录（插件 StorageDir 等） |
| `*.bak-gitpanel` | 改动前手工备份的**后端二进制** |
| `frontend/dist.bak-*/` | 改动前手工备份的**构建产物** |

后两条本来就属于「不入库」那一类（二进制与构建产物），前两条是工具缓存 / 运行态。仓库已经忽略了 `/backend/ttmux-web` 与 `/config.yaml`，这几条是同一类的补齐。

纯 `.gitignore` 改动，不动任何代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
