### PR TITLE
feat(browser): 移植 blade-agent 浏览器镜像的独有增量特性

### DIFF
--- a/backend/browser/browser.go
+++ b/backend/browser/browser.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -173,6 +174,9 @@ func ensureChrome() error {
 		"--no-first-run", "--no-default-browser-check",
 		// 高 DPI 渲染：像素密度翻倍但 CSS 布局不变 → 画面更清晰
 		"--force-device-scale-factor=" + cfg.Scale,
+		// 隐藏 navigator.webdriver 等自动化痕迹：镜像 Chrome 由 CDP 驱动，天然带自动化特征，
+		// 部分站点（尤其搜索引擎）据此提高验证码触发概率；关掉这个 blink 特性降低误伤。
+		"--disable-blink-features=AutomationControlled",
 	}
 	// 无头/有头：auto=按有无显示器自动判断；on=强制无头；off=强制有头。
 	// 强制有头但无显示器(DISPLAY 空)时 Chrome 会起不来——属用户显式选择。
@@ -275,7 +279,9 @@ func browserUA() string {
 		UserAgent string `json:"User-Agent"`
 	}
 	_ = json.Unmarshal(b, &v)
-	return v.UserAgent
+	// 无头模式下原生 UA 可能带 "HeadlessChrome" 标记，一眼被站点识别为自动化；抹掉这个词，
+	// 其余版本号/平台信息不变，看起来和有头 Chrome 一致。
+	return strings.Replace(v.UserAgent, "HeadlessChrome", "Chrome", 1)
 }
 
 // listPages 返回所有 page 类型的标签页（过滤掉 service worker / iframe 等其它 target）。
@@ -315,7 +321,7 @@ func targetWS(id string) (string, error) {
 		return "", fmt.Errorf("标签页不存在: %s", id)
 	}
 	// 没有任何 page，开一个空白页再找
-	_ = newTab("about:blank")
+	_, _ = newTab("about:blank")
 	for _, t := range listPages() {
 		if t.WebSocketDebuggerURL != "" {
 			return t.WebSocketDebuggerURL, nil
@@ -324,8 +330,8 @@ func targetWS(id string) (string, error) {
 	return "", fmt.Errorf("找不到可用的 page 目标")
 }
 
-// newTab 新建一个标签页（Chrome ≥111 要求 PUT /json/new）。
-func newTab(rawURL string) error {
+// newTab 新建一个标签页（Chrome ≥111 要求 PUT /json/new），返回新标签 id。
+func newTab(rawURL string) (string, error) {
 	u := CDPBase + "/json/new"
 	if rawURL != "" {
 		u += "?" + rawURL
@@ -333,13 +339,17 @@ func newTab(rawURL string) error {
 	req, _ := http.NewRequest(http.MethodPut, u, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("新建标签页失败: %s", resp.Status)
+		return "", fmt.Errorf("新建标签页失败: %s", resp.Status)
 	}
-	return nil
+	b, _ := io.ReadAll(resp.Body)
+	var t target
+	_ = json.Unmarshal(b, &t)
+	markFront(t.ID) // 新标签即前置，watcher 据此广播让镜像面板跟到新标签
+	return t.ID, nil
 }
 
 // closeTab 关闭指定标签页。
@@ -352,6 +362,35 @@ func closeTab(id string) error {
 	return nil
 }
 
+// 最近被「前置」的标签追踪（用户在镜像面板点标签、或经 REST 激活）。watcher 据此广播
+// 「活跃标签」给前端做自动跟随。chrome-cli 走的是裸 CDP（不经这层 HTTP API，见
+// driver.mjs），它对目标标签发的 /json/activate 会被下面 watchFrontTab 的 /json 顺序
+// 兜底捕捉到——两条路径互补：本函数覆盖「经后端」的前置，兜底覆盖「绕过后端直连
+// CDP」的前置。gen 单调递增供 watcher 判变。
+var (
+	frontMu  sync.Mutex
+	frontID  string
+	frontGen uint64
+)
+
+func markFront(id string) {
+	if id == "" {
+		return
+	}
+	frontMu.Lock()
+	if id != frontID {
+		frontID = id
+		frontGen++
+	}
+	frontMu.Unlock()
+}
+
+func frontSnapshot() (string, uint64) {
+	frontMu.Lock()
+	defer frontMu.Unlock()
+	return frontID, frontGen
+}
+
 // activateTab 把指定标签页在 Chrome 里前置（让 agent 的前台焦点与正在镜像的一致）。
 func activateTab(id string) error {
 	resp, err := http.Get(CDPBase + "/json/activate/" + id)
@@ -359,6 +398,7 @@ func activateTab(id string) error {
 		return err
 	}
 	resp.Body.Close()
+	markFront(id)
 	return nil
 }
 

--- a/backend/browser/screencast.go
+++ b/backend/browser/screencast.go
@@ -136,10 +136,52 @@ var ladder = []lvl{
 	{52, 1280, 800, 1, "标清"},
 	{64, 1600, 1000, 1, "清晰"},
 	{76, 1920, 1200, 1, "高清"},
-	{86, 2560, 1600, 1, "超清"},
+	{90, 3840, 2160, 1, "超清"}, // 顶档放宽到 4K 采集上限，配合前端 ≥2x 超采样(desktopDpr)保文字清晰
 }
 
 const autoStart = 2 // 自适应初始档（标清，快速起步再按链路上探）
+
+// cursorScript 注入被镜像页：画一个跟随指针的光点，点击时在光点处绽放涟漪。
+// 无论输入来自用户接管（Input.dispatchMouseEvent）还是 agent 经 chrome-cli/CDP 操作，
+// 都会触发页面自身的 mousemove/mousedown 监听 → 观看端由此看清「谁在哪里点/在哪」，
+// 而不是像前端本地涟漪(addRipple)那样只在查看端画、进不了实际截屏帧。
+// __bladeCur 防重复注入；__bladeCurHide 供用户接管期间短暂抑制（人在面板上已有系统光标，
+// 不需要双光标）。
+const cursorScript = `(() => {
+  if (window.__bladeCur) return; window.__bladeCur = 1;
+  const cur = document.createElement('div');
+  cur.style.cssText = 'position:fixed;left:0;top:0;z-index:2147483647;width:14px;height:14px;' +
+    'margin:-7px 0 0 -7px;border-radius:50%;background:radial-gradient(circle,#4d9bff 0%,#1f6feb 60%,rgba(31,111,235,0) 100%);' +
+    'box-shadow:0 0 10px 3px rgba(31,111,235,.6);pointer-events:none;opacity:0;transition:opacity .3s;will-change:transform';
+  const style = document.createElement('style');
+  style.textContent = '@keyframes __bladeRip{from{transform:scale(.35);opacity:.95}to{transform:scale(2.4);opacity:0}}';
+  const mount = () => {
+    (document.head || document.documentElement).appendChild(style);
+    (document.body || document.documentElement).appendChild(cur);
+  };
+  if (document.body) mount(); else addEventListener('DOMContentLoaded', mount);
+  let hideTimer;
+  let suppressUntil = 0;
+  window.__bladeCurHide = (ms) => { suppressUntil = Date.now() + (ms || 1200); cur.style.opacity = '0'; };
+  const show = (x, y) => {
+    if (Date.now() < suppressUntil) return;
+    cur.style.transform = 'translate(' + x + 'px,' + y + 'px)';
+    cur.style.opacity = '1';
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => { cur.style.opacity = '0'; }, 2000);
+  };
+  addEventListener('mousemove', (e) => show(e.clientX, e.clientY), { capture: true, passive: true });
+  addEventListener('mousedown', (e) => {
+    if (Date.now() < suppressUntil) return;
+    show(e.clientX, e.clientY);
+    const rip = document.createElement('div');
+    rip.style.cssText = 'position:fixed;z-index:2147483646;left:' + (e.clientX - 12) + 'px;top:' + (e.clientY - 12) +
+      'px;width:24px;height:24px;border-radius:50%;border:3px solid #1f6feb;pointer-events:none;' +
+      'animation:__bladeRip .5s ease-out forwards';
+    (document.body || document.documentElement).appendChild(rip);
+    setTimeout(() => rip.remove(), 600);
+  }, { capture: true, passive: true });
+})()`
 
 // keyInfo 把 DOM KeyboardEvent.key 映射到 CDP 需要的 (code, windowsVirtualKeyCode, text)。
 // 只覆盖非可打印的常用键；可打印字符走 Input.insertText，不经过这里。
@@ -188,6 +230,13 @@ func buildFrame(jpeg []byte, w, h int, seq uint16) []byte {
 func nowMs() int64 { return time.Now().UnixMilli() }
 
 func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func absFloat(n float64) float64 {
 	if n < 0 {
 		return -n
 	}
@@ -255,6 +304,12 @@ func runScreencast(sink frameSink, opts scOptions) {
 		reassert     func() // 重发本会话 device metrics 覆盖
 		lastReassert int64  // 上次自愈时刻(ms)；600ms 防抖，避免与另一活跃会话打乒乓
 		lastStreamMs int64  // 最近一帧正常 screencast 到达时间；流仍活跃时无需额外请求补帧
+		// 连击识别：CDP Input.dispatchMouseEvent 要求调用方显式给 clickCount，不会像真实 OS
+		// 那样按时间/位置自动识别双击、三击——不补的话网页的 dblclick 监听永远不会触发。
+		lastClickAt            int64 // 上次 mousedown 时刻(ms)
+		lastClickX, lastClickY float64
+		lastClickBtn           string
+		clickStreak            int
 	)
 
 	// 初始档：auto 用阶梯，手动用前端给的 q（分辨率给足，质量听用户）
@@ -269,7 +324,7 @@ func runScreencast(sink frameSink, opts scOptions) {
 		} else if q > 100 {
 			q = 100
 		}
-		cur = lvl{q: q, w: 2560, h: 1600, nth: 1, name: "手动"}
+		cur = lvl{q: q, w: 3840, h: 2160, nth: 1, name: "手动"}
 	}
 	applyLevel := func(l lvl) {
 		conn.send("Page.startScreencast", map[string]any{
@@ -336,6 +391,78 @@ func runScreencast(sink frameSink, opts scOptions) {
 		}()
 	}
 	conn.send("Page.enable", nil)
+
+	// 虚拟光标：往被镜像页注入轻量脚本，监听 mousemove/mousedown 画光标+点击涟漪。
+	// addScriptToEvaluateOnNewDocument 覆盖后续导航，Runtime.evaluate 覆盖当前已加载页；
+	// __bladeCur 防重复注入。
+	conn.send("Page.addScriptToEvaluateOnNewDocument", map[string]any{"source": cursorScript})
+	conn.send("Runtime.evaluate", map[string]any{"expression": cursorScript})
+
+	// 只给非本人操作画光标：人在面板上已有系统光标，双光标观感怪 —— 用户接管的每次鼠标
+	// 输入前节流通知页面暂停虚拟光标 1.5s。500ms 节流：连续操作最多每半秒发一次。
+	var lastCurHide int64
+	hideCursorForUser := func() {
+		now := nowMs()
+		if now-lastCurHide < 500 {
+			return
+		}
+		lastCurHide = now
+		conn.send("Runtime.evaluate", map[string]any{"expression": "window.__bladeCurHide&&window.__bladeCurHide(1500)"})
+	}
+
+	// 前台标签跟随：谁在操作、operating 到哪个标签，就把这个连接对应的镜像面板广播过去
+	// 跟上（前端据此实现"首连即同步到 agent 当前标签"和"agent 切标签面板自动跟随"）。
+	// 活跃标签以 markFront 的显式记录（frontSnapshot）为准——它在经后端 REST 前置
+	// （用户点标签栏、TabActivate、newTab）时更新；chrome-cli 走裸 CDP 直连 Chrome（见
+	// driver.mjs），不经这层 HTTP API，markFront 感知不到，所以再叠一层 /json 顺序兜底：
+	// 首位标签变化也视为一次前置，兜的正是"绕过后端直连 CDP"这条路径。
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		lastGen := uint64(0)
+		lastOrderFirst := ""
+		synced := false
+		tick := time.NewTicker(1 * time.Second)
+		defer tick.Stop()
+		for {
+			select {
+			case <-watchDone:
+				return
+			case <-tick.C:
+			}
+			pages := listPages()
+			if len(pages) == 0 {
+				continue
+			}
+			if pages[0].ID != lastOrderFirst {
+				lastOrderFirst = pages[0].ID
+				markFront(pages[0].ID)
+			}
+			id, gen := frontSnapshot()
+			if synced && gen == lastGen {
+				continue
+			}
+			lastGen = gen
+			var active *target
+			for i := range pages {
+				if pages[i].ID == id {
+					active = &pages[i]
+					break
+				}
+			}
+			if active == nil { // 还没有前置记录（刚启动）：退回第一个标签，至少给个基线
+				active = &pages[0]
+			}
+			synced = true
+			list := make([]map[string]any, 0, len(pages))
+			for _, p := range pages {
+				list = append(list, map[string]any{"id": p.ID, "title": p.Title, "url": p.URL})
+			}
+			if sink.writeText(map[string]any{"type": "active", "id": active.ID, "url": active.URL, "tabs": list}) != nil {
+				return
+			}
+		}
+	}()
 
 	// 手机模式：把本镜像连接对应的渲染器切到移动视口（设备指标/触摸/UA 覆盖作用于整个
 	// page 渲染，故镜像里看到的就是真实移动端布局，agent 用 chrome-cli 截同一页也是移动端）。
@@ -707,7 +834,7 @@ func runScreencast(sink frameSink, opts scOptions) {
 				}
 				mu.Lock()
 				auto = false
-				cur = lvl{q: q, w: 2560, h: 1600, nth: 1, name: "手动"}
+				cur = lvl{q: q, w: 3840, h: 2160, nth: 1, name: "手动"}
 				l := cur
 				mu.Unlock()
 				applyLevel(l)
@@ -750,6 +877,7 @@ func runScreencast(sink frameSink, opts scOptions) {
 			if t == "" {
 				return
 			}
+			hideCursorForUser()
 			p := map[string]any{"type": t, "x": ev.X, "y": ev.Y, "modifiers": ev.Modifiers}
 			if ev.Sub != "move" {
 				btn := ev.Button
@@ -757,8 +885,21 @@ func runScreencast(sink frameSink, opts scOptions) {
 					btn = "left"
 				}
 				p["button"] = btn
-				p["buttons"] = 1
-				p["clickCount"] = 1
+				if ev.Sub == "down" {
+					// 500ms 内、24px 半径内、同键位 → 算一次连击；否则重新起算连击数。
+					now := nowMs()
+					if clickStreak > 0 && btn == lastClickBtn && now-lastClickAt <= 500 &&
+						absFloat(ev.X-lastClickX) <= 24 && absFloat(ev.Y-lastClickY) <= 24 {
+						clickStreak++
+					} else {
+						clickStreak = 1
+					}
+					lastClickAt, lastClickX, lastClickY, lastClickBtn = now, ev.X, ev.Y, btn
+					p["buttons"] = 1
+				} else { // up：松开时键位掩码归零，clickCount 沿用本次按下时定的连击数
+					p["buttons"] = 0
+				}
+				p["clickCount"] = clickStreak
 			} else {
 				// 移动时带住按下的键位（1=左键），否则 Chrome 当成悬停 → 拖滑块/画布/拖拽都失效
 				p["buttons"] = ev.Buttons

--- a/backend/browser/tabs.go
+++ b/backend/browser/tabs.go
@@ -38,7 +38,7 @@ func NewTab(c *gin.Context) {
 	if body.URL == "" {
 		body.URL = "about:blank"
 	}
-	if err := newTab(body.URL); err != nil {
+	if _, err := newTab(body.URL); err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
 		return
 	}

--- a/cli/chrome-cli/driver.mjs
+++ b/cli/chrome-cli/driver.mjs
@@ -1,28 +1,49 @@
 // chrome driver — Playwright over CDP。
 // 由 cli/chrome-cli/build.sh 内联进 launcher 生成根目录 chrome；本文件是真源，改这里。
 // 用法: node driver.mjs <verb> [args] [--tab N|--url 子串] [--timeout ms] [--cdp 地址]
-import { chromium } from 'playwright-core'
-import { writeFile } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
+//
+// 常驻 daemon：每条命令原本要付一次 ~0.5s 的 playwright 连接冷启动，agent 高频调用（测试
+// 循环里几十条命令很常见）时这笔开销累加起来很扎眼。改成 unix socket 常驻daemon 复用同一条
+// CDP 连接，热路径缩到几十毫秒；daemon 空闲一段时间自杀（见 DAEMON_IDLE_MS），不会常驻占用。
+// 单条命令本身仍是一次性冷启动 `node driver.mjs <verb>` 进程（无状态，好调试）；这层进程
+// 内部把请求转发给 daemon（连不上就现拉起一个），daemon 才是真正持有 CDP 连接、执行动作的
+// 地方。daemon 侧还挂了看门狗（单条命令处理超时就把整个 daemon 进程杀掉重来，见
+// handleConnection）——防的是 CDP 连接在 Chrome 被内存压力杀掉/重启期间可能陷入不带退避的
+// 忙等死循环（不依赖出问题的那段代码自己配合退出，直接从外面强杀更可靠）。
+import { writeFile, mkdir, mkdtemp, rm, copyFile, rename } from 'node:fs/promises'
+import { existsSync, unlinkSync, writeFileSync, openSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, extname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import net from 'node:net'
 
-const argv = process.argv.slice(2)
-const verb = argv[0] || 'help'
-const rest = argv.slice(1)
-const flags = {}
-const pos = []
-const booleanFlags = new Set(['full', 'fast', 'fresh', 'mobile'])
-for (let i = 0; i < rest.length; i++) {
-  const a = rest[i]
-  if (a.startsWith('--')) {
-    const name = a.slice(2)
-    if (booleanFlags.has(name)) flags[name] = true
-    else flags[name] = rest[++i]
+const SELF_PATH = fileURLToPath(import.meta.url)
+const SOCK_PATH = process.env.TTMUX_CHROME_SOCK || '/tmp/ttmux-chrome-cli.sock'
+const DAEMON_LOG = process.env.TTMUX_CHROME_DAEMON_LOG || '/tmp/ttmux-chrome-cli.log'
+const DAEMON_IDLE_MS = Number(process.env.TTMUX_CHROME_DAEMON_IDLE || 300) * 1000
+
+class ChromeError extends Error {}
+
+// ── 纯工具函数：不依赖某一次调用的 flags/pos，daemon 内多条请求共用也安全 ──────────────
+
+function parseArgs(argv) {
+  const verb = argv[0] || 'help'
+  const rest = argv.slice(1)
+  const flags = {}
+  const pos = []
+  const booleanFlags = new Set(['full', 'fast', 'fresh', 'mobile'])
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i]
+    if (a.startsWith('--')) {
+      const name = a.slice(2)
+      if (booleanFlags.has(name)) flags[name] = true
+      else flags[name] = rest[++i]
+    }
+    else pos.push(a)
   }
-  else pos.push(a)
+  return { verb, flags, pos }
 }
-
-const log = (x) => { if (x !== undefined) console.log(typeof x === 'string' ? x : JSON.stringify(x, null, 2)) }
-const die = (m) => { console.error('chrome: ' + m); process.exit(1) }
 const num = (x, d) => {
   const n = Number(x)
   return Number.isFinite(n) ? n : d
@@ -44,8 +65,8 @@ const DEVICES = {
   pixel: { width: 412, height: 915, scale: 2.625, ua: 'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36' },
   ipad: { width: 820, height: 1180, scale: 2, ua: 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1' },
 }
-const resolveDevice = () => {
-  if (flags.device) return DEVICES[flags.device] || die('未知设备: ' + flags.device + '（可选: ' + Object.keys(DEVICES).join(', ') + '）')
+const resolveDevice = (flags, fail) => {
+  if (flags.device) return DEVICES[flags.device] || fail('未知设备: ' + flags.device + '（可选: ' + Object.keys(DEVICES).join(', ') + '）')
   if (flags.mobile) return DEVICES.iphone
   return null
 }
@@ -53,8 +74,7 @@ const withTimeout = (promise, ms, label) => Promise.race([
   promise,
   new Promise((_, reject) => setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms)),
 ])
-const to = Number(flags.timeout || 15000)
-const settle = () => num(flags.wait || flags.settle, 0)
+const settleMs = (flags) => num(flags.wait || flags.settle, 0)
 const chromeExecutable = () => {
   const candidates = [
     process.env.CHROME_BIN,
@@ -67,26 +87,44 @@ const chromeExecutable = () => {
   ].filter(Boolean)
   return candidates.find((p) => existsSync(p))
 }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+// record stop 的真实耗时是 ffmpeg 编码时间（见 runFFmpeg 的 60s 内部超时），跟 --timeout 这个
+// "元素等待多久"语义的旗标没关系——两端(daemon 看门狗、client socket 超时)都得按这个下限算，
+// 否则长录制会在 ffmpeg 还没编完时就被看门狗当成"卡死"强杀。
+const effectiveTimeoutMs = (verb, timeoutMs) => verb === 'record' ? Math.max(timeoutMs, 60000) : timeoutMs
 
-if ((verb === 'screenshot' || verb === 'shot') && flags.fresh) {
+// 选中目标标签后把它前置（真实 CDP Target.activateTarget，不只是选中）——Web 镜像面板的
+// 「前台标签跟随」（见 backend/browser/screencast.go 的 /json 顺序兜底）靠的正是标签被前置
+// 这件事本身，agent 操作到哪，面板就跟到哪。前置失败（标签刚好被关掉等）不影响后续真正的
+// 操作，吞掉即可。
+async function pick(pages, flags, fail) {
+  const p = pickPage(pages, flags, fail)
+  await p.bringToFront().catch(() => {})
+  return p
+}
+function pickPage(pages, flags, fail) {
+  if (flags.tab != null) return pages[Number(flags.tab)] || fail('无此 tab #' + flags.tab)
+  if (flags.url) return pages.find((x) => x.url().includes(flags.url)) || fail('无匹配 url 的 tab: ' + flags.url)
+  return pages[0] || fail('当前没有打开的 tab（先 chrome new <url>）')
+}
+
+// ── --fresh 截图：临时干净 Chrome，与共享 daemon/CDP 连接无关，不占 daemon ──────────────
+
+async function freshScreenshot(flags, pos, timeoutMs, io) {
+  const fail = (m) => { throw new ChromeError(m) }
+  const to = timeoutMs
   const f = pos[0] || 'screenshot.png'
   const target = flags.goto || flags.open || flags.url || pos[1] || 'about:blank'
-  const device = resolveDevice()
+  const device = resolveDevice(flags, fail)
   const vp = parseViewport(flags.viewport) || (device ? { width: device.width, height: device.height } : { width: 1280, height: 800 })
   const type = imageType(f)
   const quality = type === 'jpeg' ? num(flags.quality, 85) : undefined
   let fresh
   try {
+    const { chromium } = await import('playwright-core')
     const chromeBin = chromeExecutable()
-    const launch = chromeBin
-      ? { executablePath: chromeBin }
-      : { channel: 'chrome' }
-    fresh = await chromium.launch({
-      ...launch,
-      headless: true,
-      args: ['--no-sandbox', '--disable-dev-shm-usage'],
-      timeout: to,
-    })
+    const launch = chromeBin ? { executablePath: chromeBin } : { channel: 'chrome' }
+    fresh = await chromium.launch({ ...launch, headless: true, args: ['--no-sandbox', '--disable-dev-shm-usage'], timeout: to })
     const context = await fresh.newContext({
       viewport: vp,
       deviceScaleFactor: num(flags.scale, device ? device.scale : 1),
@@ -94,49 +132,43 @@ if ((verb === 'screenshot' || verb === 'shot') && flags.fresh) {
     })
     const p = await context.newPage()
     await p.goto(target, { waitUntil: flags.waitUntil || 'domcontentloaded', timeout: to })
-    if (settle() > 0) await p.waitForTimeout(settle())
+    if (settleMs(flags) > 0) await p.waitForTimeout(settleMs(flags))
     await withTimeout(p.screenshot({ path: f, fullPage: !!flags.full, type, quality, timeout: to }), to + 1000, 'fresh screenshot')
-    log(f)
+    io.log(f)
     await fresh.close()
-    process.exit(0)
   } catch (e) {
     await fresh?.close().catch(() => {})
-    die(e.message)
+    throw new ChromeError(e.message)
   }
 }
 
-const cdp = flags.cdp || process.env.TTMUX_CHROME_CDP || 'http://127.0.0.1:9222'
-let browser
-try { browser = await chromium.connectOverCDP(cdp) }
-catch (e) { die('连不上 Chrome (' + cdp + '): ' + e.message) }
+// ── 主动词分发：操作一条已连好的 CDP browser。daemon 与一次性冷启动路径共用 ─────────────
 
-const ctx = browser.contexts()[0] || (await browser.newContext())
-const pages = ctx.pages()
+async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
+  const fail = (m) => { throw new ChromeError(m) }
+  const to = timeoutMs
+  const settle = () => settleMs(flags)
+  const ctx = browser.contexts()[0] || (await browser.newContext())
+  const pages = ctx.pages()
+  const pickHere = () => pick(pages, flags, fail)
 
-const pick = () => {
-  if (flags.tab != null) return pages[Number(flags.tab)] || die('无此 tab #' + flags.tab)
-  if (flags.url) return pages.find((x) => x.url().includes(flags.url)) || die('无匹配 url 的 tab: ' + flags.url)
-  return pages[0] || die('当前没有打开的 tab（先 chrome new <url>）')
-}
-
-try {
   switch (verb) {
-    case 'goto': { const p = pick(); await p.goto(pos[0], { waitUntil: 'load', timeout: to }); log({ url: p.url(), title: await p.title() }); break }
-    case 'url': log(pick().url()); break
-    case 'title': log(await pick().title()); break
-    case 'click': await pick().click(pos[0], { timeout: to }); log('ok'); break
-    case 'fill': await pick().fill(pos[0], pos[1] ?? '', { timeout: to }); log('ok'); break
-    case 'type': await pick().type(pos[0], pos[1] ?? '', { timeout: to }); log('ok'); break
-    case 'press': { const p = pick(); if (pos.length > 1) await p.press(pos[0], pos[1], { timeout: to }); else await p.keyboard.press(pos[0]); log('ok'); break }
-    case 'text': log(await pick().innerText(pos[0] || 'body', { timeout: to })); break
-    case 'attr': log(await pick().getAttribute(pos[0], pos[1], { timeout: to })); break
-    case 'html': { const p = pick(); log(pos[0] ? await p.locator(pos[0]).first().evaluate((e) => e.outerHTML) : await p.content()); break }
-    case 'eval': { const r = await pick().evaluate(pos[0]); log(r === undefined ? 'undefined' : r); break }
-    case 'wait': await pick().waitForSelector(pos[0], { timeout: to }); log('ok'); break
+    case 'goto': { const p = await pickHere(); await p.goto(pos[0], { waitUntil: 'load', timeout: to }); io.log({ url: p.url(), title: await p.title() }); break }
+    case 'url': io.log((await pickHere()).url()); break
+    case 'title': io.log(await (await pickHere()).title()); break
+    case 'click': await (await pickHere()).click(pos[0], { timeout: to }); io.log('ok'); break
+    case 'fill': await (await pickHere()).fill(pos[0], pos[1] ?? '', { timeout: to }); io.log('ok'); break
+    case 'type': await (await pickHere()).type(pos[0], pos[1] ?? '', { timeout: to }); io.log('ok'); break
+    case 'press': { const p = await pickHere(); if (pos.length > 1) await p.press(pos[0], pos[1], { timeout: to }); else await p.keyboard.press(pos[0]); io.log('ok'); break }
+    case 'text': io.log(await (await pickHere()).innerText(pos[0] || 'body', { timeout: to })); break
+    case 'attr': io.log(await (await pickHere()).getAttribute(pos[0], pos[1], { timeout: to })); break
+    case 'html': { const p = await pickHere(); io.log(pos[0] ? await p.locator(pos[0]).first().evaluate((e) => e.outerHTML) : await p.content()); break }
+    case 'eval': { const r = await (await pickHere()).evaluate(pos[0]); io.log(r === undefined ? 'undefined' : r); break }
+    case 'wait': await (await pickHere()).waitForSelector(pos[0], { timeout: to }); io.log('ok'); break
     case 'screenshot': case 'shot': {
       const f = pos[0] || 'screenshot.png'
-      const p = pick()
-      const device = resolveDevice()
+      const p = await pickHere()
+      const device = resolveDevice(flags, fail)
       const vp = parseViewport(flags.viewport) || (device ? { width: device.width, height: device.height } : null)
       const clip = parseClip(flags.clip)
       if (vp) await p.setViewportSize(vp)
@@ -167,7 +199,7 @@ try {
         const out = await withTimeout(s.send('Page.captureScreenshot', params), to, 'device screenshot')
         await writeFile(f, Buffer.from(out.data, 'base64'))
         await s.send('Emulation.clearDeviceMetricsOverride').catch(() => {})
-        log(f)
+        io.log(f)
         break
       }
       const cdpScreenshot = async () => {
@@ -193,18 +225,494 @@ try {
           await withTimeout(cdpScreenshot(), to, 'fallback screenshot')
         }
       }
-      log(f)
+      io.log(f)
       break
     }
-    case 'pdf': { const f = pos[0] || 'page.pdf'; await pick().pdf({ path: f }); log(f); break }
-    case 'tabs': log(await Promise.all(pages.map(async (pg, i) => ({ i, title: await pg.title().catch(() => ''), url: pg.url() })))); break
-    case 'new': { const np = await ctx.newPage(); if (pos[0]) await np.goto(pos[0], { waitUntil: 'load', timeout: to }); log({ i: ctx.pages().indexOf(np), url: np.url() }); break }
-    case 'close': await pick().close(); log('ok'); break
-    default: die('未知命令: ' + verb)
+    case 'pdf': { const f = pos[0] || 'page.pdf'; await (await pickHere()).pdf({ path: f }); io.log(f); break }
+    case 'tabs': io.log(await Promise.all(pages.map(async (pg, i) => ({ i, title: await pg.title().catch(() => ''), url: pg.url() })))); break
+    case 'new': { const np = await ctx.newPage(); if (pos[0]) await np.goto(pos[0], { waitUntil: 'load', timeout: to }); await np.bringToFront().catch(() => {}); io.log({ i: ctx.pages().indexOf(np), url: np.url() }); break }
+    case 'close': await (await pickHere()).close(); io.log('ok'); break
+    default: fail('未知命令: ' + verb)
   }
-} catch (e) {
-  await browser.close().catch(() => {})
-  die(e.message)
 }
-// connectOverCDP 的 close 仅断开连接，不会杀掉全局 Chrome。
-await browser.close()
+
+// 虚拟光标：往被录制页注入轻量脚本，画一个跟随 mousemove 的光点 + mousedown 涟漪。与 Web
+// 镜像面板注入的是同一份脚本（见 backend/browser/screencast.go 的 cursorScript），靠
+// window.__bladeCur 幂等守卫——面板和录制同时挂在同一页面时不会重复注入。单独录制（没人开着
+// 镜像面板围观）时，这份注入让产出的视频里依然能看清点在哪、有没有反应。
+const cursorScript = `(() => {
+  if (window.__bladeCur) return; window.__bladeCur = 1;
+  const cur = document.createElement('div');
+  cur.style.cssText = 'position:fixed;left:0;top:0;z-index:2147483647;width:14px;height:14px;' +
+    'margin:-7px 0 0 -7px;border-radius:50%;background:radial-gradient(circle,#4d9bff 0%,#1f6feb 60%,rgba(31,111,235,0) 100%);' +
+    'box-shadow:0 0 10px 3px rgba(31,111,235,.6);pointer-events:none;opacity:0;transition:opacity .3s;will-change:transform';
+  const style = document.createElement('style');
+  style.textContent = '@keyframes __bladeRip{from{transform:scale(.35);opacity:.95}to{transform:scale(2.4);opacity:0}}';
+  const mount = () => {
+    (document.head || document.documentElement).appendChild(style);
+    (document.body || document.documentElement).appendChild(cur);
+  };
+  if (document.body) mount(); else addEventListener('DOMContentLoaded', mount);
+  let hideTimer;
+  let suppressUntil = 0;
+  window.__bladeCurHide = (ms) => { suppressUntil = Date.now() + (ms || 1200); cur.style.opacity = '0'; };
+  const show = (x, y) => {
+    if (Date.now() < suppressUntil) return;
+    cur.style.transform = 'translate(' + x + 'px,' + y + 'px)';
+    cur.style.opacity = '1';
+    clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => { cur.style.opacity = '0'; }, 2000);
+  };
+  addEventListener('mousemove', (e) => show(e.clientX, e.clientY), { capture: true, passive: true });
+  addEventListener('mousedown', (e) => {
+    if (Date.now() < suppressUntil) return;
+    show(e.clientX, e.clientY);
+    const rip = document.createElement('div');
+    rip.style.cssText = 'position:fixed;z-index:2147483646;left:' + (e.clientX - 12) + 'px;top:' + (e.clientY - 12) +
+      'px;width:24px;height:24px;border-radius:50%;border:3px solid #1f6feb;pointer-events:none;' +
+      'animation:__bladeRip .5s ease-out forwards';
+    (document.body || document.documentElement).appendChild(rip);
+    setTimeout(() => rip.remove(), 600);
+  }, { capture: true, passive: true });
+})()`
+
+// ── Recorder：把某个标签的画面录成 mp4。daemon 里跨 `record start`/`record stop` 两次独立
+// 调用持有状态（这两条命令是两个分开的一次性冷启动进程，靠 daemon 常驻才能把状态接起来）。
+//
+// 帧来自独立的 CDP screencast 会话（固定质量/分辨率，不受镜像面板自适应码率影响，也不影响
+// 它——两条会话各自独立）。CDP 是变化驱动：画面静止时不吐帧，所以按「下一帧到达间隔」给上一
+// 帧定时长（超过 500ms 的间隔截断到 500ms，压掉「等页面加载」的死时间，不然一段静止 10 秒的
+// 页面会占掉 10 秒视频却什么信息量都没有）。最后用 ffmpeg 的 concat 变时长图片序列一次性编码，
+// 每帧过一遍 scale+pad 滤镜统一画布尺寸——录制过程中如果镜像面板改了这个标签的视口大小（同一
+// 个 CDP target，视口覆盖是后写者赢），各帧原始尺寸可能不一致，统一到画布尺寸后 concat 才能正
+// 常编码，不需要按尺寸分段再拼接。
+const RECORD_FRAME_GAP_CAP_MS = 500
+const RECORD_STOP_GRACE_MS = 500 // 停止后再等一下，把最后一个动作的异步渲染截进去，不掐在半截
+const RECORD_WIDTH = 1280
+const RECORD_HEIGHT = 800
+
+class Recorder {
+  constructor() { this.active = false; this.cs = null; this.tmpDir = null; this.frames = []; this.outPath = null }
+  isActive() { return this.active }
+  async handle(browser, flags, pos, fail, io) {
+    const sub = pos[0]
+    if (sub === 'start') {
+      if (this.active) fail('已经在录制：' + this.outPath + '（先 record stop）')
+      const outPath = resolveRecordPath(pos[1], fail)
+      const ctx = browser.contexts()[0] || (await browser.newContext())
+      const page = await pick(ctx.pages(), flags, fail)
+      await this._start(ctx, page, outPath, fail)
+      io.log({ recording: true, path: outPath })
+      return
+    }
+    if (sub === 'stop') {
+      if (!this.active) fail('当前没有在录制')
+      const outPath = await this._stop(fail)
+      io.log({ recording: false, path: outPath })
+      return
+    }
+    if (sub === 'status') {
+      io.log({ recording: this.active, path: this.active ? this.outPath : null, frames: this.frames.length })
+      return
+    }
+    fail('record 用法: record start <path.mp4> | record stop | record status')
+  }
+  async _start(ctx, page, outPath, fail) {
+    this.tmpDir = await mkdtemp(join(tmpdir(), 'ttmux-record-'))
+    this.frames = []
+    this.outPath = outPath
+    try {
+      this.cs = await ctx.newCDPSession(page)
+    } catch (e) {
+      throw new ChromeError('录制会话建立失败: ' + e.message)
+    }
+    this.cs.on('Page.screencastFrame', (frame) => this._onFrame(frame).catch(() => {}))
+    await this.cs.send('Page.addScriptToEvaluateOnNewDocument', { source: cursorScript }).catch(() => {})
+    await this.cs.send('Runtime.evaluate', { expression: cursorScript }).catch(() => {})
+    await this.cs.send('Page.startScreencast', {
+      format: 'jpeg', quality: 50, maxWidth: RECORD_WIDTH, maxHeight: RECORD_HEIGHT, everyNthFrame: 2,
+    })
+    this.active = true
+  }
+  async _onFrame(frame) {
+    const idx = this.frames.length
+    const file = join(this.tmpDir, `f${String(idx).padStart(6, '0')}.jpg`)
+    writeFileSync(file, Buffer.from(frame.data, 'base64'))
+    this.frames.push({ file, ts: Date.now() })
+    await this.cs.send('Page.screencastFrameAck', { sessionId: frame.sessionId }).catch(() => {})
+  }
+  async _stop(fail) {
+    this.active = false
+    const cs = this.cs
+    const frames = this.frames
+    const tmpDir = this.tmpDir
+    const outPath = this.outPath
+    this.cs = null
+    try { await cs.send('Page.stopScreencast') } catch {}
+    await sleep(RECORD_STOP_GRACE_MS) // 让最后一个动作的异步渲染多来一帧
+    // screencast 是变化驱动：整段录制期间页面如果一直没有重绘（开始录制后立刻就 stop、或者
+    // 就是在盯着一个静态页面看），可能一帧都没有——实测确会出现。与其报错让这段录制白录，
+    // 不如退化成单帧兜底：录制结束时截一张当前画面权当只有一帧的视频，好过什么都没有。
+    if (frames.length === 0) {
+      try {
+        const shot = await cs.send('Page.captureScreenshot', { format: 'jpeg', quality: 50 })
+        const file = join(tmpDir, 'f000000.jpg')
+        writeFileSync(file, Buffer.from(shot.data, 'base64'))
+        frames.push({ file, ts: Date.now() })
+      } catch {}
+    }
+    try { await cs.detach() } catch {}
+    if (frames.length === 0) {
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+      fail('没有捕获到任何画面帧（标签一直静止/不可见？）')
+    }
+    const listPath = join(tmpDir, 'list.txt')
+    const lines = []
+    for (let i = 0; i < frames.length; i++) {
+      const next = frames[i + 1]
+      const gapMs = next ? next.ts - frames[i].ts : RECORD_STOP_GRACE_MS
+      const durS = Math.min(gapMs, RECORD_FRAME_GAP_CAP_MS) / 1000
+      lines.push(`file '${frames[i].file.replace(/'/g, "'\\''")}'`, `duration ${durS.toFixed(3)}`)
+    }
+    lines.push(`file '${frames[frames.length - 1].file.replace(/'/g, "'\\''")}'`) // ffmpeg concat 的最后一帧要再列一次，否则最后一条 duration 不生效
+    writeFileSync(listPath, lines.join('\n') + '\n')
+
+    const finalOut = join(tmpDir, 'out.mp4')
+    const vf = `scale=${RECORD_WIDTH}:${RECORD_HEIGHT}:force_original_aspect_ratio=decrease,pad=${RECORD_WIDTH}:${RECORD_HEIGHT}:(ow-iw)/2:(oh-ih)/2,format=yuv420p`
+    await runFFmpeg(['-y', '-f', 'concat', '-safe', '0', '-i', listPath, '-vf', vf, '-vsync', 'vfr', '-movflags', '+faststart', finalOut], fail)
+
+    await mkdir(dirname(outPath), { recursive: true }).catch(() => {})
+    // 原子写入：先落到目标同目录的临时文件（ffmpeg 输出在系统临时目录，与 outPath 大概率不同
+    // 文件系统，rename 会因 EXDEV 失败，所以先 copy 到同目录再 rename）再 rename，中途失败/被
+    // 杀不会留一个半成品占住最终路径。
+    const stagedOut = outPath + '.tmp'
+    await rm(stagedOut, { force: true }).catch(() => {})
+    await copyFile(finalOut, stagedOut)
+    await rename(stagedOut, outPath)
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    return outPath
+  }
+}
+
+function resolveRecordPath(raw, fail) {
+  if (!raw) fail('record start 需要输出文件路径，如: record start out.mp4')
+  let p = resolve(raw) // 相对路径按 daemon 已 chdir 到的客户端 cwd 解析，与截图的路径语义一致
+  if (extname(p).toLowerCase() !== '.mp4') p += '.mp4'
+  return p
+}
+
+function runFFmpeg(args, fail) {
+  return new Promise((resolvePromise, reject) => {
+    let proc
+    try {
+      proc = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] })
+    } catch (e) {
+      reject(new ChromeError('未找到 ffmpeg，录制需要系统装有 ffmpeg: ' + e.message))
+      return
+    }
+    let stderr = ''
+    proc.stderr.on('data', (c) => { stderr += c.toString('utf8'); if (stderr.length > 8192) stderr = stderr.slice(-8192) })
+    proc.on('error', (e) => reject(new ChromeError('ffmpeg 启动失败（是否已安装？）: ' + e.message)))
+    const watchdog = setTimeout(() => { proc.kill('SIGKILL') }, 60000)
+    proc.on('close', (code) => {
+      clearTimeout(watchdog)
+      if (code === 0) resolvePromise()
+      else reject(new ChromeError('ffmpeg 编码失败(code ' + code + '): ' + stderr.slice(-500)))
+    })
+  })
+}
+
+// ── Session：daemon 里跨请求复用的 CDP 连接（一次性冷启动路径也走它，只是活不过一条命令） ──
+
+class Session {
+  constructor() { this.browser = null; this.recorder = new Recorder() }
+  async browserFor(cdp) {
+    if (this.browser && !this.browser.isConnected()) this.browser = null
+    if (!this.browser) {
+      try {
+        const { chromium } = await import('playwright-core')
+        this.browser = await chromium.connectOverCDP(cdp, { timeout: 10000 })
+      } catch (e) {
+        throw new ChromeError('连不上 Chrome (' + cdp + '): ' + e.message)
+      }
+    }
+    return this.browser
+  }
+  async run(verb, flags, pos, timeoutMs, io) {
+    const cdp = flags.cdp || process.env.TTMUX_CHROME_CDP || 'http://127.0.0.1:9222'
+    const browser = await this.browserFor(cdp)
+    const fail = (m) => { throw new ChromeError(m) }
+    try {
+      // record 的状态（进行中的 CDP screencast 会话）要跨 start/stop 两次独立调用存活，
+      // 不能像其它动词那样是一次性的 executeVerb 调用，得单独路由到常驻的 recorder 实例。
+      if (verb === 'record') { await this.recorder.handle(browser, flags, pos, fail, io); return }
+      await executeVerb(browser, verb, flags, pos, timeoutMs, io)
+    } catch (e) {
+      // Chrome 死在命令中途（被回收/重启）：丢弃缓存连接，下条命令干净重连；
+      // 页面级错误（选择器超时等）原样往上抛，daemon_request_with_retry 据此判断要不要重试。
+      if (this.browser && !this.browser.isConnected()) this.browser = null
+      throw e
+    }
+  }
+  async close() {
+    // daemon 被杀（空闲自杀/SIGTERM/看门狗）时若正巧在录制，尽力落盘一份而不是丢掉——
+    // 半途而废的录制总比什么都没有强，agent 至少能看到"进行到哪一步"。
+    if (this.recorder.isActive()) {
+      await this.recorder._stop(() => { throw new ChromeError('') }).catch(() => {})
+    }
+    try { await this.browser?.close() } catch {} // 仅断连接，不杀共享 Chrome
+    this.browser = null
+  }
+}
+
+// ── daemon：unix socket 常驻，串行处理（同一时刻只处理一条请求，chdir 才安全） ──────────
+
+// 压测实测过的、明确是"瞬时性"而非"真错误"的失败特征：内存紧张/高并发时 Chrome/CDP 连接
+// 被打断的典型报错。命中这些且动词在 IDEMPOTENT_VERBS 里才会被自动重试；其它错误（选择器
+// 超时、URL 无效等）原样报给调用方，不能被这里的重试悄悄吞掉。
+const TRANSIENT_ERROR_MARKERS = ['Page crashed', 'has been closed', 'Connection closed while reading from the driver', 'ERR_ABORTED']
+// click/press/fill/type/eval/close 有副作用，"命令发出去了但没等到回复"这种不确定状态下
+// 重试可能悄悄重复执行（比如表单重复提交）——不放进这个白名单，交给 agent 自己判断要不要
+// 手动重试。其余只读或"重复执行等效于一次"的动词才安全自动重试。
+const IDEMPOTENT_VERBS = new Set(['goto', 'url', 'title', 'text', 'attr', 'html', 'wait', 'screenshot', 'shot', 'pdf', 'tabs', 'new', 'fill'])
+const isTransientError = (stderr) => TRANSIENT_ERROR_MARKERS.some((m) => stderr.includes(m))
+
+function makeIO() {
+  const lines = []
+  return { lines, log: (x) => { if (x !== undefined) lines.push(typeof x === 'string' ? x : JSON.stringify(x, null, 2)) } }
+}
+
+async function probeAlive(sockPath) {
+  return new Promise((resolve) => {
+    const s = net.connect(sockPath)
+    const done = (ok) => { s.destroy(); resolve(ok) }
+    s.once('connect', () => done(true))
+    s.once('error', () => done(false))
+    setTimeout(() => done(false), 1000)
+  })
+}
+
+async function handleConnection(conn, session) {
+  // 看门狗兜底：内存紧张期间 Chrome/driver 被杀死后，playwright 客户端内部的重连逻辑可能
+  // 陷入不带退避的忙等（不依赖那段代码自己配合退出，直接从外面强杀整个 daemon 进程更可靠）。
+  // 下条命令的 daemonRequest() 连不上旧 socket 会自动重新拉起一个新 daemon，不需要人工介入。
+  //
+  // 定时值 = timeoutS，比客户端 daemonRequestWithRetry 里首次尝试的 fullTimeoutS(=timeoutMs/
+  // 1000+35) 正好少 5 秒——看门狗总先于客户端自己的超时触发：daemon 被强杀时客户端第一次
+  // 尝试的连接会立刻收到断连（而不是干等到自己超时），第二次重试就能连上刚重建的新 daemon。
+  let buf = ''
+  let req
+  try {
+    req = await new Promise((resolve, reject) => {
+      conn.setTimeout(10000)
+      conn.on('data', (chunk) => {
+        buf += chunk.toString('utf8')
+        const nl = buf.indexOf('\n')
+        if (nl !== -1) resolve(JSON.parse(buf.slice(0, nl)))
+      })
+      conn.on('timeout', () => reject(new Error('recv timeout')))
+      conn.on('error', reject)
+      conn.on('close', () => reject(new Error('connection closed before request complete')))
+    })
+  } catch {
+    conn.destroy()
+    return
+  }
+  const argv = Array.isArray(req.argv) ? req.argv : []
+  if (req.cwd && existsSync(req.cwd)) { try { process.chdir(req.cwd) } catch {} }
+  const { verb, flags, pos } = parseArgs(argv)
+  const timeoutMs = num(flags.timeout, 15000)
+  const timeoutS = effectiveTimeoutMs(verb, timeoutMs) / 1000 + 30
+  conn.setTimeout(timeoutS * 1000)
+  const io = makeIO()
+  let code = 0
+  let stderr = ''
+  const watchdog = setTimeout(() => { process.exit(1) }, timeoutS * 1000)
+  try {
+    await session.run(verb, flags, pos, timeoutMs, io)
+  } catch (e) {
+    code = 1
+    stderr = 'chrome: ' + (e?.message || String(e)) + '\n'
+  } finally {
+    clearTimeout(watchdog)
+  }
+  const stdout = io.lines.length ? io.lines.join('\n') + '\n' : ''
+  try { conn.end(JSON.stringify({ code, stdout, stderr })) } catch {}
+}
+
+async function daemonMain() {
+  // OOM 牺牲顺序：daemon 常驻但体量小，配额吃紧时希望先于用户的 dev server 被杀
+  // （Linux-only；其它平台 /proc 不存在，写失败静默忽略即可）。
+  try { writeFileSync('/proc/self/oom_score_adj', '900') } catch {}
+
+  if (existsSync(SOCK_PATH)) {
+    if (await probeAlive(SOCK_PATH)) return // 已有活 daemon，本次是重复拉起，直接退出
+    try { unlinkSync(SOCK_PATH) } catch {} // 连不上的残留 socket 文件，清掉重建
+  }
+
+  const session = new Session()
+  let queue = Promise.resolve() // 串行队列：同一时刻只处理一条请求（chdir 是全进程状态，必须串行）
+  let idleTimer = null
+  // 录制中不能空闲自杀：录制期间 agent 可能在做别的事，daemon 收不到新命令，但录制本身要
+  // 一直挂着（CDP screencast 会话）——空闲计时器到点先看是不是还在录，是就顺延，不能真杀掉。
+  const scheduleIdleCheck = () => {
+    idleTimer = setTimeout(() => {
+      if (session.recorder.isActive()) { scheduleIdleCheck(); return }
+      shutdown()
+    }, DAEMON_IDLE_MS)
+  }
+  const server = net.createServer((conn) => {
+    if (idleTimer) { clearTimeout(idleTimer); idleTimer = null }
+    queue = queue
+      .then(() => handleConnection(conn, session))
+      .catch(() => {})
+      .finally(() => { scheduleIdleCheck() })
+  })
+  const shutdown = async () => {
+    server.close()
+    await session.close()
+    try { unlinkSync(SOCK_PATH) } catch {}
+    process.exit(0)
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
+  await mkdir(dirname(SOCK_PATH), { recursive: true }).catch(() => {})
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(SOCK_PATH, resolve)
+  })
+  scheduleIdleCheck() // 空闲自杀：释放 CDP 连接，daemon 不常驻占用（录制中会顺延，见上）
+}
+
+// ── 客户端：一次性冷启动进程，把命令转发给 daemon（连不上就现拉起） ─────────────────────
+
+function spawnDaemon() {
+  return new Promise((resolve) => {
+    let logFd
+    try { logFd = openSync(DAEMON_LOG, 'a') } catch { resolve(false); return }
+    let child
+    try {
+      child = spawn(process.execPath, [SELF_PATH, '_daemon'], {
+        detached: true, stdio: ['ignore', logFd, logFd],
+      })
+    } catch { resolve(false); return }
+    child.unref()
+    ;(async () => {
+      for (let i = 0; i < 100; i++) {
+        if (existsSync(SOCK_PATH) && await probeAlive(SOCK_PATH)) { resolve(true); return }
+        await sleep(50)
+      }
+      resolve(false)
+    })()
+  })
+}
+
+// 把命令转发给 daemon；daemon 不在则拉起。返回 {resp, sentBeforeFailure}。resp 为 null 表示
+// 失败；sentBeforeFailure 标记失败发生在"命令已经发给 daemon 之后"——这种情况下命令有没有
+// 真的执行到一半是不确定的，daemonRequestWithRetry 据此判断非幂等动词能不能安全重试（见
+// IDEMPOTENT_VERBS）。连不上 daemon（还没写过 socket）永远是 sentBeforeFailure=false，零副
+// 作用，随便重试。
+async function daemonRequest(argv, timeoutS) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let client
+    try {
+      client = await new Promise((resolve, reject) => {
+        const s = net.connect(SOCK_PATH)
+        s.once('connect', () => resolve(s))
+        s.once('error', reject)
+      })
+    } catch {
+      if (attempt === 1) return { resp: null, sentBeforeFailure: false }
+      if (!(await spawnDaemon())) return { resp: null, sentBeforeFailure: false }
+      continue
+    }
+    try {
+      const respText = await new Promise((resolve, reject) => {
+        let out = ''
+        client.setTimeout(timeoutS * 1000)
+        client.on('data', (c) => { out += c.toString('utf8') })
+        client.on('end', () => resolve(out))
+        client.on('timeout', () => reject(new Error('daemon request timeout')))
+        client.on('error', reject)
+        client.write(JSON.stringify({ argv, cwd: process.cwd() }) + '\n')
+      })
+      return { resp: JSON.parse(respText), sentBeforeFailure: false }
+    } catch {
+      return { resp: null, sentBeforeFailure: true } // 已经写过 socket，副作用不确定
+    } finally {
+      client.destroy()
+    }
+  }
+  return { resp: null, sentBeforeFailure: false }
+}
+
+// daemonRequest 的重试外壳。压测发现内存紧张、或高并发时 daemon 偶发因瞬时故障（连不上、
+// 命令执行到一半断连、Chrome/CDP 连接被打断）失败——这些原本会直接暴露成 agent 可见的一次
+// 调用失败，但下一次调用往往就恢复正常（daemon 有看门狗兜底不会永久卡死）。与其让 agent 自
+// 己发现失败再决定要不要重试，这里把"已知大概率会自愈"的失败自动重试掉，只把重试耗尽后仍然
+// 失败的、或本来就不安全重试的情况（见 IDEMPOTENT_VERBS）暴露给调用方。
+//
+// 超时预算：只有第一次尝试给足调用方指定的完整超时（保留"就是要等一个慢页面"这种合法场景
+// 的语义）；重试是在"上一次大概率是撞见了 daemon/Chrome 瞬时故障"的前提下再搏一次，不该再
+// 陪等一整个完整预算——重试如果每次都用完整预算，最坏情况会从单次调用的 ~50s 叠加到 3 次共
+// ~150s，对 agent 来说是明显的可感知卡顿。重试专用超时给一个较短的固定上限。
+async function daemonRequestWithRetry(argv, timeoutMs, verb) {
+  const fullTimeoutS = effectiveTimeoutMs(verb, timeoutMs) / 1000 + 35
+  const retryTimeoutS = Math.min(fullTimeoutS, 20)
+  const attempts = 3
+  let resp = null
+  for (let i = 0; i < attempts; i++) {
+    const r = await daemonRequest(argv, i === 0 ? fullTimeoutS : retryTimeoutS)
+    resp = r.resp
+    const last = i === attempts - 1
+    if (resp === null) {
+      if (r.sentBeforeFailure && !IDEMPOTENT_VERBS.has(verb)) return null
+      if (last) return null
+      await sleep(300 * (i + 1))
+      continue
+    }
+    const transient = resp.code && IDEMPOTENT_VERBS.has(verb) && isTransientError(resp.stderr || '')
+    if (transient && !last) { await sleep(300 * (i + 1)); continue }
+    return resp
+  }
+  return resp
+}
+
+// ── 入口 ──────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const { verb, flags, pos } = parseArgs(argv)
+  // help/setup 正常经 launcher.sh 拦截，不会走到这里；留个兜底给直接 `node driver.mjs` 调用。
+  if (verb === 'help' || verb === '-h' || verb === '--help') { console.log('chrome help 见 launcher.sh 或 README'); return }
+  if (verb === '-v' || verb === '--version') { console.log('chrome (ttmux) v0.2.0'); return }
+  if (verb === '_daemon') { await daemonMain(); return }
+
+  const timeoutMs = num(flags.timeout, 15000)
+
+  if ((verb === 'screenshot' || verb === 'shot') && flags.fresh) {
+    // 私有实例与共享 Chrome 无关，不占 daemon
+    const io = makeIO()
+    try {
+      await freshScreenshot(flags, pos, timeoutMs, io)
+      process.stdout.write(io.lines.length ? io.lines.join('\n') + '\n' : '')
+    } catch (e) {
+      console.error('chrome: ' + (e?.message || String(e)))
+      process.exitCode = 1
+    }
+    return
+  }
+
+  const resp = await daemonRequestWithRetry(argv, timeoutMs, verb)
+  if (resp === null) {
+    console.error(`chrome: daemon 不可用（拉起失败或通信异常，日志见 ${DAEMON_LOG}）`)
+    process.exitCode = 1
+    return
+  }
+  if (resp.stdout) process.stdout.write(resp.stdout)
+  if (resp.stderr) process.stderr.write(resp.stderr)
+  process.exitCode = resp.code || 0
+}
+
+main().catch((e) => { console.error('chrome: ' + (e?.message || String(e))); process.exitCode = 1 })

--- a/cli/chrome-cli/launcher.sh
+++ b/cli/chrome-cli/launcher.sh
@@ -123,6 +123,9 @@ chrome — 浏览器自动化（Playwright over CDP，驱动 ttmux Web 镜像那
   chrome tabs                      列出标签页（序号 / 标题 / url）
   chrome new   [url]               新开标签页
   chrome close                     关闭标签页
+  chrome record start <文件.mp4>   录制目标标签当前画面（需要系统装有 ffmpeg）
+  chrome record stop               停止并落盘录制
+  chrome record status             查看是否在录制
 
   通用选项: --tab <序号> | --url <子串>  选目标标签页（默认第一个）
             --timeout <ms>（默认 15000）  --cdp <地址>
@@ -131,6 +134,7 @@ chrome — 浏览器自动化（Playwright over CDP，驱动 ttmux Web 镜像那
             --mobile（手机视口=iPhone）  --device iphone|iphone-se|pixel|ipad（指定机型）
             默认截图失败时自动降级到 CDP 截图；所有路径受 --timeout 约束
   环境变量: TTMUX_CHROME_CDP=http://127.0.0.1:9222  TTMUX_CHROME_SCALE=2
+            TTMUX_CHROME_DAEMON_IDLE=300（常驻 daemon 空闲自杀秒数）
 EOF
 }
 

--- a/frontend/src/BrowserView.tsx
+++ b/frontend/src/BrowserView.tsx
@@ -188,11 +188,18 @@ export default function BrowserView() {
   const imeRef = useRef<HTMLTextAreaElement>(null)
   const composingRef = useRef(false)
   const [imePos, setImePos] = useState({ x: 8, y: 8 })
+  // 跟随 agent：后端广播 {type:'active'} 时若未暂停就自动切到 agent 正在操作的标签。
+  // 用户手动切标签/操作镜像页面时暂停，空闲一段时间无操作后自动恢复。
+  const [followPaused, setFollowPaused] = useState(false)
+  const followPausedRef = useRef(false)
+  const followIdleTimerRef = useRef(0 as any)
+  const FOLLOW_RESUME_IDLE_MS = 12000
 
   // control 开关用 ref 同步，供事件回调读取最新值
   useEffect(() => { controlRef.current = control }, [control])
   useEffect(() => { deviceRef.current = device }, [device])
   useEffect(() => { tabsRef.current = tabs }, [tabs])
+  useEffect(() => () => clearTimeout(followIdleTimerRef.current), [])
 
   // 跟踪舞台尺寸：旋转 90/270 时 <img> 盒子宽高要对调，才能铺满竖屏
   useEffect(() => {
@@ -253,8 +260,23 @@ export default function BrowserView() {
     if (t) setUrl(t.url === 'about:blank' ? '' : t.url)
   }, [target, tabs])
 
+  // 暂停跟随：人正在手动操作（切标签/点镜像页面），此时后端广播的 active 不该把面板拽走。
+  // 空闲 12s 无操作后自动恢复——不需要用户记得手动点回来。
+  const pauseFollow = () => {
+    followPausedRef.current = true
+    setFollowPaused(true)
+    clearTimeout(followIdleTimerRef.current)
+    followIdleTimerRef.current = setTimeout(resumeFollow, FOLLOW_RESUME_IDLE_MS)
+  }
+  const resumeFollow = () => {
+    clearTimeout(followIdleTimerRef.current)
+    followPausedRef.current = false
+    setFollowPaused(false)
+  }
+
   // 切换标签：镜像该 tab + 在 Chrome 里把它前置（让 agent 前台焦点一致）
   const switchTab = (id: string) => {
+    pauseFollow() // 人手动选的，别被下一条 active 广播立刻拽回去
     setTarget(id)
     api('POST', `/browser/tabs/${id}/activate`).catch(() => {})
   }
@@ -295,6 +317,11 @@ export default function BrowserView() {
     catch (e: any) { message.error(e.message) }
   }
 
+  // 桌面视口按 ≥2x 采样出图（哪怕显示器是 1x），JPEG 压缩本身会糊字，超采样后再压缩，
+  // 文字边缘留下的细节更多，肉眼看起来清晰得多；观看端本来就用 object-fit 缩放显示，
+  // 采样倍数与显示器实际 dpr 无需一致。
+  const desktopDpr = () => Math.max(window.devicePixelRatio || 1, 2)
+
   // 当前设备 → emulate 消息载荷。桌面把远端渲染成「和观看区同比、但宽≥1280 的桌面视口」，整帧
   // 铺满组件。视口只在观看区【宽】变化时重算(见 emulate effect)；高度抖动(移动端工具栏/滚动)不重算，
   // 显示盒的高也只按【宽】算(见 <img>) → 铺满且高度抖动时内容缩放比恒定、不忽大忽小。
@@ -304,12 +331,12 @@ export default function BrowserView() {
     const el = stageRef.current
     const pw = el ? el.clientWidth : 0
     const ph = el ? el.clientHeight : 0
-    if (pw <= 0 || ph <= 0) return { type: 'emulate', mobile: false, mw: 0, mh: 0, dpr: window.devicePixelRatio || 1 }
+    if (pw <= 0 || ph <= 0) return { type: 'emulate', mobile: false, mw: 0, mh: 0, dpr: desktopDpr() }
     // 宽 = max(观看区宽, 桌面下限 1280)：窄窗格(iPad 分屏/手机)也按桌面宽出图、不掉手机版；宽屏用原生宽。
     // 高 = 宽 × 观看区当前宽高比 → 视口与观看区同比、铺满不留白。
     const mw = Math.max(Math.round(pw), 1280)
     const mh = Math.max(1, Math.round((mw * ph) / pw))
-    return { type: 'emulate', mobile: false, mw, mh, dpr: window.devicePixelRatio || 1 }
+    return { type: 'emulate', mobile: false, mw, mh, dpr: desktopDpr() }
   }
 
   // 发 emulate 但【去重】：载荷和上次一样就不发。重设 device metrics 会让后端产一个「视口尚未稳」
@@ -366,6 +393,13 @@ export default function BrowserView() {
       if (msg.type === 'level') { setLevelName(msg.name || ''); return }
       // 被镜像页打开了新窗口/标签 → 镜像跟过去（点 target=_blank 链接、window.open 等）
       if (msg.type === 'newtab') { followNewTab(); return }
+      // 后端广播的当前前台标签（agent 经 chrome-cli 操作、或别处经 REST 前置）：
+      // 未暂停跟随时自动切过去；顺手拿它带的标签列表刷新标题/地址，比 3s 轮询更及时。
+      if (msg.type === 'active') {
+        if (Array.isArray(msg.tabs)) setTabs((prev) => mergeTabs(prev, msg.tabs))
+        if (!followPausedRef.current && msg.id && msg.id !== target) setTarget(msg.id)
+        return
+      }
       // 复制选区回包：把远端页面当前选区文本写进本设备剪贴板（需安全上下文，HTTPS 默认已开）
       if (msg.type === 'copied') {
         const text: string = msg.text || ''
@@ -482,6 +516,7 @@ export default function BrowserView() {
   const onMouse = (sub: string) => (e: React.MouseEvent) => {
     if (!controlRef.current) return
     e.preventDefault()
+    if (sub === 'down') pauseFollow() // 人在直接操作镜像页面，别被 agent 的 active 广播拽走
     const pt = mapXY(e)
     if (sub === 'down') {
       const st = stageRef.current
@@ -500,6 +535,24 @@ export default function BrowserView() {
       d.active = false
     }
   }
+  // 兜底：在 <img> 范围外松开鼠标时，浏览器把 mouseup 派给鼠标当前所在的元素而不是 <img>
+  // 本身，导致 onMouse('up') 收不到事件 —— 拖拽框选/远端滑块会一直卡在"按下"态。用 window
+  // 级监听兜底；靠 dragRef.active 去重（同一次释放若已被 <img> 自身的 onMouseUp 处理过，
+  // active 会先被置 false，这里直接跳过，不会重复发送)。
+  useEffect(() => {
+    const onWindowMouseUp = (e: MouseEvent) => {
+      const d = dragRef.current
+      if (!d.active) return
+      d.active = false
+      if (!controlRef.current) return
+      const pt = mapClientXY(e.clientX, e.clientY)
+      send({ type: 'mouse', sub: 'up', x: pt.x, y: pt.y, button: 'left', buttons: 0, modifiers: mods(e) })
+      if (d.moved) send({ type: 'select', x1: d.x, y1: d.y, x2: pt.x, y2: pt.y })
+    }
+    window.addEventListener('mouseup', onWindowMouseUp)
+    return () => window.removeEventListener('mouseup', onWindowMouseUp)
+  }, [rotation])
+
   // 移动节流：低带宽下高频 move 会挤占上行，限到 ~45ms 一发
   const onMove = (e: React.MouseEvent) => {
     if (!controlRef.current) return
@@ -534,11 +587,13 @@ export default function BrowserView() {
   // 滚轮合并：40ms 窗口内累加 delta 后一次性发，避免滚动时刷爆上行
   const onWheel = (e: React.WheelEvent) => {
     if (!controlRef.current) return
+    pauseFollow()
     const { x, y } = mapXY(e as any)
     queueWheel(x, y, e.deltaX, e.deltaY, mods(e))
   }
   const onTouchStart = (e: React.TouchEvent) => {
     if (!controlRef.current || e.touches.length !== 1) return
+    pauseFollow()
     const t = e.touches[0]
     touchRef.current = { x: t.clientX, y: t.clientY, t: performance.now(), moved: false }
     stageRef.current?.focus()
@@ -601,6 +656,7 @@ export default function BrowserView() {
   }
   const onKey = (e: React.KeyboardEvent) => {
     if (!controlRef.current) return
+    pauseFollow()
     // 输入法组合中：按键属于输入法（key 为 "Process"/keyCode 229），不转发也不
     // preventDefault，否则组合被打断；组合结果统一由 flushIme 发送。
     if (composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229) return
@@ -640,6 +696,12 @@ export default function BrowserView() {
         onAdd={newTab}
         extra={
           <Space size={10} style={{ paddingRight: 4 }}>
+            {/* 暂停跟随时才出现：人正在手动操作，点一下立即恢复自动跟随 agent 的标签 */}
+            {followPaused && (
+              <Button size="small" onClick={resumeFollow} title={t('browser.resumeFollowTitle')}>
+                ▶ {t('browser.resumeFollow')}
+              </Button>
+            )}
             {/* 清晰度：选中档亮蓝底 + 白字加粗 + 辉光，未选中压暗，对比鲜明 */}
             <Space.Compact size="small">
               {QUALITY_OPTS.map((o) => {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -478,6 +478,8 @@ const enUS = {
   'browser.openExternal': 'Open externally',
   'browser.openExternalFailed': 'Failed to launch the system browser',
   'browser.openExternalNoUrl': 'No URL to open',
+  'browser.resumeFollow': 'Follow agent',
+  'browser.resumeFollowTitle': 'Auto-follow paused (you’re driving manually) — click to resume now, or it resumes on its own after 12s idle',
   'browser.deviceTitle': 'Device emulation: switch to a phone/tablet viewport to test mobile pages',
   'browser.copied': 'Copied',
   'browser.noSelection': 'Nothing selected in the page',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -478,6 +478,8 @@ const zhCN = {
   'browser.openExternal': '外部打开',
   'browser.openExternalFailed': '唤起系统浏览器失败',
   'browser.openExternalNoUrl': '当前没有可打开的网址',
+  'browser.resumeFollow': '跟随 Agent',
+  'browser.resumeFollowTitle': '已暂停自动跟随（你在手动操作），点击立即恢复，或 12 秒无操作后自动恢复',
   'browser.deviceTitle': '设备模拟：切换手机/平板视口，测移动端页面',
   'browser.copied': '已复制',
   'browser.noSelection': '网页里没有选中文字',


### PR DESCRIPTION
## 背景

blade-agent 的浏览器镜像（`browserd/*.go` + `BrowserMirror.tsx`）代码头注释明确写着"移植自 Roam(ttmux)"——最初就是从本项目的 `backend/browser` + `frontend/src/BrowserView.tsx` 搬过去的，之后两边各自独立演化。这次是反向操作：把 blade-agent 在此基础上新增、且适用于 ttmux 单机真实 Chrome 场景的部分搬回来。

跳过了两类不适用的：session/多标签隔离（ttmux 单人用，不需要）；无头沙盒容器专属修复，如强制 zh-CN locale、WebGL swiftshader 替代方案、OOM subreaper、CSRF token（ttmux 跑用户本机真实 Chrome，这些问题本就不存在或不构成风险）。

## 改动

1. **双击/三击识别**：`Input.dispatchMouseEvent` 的 `clickCount` 之前硬编码为 1，网页的 `dblclick` 监听永远不会触发；补上 500ms + 24px 半径的连击状态机。
2. **mouseup 视口外释放兜底**：在镜像 `<img>` 外松开鼠标，原生事件不会派给 `<img>` 自身，导致拖拽/滑块卡在按下态；补一个 window 级监听。
3. **顶档分辨率 + 超采样**：超清档 2560×1600 → 3840×2160，前端桌面视口强制 `dpr ≥ 2`，JPEG 压缩后文字仍然清晰。
4. **反自动化指纹伪装**：`--disable-blink-features=AutomationControlled` + UA 去掉 `HeadlessChrome` 标记，降低被识别为自动化触发验证码的概率。
5. **光标覆盖层注入被镜像页面**：注入一个跟随 `mousemove` 的光点 + `mousedown` 涟漪动画，画进真实的 CDP 截屏帧里（不是查看端本地的乐观反馈，而是被控页面 DOM 本身的一部分）——无论谁在操作（人工接管还是 agent 经 chrome-cli），观看端都能看清"谁在哪里点"。
6. **前台标签显式追踪**：`markFront`/`frontSnapshot` + `/json` 顺序兜底（覆盖 chrome-cli 裸连 CDP、绕过后端 REST 层的路径），配合前端的"首连同步到当前标签"、"agent 切标签自动跟随"、"用户接管后暂停跟随、12s 空闲自动恢复"。
7. **chrome-cli 从一次性冷启动脚本改成 daemon 常驻**：unix socket + 看门狗（单条命令处理超时整个 daemon 被强杀重建）+ 幂等感知自动重试（区分"命令已发出但没等到回复"这种不确定状态，只对安全重试的动词自动重试）。顺带让 `pick()` 在选中标签后真正前置（`bringToFront`），这是第 6 点"前台标签跟随"对 agent 操作生效的关键一环。
8. **屏幕录制**：`chrome record start/stop/status`，独立于镜像面板的 CDP screencast 会话（互不干扰），ffmpeg concat 变时长编码（把"等页面加载"的静止死时间截断到 500ms 封顶，不然会占大量体积却没信息量），处理了"页面全程静止导致零帧"的边界情况（退化成单帧兜底）。

## 测试

- `go build` / `go vet` / `go test ./...`、`tsc --noEmit`、`npm run i18n:check`、`vitest run` 全绿（backend + frontend + 现有 CLI/plugins 测试）。
- 真机端到端验证（不只是单元测试）：
  - 用真实 WebSocket 连接镜像 `/api/browser/stream`，确认收到二进制帧、`active`（前台标签）广播、`level`（画质档位）消息。
  - 用 Playwright 驱动真实前端页面：登录、进浏览器面板、抓 WS 出站帧验证"拖到画面外再松开"确实触发了 window 级 mouseup 兜底并正确完成拖选；验证"跟随 Agent"暂停/恢复按钮在真实 UI 里正确出现/消失。
  - `chrome eval "!!window.__bladeCur"` 确认光标覆盖脚本真的注入进了被镜像页面 DOM。
  - WS 发送两次快速 down/up 验证页面 `dblclick` 监听器被触发。
  - `ps aux` 确认真实 Chrome 进程的启动参数里有 `--disable-blink-features=AutomationControlled`。
  - 真实安装的 `chrome` CLI（daemon 化后）反复调用验证冷启动/热路径耗时，以及 `chrome record start/stop` 产出合法 h264/mp4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)