### PR TITLE
feat(web): 点路径开右栏、Edit 卡片可点开文件、概览卡整张可点、状态条横滑

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1107,7 +1107,8 @@ function TerminalPane(props: {
   // 所以窄屏干脆不传 onOpenFile，路径退化成普通文字（见 15 设计 §9）。
   const openFileFromChat = (path: string, line?: number) => {
     if (fileDock !== 'left') location.hash = '#/files'
-    requestIntent(OPEN_FILE_INTENT, { path, line })
+    // side：开到右栏，别把左栏正在看的对话顶掉（FileWorkspace 只在 A 栏有首 tab 时才照办）
+    requestIntent(OPEN_FILE_INTENT, { path, line, side: fileDock === 'left' })
   }
 
   // 标签条是单行横向滑动（见 index.css .tt-tabs）：窄栏/手机上会话一多，当前标签会滑出视口，

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1547,9 +1547,13 @@ function TerminalPane(props: {
         <button type="button" className={`pill${activeNeedsInput ? ' wait' : ''}`} onClick={() => setSwitchOpen(true)}>
           <i className={`d${activeAgentLive && !activeNeedsInput ? ' live' : ''}`} style={{ background: dot }} />
           {active && <TabName name={active} project={false} />}
-          {activeNeedsInput && <span className="tag">{t('session.waiting')}</span>}
-          {terms.length > 1 && <span className="n">{terms.length}</span>}
-          <span className="ca">{TI.caret}</span>
+          {/* 右侧那簇裹成一个：名字要绝对居中，就得让流里只剩「左一个、右一个」，
+              否则 space-between 会把计数也均分到中间去 */}
+          <span className="ri">
+            {activeNeedsInput && <span className="tag">{t('session.waiting')}</span>}
+            {terms.length > 1 && <span className="n">{terms.length}</span>}
+            <span className="ca">{TI.caret}</span>
+          </span>
         </button>
         {active && claudeMap[active]?.running && (
           <button type="button" className={`ic${claudeView[active] ? ' on' : ''}`} aria-label="Claude"

--- a/frontend/src/FileWorkspace.test.tsx
+++ b/frontend/src/FileWorkspace.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { App as AntApp } from 'antd'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import FileWorkspace from './FileWorkspace'
 import { I18nProvider } from './i18n'
+import { requestIntent, OPEN_FILE_INTENT } from './intents'
 
 vi.mock('./FileBrowser', () => ({ default: () => <div data-testid="file-browser" /> }))
 vi.mock('./fileview', () => ({ FileView: () => <div data-testid="file-view" /> }))
@@ -84,5 +85,58 @@ describe('FileWorkspace resize shield', () => {
     expect(document.body.querySelector('[data-pointer-resize-shield="true"]')).toBeNull()
     expect(document.body.style.userSelect).toBe('text')
     expect(document.body.style.cursor).toBe('default')
+  })
+})
+
+// 从对话里点 Read/Edit 的路径开文件：必须开到**右栏**。
+// A 栏的首 tab 是会话（终端/对话）本身，开在那儿等于把你正在看的对话顶掉——
+// 而点这个路径的动机恰恰是「一边对着看」。
+describe('FileWorkspace 从对话打开文件', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+  })
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+  const renderWithSession = () => render(
+    <I18nProvider>
+      <AntApp>
+        <FileWorkspace dir="/workspace" leadingTab={<span data-testid="lead-tab" />} leadingTitle="sess"
+          leadingContent={<div data-testid="chat" />} />
+      </AntApp>
+    </I18nProvider>,
+  )
+
+  const tabTexts = (container: HTMLElement) =>
+    [...container.querySelectorAll('[data-tab-key]')].map((e) => (e.textContent || '').trim())
+
+  it('side 意图把文件开成第二栏，会话首 tab 仍在', () => {
+    const { container } = renderWithSession()
+    expect(container.querySelectorAll('[data-drop-group]').length).toBeGreaterThan(0)
+
+    act(() => { requestIntent(OPEN_FILE_INTENT, { path: '/workspace/a.ts', side: true }) })
+
+    const keys = [...container.querySelectorAll('[data-tab-key]')].map((e) => e.getAttribute('data-tab-key'))
+    expect(keys).toContain('lead')                      // 会话首 tab 还在
+    expect(keys).toContain('/workspace/a.ts')           // 文件开出来了
+    // 两个编辑组 → 分栏成立（B 栏非空才会渲染第二个 pane）
+    expect(container.querySelectorAll('[data-drop-content="1"]').length).toBe(2)
+    expect(tabTexts(container).length).toBeGreaterThan(1)
+  })
+
+  it('不带 side 时沿用旧行为：开在 A 栏（⌘K 搜索那条路）', () => {
+    const { container } = renderWithSession()
+    act(() => { requestIntent(OPEN_FILE_INTENT, { path: '/workspace/b.ts' }) })
+    expect(container.querySelectorAll('[data-drop-content="1"]').length).toBe(1)
+  })
+
+  it('没有会话首 tab 时（纯文件页）side 不生效，不该无故拆出空的一栏', () => {
+    const { container } = render(
+      <I18nProvider><AntApp><FileWorkspace dir="/workspace" /></AntApp></I18nProvider>,
+    )
+    act(() => { requestIntent(OPEN_FILE_INTENT, { path: '/workspace/c.ts', side: true }) })
+    expect(container.querySelectorAll('[data-drop-content="1"]').length).toBe(1)
   })
 })

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -115,6 +115,18 @@ export default function FileWorkspace({
     setActiveOf(g, p); setFocus(g)
   }
   const openFileTab = (p: string) => openInGroup(p, split ? focus : 'A')
+  // 从对话里点 Read/Edit 的路径开文件：**一律开到右栏**，不占 A 栏。
+  // A 栏的首 tab 是会话（终端/对话）本身，开在那儿等于把你正在看的对话顶掉——
+  // 而你点这个路径的动机恰恰是「一边对着看」。已经在 A 栏开着的就挪过来，不留两份。
+  const openFileToSide = (p: string) => {
+    if (filesA.includes(p)) {
+      const nextA = filesA.filter((x) => x !== p)
+      setFilesA(nextA)
+      if (activeA === p) setActiveA(hasLeading ? null : (nextA[0] ?? null))
+    }
+    if (!filesB.includes(p)) setFilesB([...filesB, p])
+    setActiveB(p); setFocus('B')
+  }
   // 对话页点「Grep 命中 path:line」跳过来时要定位到那一行。按路径记，nonce 自增——
   // 同一文件已经开着时 FileView 的 props 不变，没有 nonce 第二次点同一处就毫无反应。
   const [reveal, setReveal] = useState<{ path: string; line: number; nonce: number } | null>(null)
@@ -122,18 +134,22 @@ export default function FileWorkspace({
   // 点过来时，意图早在本组件存在之前就发完了（见 intents.ts）。
   const openFileRef = useRef(openFileTab)
   openFileRef.current = openFileTab
+  const openSideRef = useRef(openFileToSide)
+  openSideRef.current = openFileToSide
   useEffect(() => {
     const on = () => {
-      const data = takeIntentData<{ path?: string; line?: number }>(OPEN_FILE_INTENT)
+      const data = takeIntentData<{ path?: string; line?: number; side?: boolean }>(OPEN_FILE_INTENT)
       if (!data || data === true || !data.path) return
-      openFileRef.current(data.path)
+      // side 只有「A 栏被会话占着」时才有意义（文件页没有首 tab，开哪栏都不挡事）
+      if (data.side && hasLeading) openSideRef.current(data.path)
+      else openFileRef.current(data.path)
       const line = Number(data.line)
       if (line > 0) setReveal((prev) => ({ path: data.path!, line, nonce: (prev?.nonce || 0) + 1 }))
     }
     on()
     window.addEventListener(INTENT_EVENT, on)
     return () => window.removeEventListener(INTENT_EVENT, on)
-  }, [])
+  }, [hasLeading])
   // VSCode「侧栏打开预览」：把该 markdown 的渲染预览开到另一栏（预览 tab 用前缀区分，可与源码同时存在）
   const openPreviewToSide = (fromGroup: Group, p: string) => {
     const to: Group = fromGroup === 'A' ? 'B' : 'A'

--- a/frontend/src/Overview.tsx
+++ b/frontend/src/Overview.tsx
@@ -77,7 +77,16 @@ const OV_CSS = `
 .ov-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:var(--sp-3);align-items:start}
 .ov-proj{min-width:0;background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:var(--r-card);
   padding:var(--sp-3) var(--sp-3) var(--sp-2);display:flex;flex-direction:column;gap:var(--sp-1);transition:border-color .15s}
-.ov-proj:hover{border-color:rgba(88,166,255,.35)}
+.ov-proj{cursor:pointer}
+.ov-proj:hover{border-color:rgba(88,166,255,.35);background:var(--bg-elevated)}
+.ov-proj:focus-visible{outline:1px solid var(--accent-border);outline-offset:2px}
+/* 指针落在会话行/卡内链接上时，把卡片自己的 hover 收回去：
+   高亮要指明「点下去会中哪个」，两层同时亮等于没说 */
+.ov-proj:has(.ov-trow:hover),.ov-proj:has(.ov-foot a:hover){background:var(--bg-container)}
+.ov-proj:has(.ov-trow:hover) .hd .go,.ov-proj:has(.ov-foot a:hover) .hd .go{color:var(--text-dimmer);transform:none}
+/* 右上角只留一枚箭头当方向暗示：整张卡都能点，再写一遍「进入项目」是废话 */
+.ov-proj .hd .go{flex:0 0 auto;display:inline-flex;color:var(--text-dimmer);transition:color .15s,transform .15s}
+.ov-proj:hover .hd .go{color:var(--accent);transform:translateX(2px)}
 .ov-proj .hd{display:flex;align-items:center;gap:8px}
 .ov-ico{width:28px;height:28px;flex:0 0 auto;display:grid;place-items:center;border-radius:var(--r-sm);
   font-size:12px;font-weight:800}
@@ -86,7 +95,7 @@ const OV_CSS = `
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ov-proj .nm span{display:block;margin-top:2px;font:var(--fs-micro)/1.3 ui-monospace,monospace;color:var(--text-dimmer);
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.ov-proj .hd a{flex:0 0 auto;font-size:var(--fs-meta)}
+
 .ov-trow{display:flex;align-items:center;gap:var(--sp-2);min-height:32px;padding:var(--sp-1) var(--sp-2);
   border-radius:var(--r-xs);font-size:var(--fs-sm);cursor:pointer;transition:background .14s}
 .ov-trow:first-of-type{margin-top:6px}
@@ -497,20 +506,27 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
                   const projSwarms = swarms.filter((sw) => sw.projKey === p.key)
                   const [fg, bg] = icoOf(p.key)
                   return (
-                    <div key={p.key} className="ov-proj ov-in" style={{ animationDelay: `${Math.min(i, 6) * 40}ms` }}>
+                    // 整张卡就是「进入项目」的按钮——原来右上角那条「进入项目 ›」是全卡唯一的入口，
+                    // 卡片其余部分点了没反应，等于把一个 300px 宽的目标缩成一个 60px 的小链接。
+                    // 卡内的会话行/看板/去收尾各自 stopPropagation，点它们不会顺带进项目。
+                    <div key={p.key} className="ov-proj ov-in" role="button" tabIndex={0}
+                      title={t('overview.enterProject')}
+                      onClick={() => goProject(p.key)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goProject(p.key) } }}
+                      style={{ animationDelay: `${Math.min(i, 6) * 40}ms` }}>
                       <div className="hd">
                         <span className="ov-ico" style={{ color: fg, background: bg }}>{(p.name[0] || '?').toUpperCase()}</span>
                         <span className="nm">
                           <b title={p.name}>{p.name}</b>
                           <span title={p.dir}>{p.dir}</span>
                         </span>
-                        <a onClick={() => goProject(p.key)}>{t('overview.enterProject')}<Go /></a>
+                        <span className="go" aria-hidden><Go /></span>
                       </div>
                       {shown.map((s) => {
                         const w = waiting[s.name]
                         const r = running(s.name)
                         return (
-                          <div key={s.name} className="ov-trow" onClick={() => openTerm(s.name)}>
+                          <div key={s.name} className="ov-trow" onClick={(e) => { e.stopPropagation(); openTerm(s.name) }}>
                             {dot(false, w ? '#d29922' : r ? 'var(--ok)' : undefined)}
                             <span className="t" title={`${s.label || s.name}（${s.id || s.name}）`}>{s.label || s.name}</span>
                             {ann[s.name]?.primary?.linked && <Tag color="cyan" style={{ margin: 0, fontSize: 'var(--fs-micro)', lineHeight: '16px', padding: '0 5px' }}><BranchIcon size={11} /></Tag>}
@@ -525,12 +541,12 @@ export default function Overview({ openTerm }: { openTerm: (n: string) => void }
                         <div key={sw.name} className="ov-foot">
                           <SwarmIcon size={12} /><b>{sw.name}</b>
                           <span style={{ color: 'var(--text-dimmer)' }}>{t('project.swarm.members', { mine: sw.inProj, total: sw.total })}</span>
-                          <a onClick={() => goSwarm(sw.name)}>{t('project.swarm.board')}<Go /></a>
+                          <a onClick={(e) => { e.stopPropagation(); goSwarm(sw.name) }}>{t('project.swarm.board')}<Go /></a>
                         </div>
                       ))}
                       {p.unfinished > 0 && (
                         <div className="ov-foot w"><FlagIcon size={12} />{t('overview.unfinishedN', { count: p.unfinished })}
-                          <a onClick={() => goProject(p.key)}>{t('overview.goFinish')}<Go /></a>
+                          <a onClick={(e) => { e.stopPropagation(); goProject(p.key) }}>{t('overview.goFinish')}<Go /></a>
                         </div>
                       )}
                     </div>

--- a/frontend/src/chat/StatusBar.tsx
+++ b/frontend/src/chat/StatusBar.tsx
@@ -11,7 +11,7 @@
 //   失败 → 跳到最近一次失败那条
 //   分支 → 打开 Git 面板
 //   用时 → 详情
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '../i18n'
 import { ArrowToBottom, ChecklistIcon, ChevronRight, ClockIcon, WarnIcon } from '../icons'
 import { BranchIcon } from '../git/parts'
@@ -77,6 +77,26 @@ export function StatusBar({ status, accent, unread, onJump, actions = {} }: {
   const [panel, setPanel] = useState<Panel>('none')
   const toggle = (p: Panel) => setPanel((cur) => (cur === p ? 'none' : p))
 
+  // 手机上七八个 chip 一行放不下 → 横滑。两侧渐隐提示「这边还有」，
+  // 沿用快捷键条那套 data-l/data-r 约定（见 .tt-keyrow），不另发明一套。
+  const stripRef = useRef<HTMLDivElement>(null)
+  const [fade, setFade] = useState({ l: false, r: false })
+  const syncFade = useCallback(() => {
+    const el = stripRef.current
+    if (!el) return
+    setFade({ l: el.scrollLeft > 2, r: el.scrollLeft + el.clientWidth < el.scrollWidth - 2 })
+  }, [])
+  useEffect(() => {
+    const el = stripRef.current
+    if (!el) return
+    syncFade()
+    // chip 数量会随会话变（多出一个「失败」就可能从放得下变成放不下），用 RO 而不是只在挂载时量一次
+    const ro = new ResizeObserver(syncFade)
+    ro.observe(el)
+    for (const c of Array.from(el.children)) ro.observe(c)
+    return () => ro.disconnect()
+  }, [syncFade, status])
+
   const ctx = status.context
   // 上下文接近满了要变色：85% 起黄，95% 起红。这是唯一会「越用越糟」的指标。
   const tight = !!ctx && ctx.percent >= 85
@@ -92,65 +112,68 @@ export function StatusBar({ status, accent, unread, onJump, actions = {} }: {
 
   return (
     <div className="cc-statusbar">
-      {status.mode && (
-        <button type="button" className={`cc-st-pill${actions.onCycleMode ? ' is-btn' : ''}`}
-          style={{ color: TONE[status.mode.tone] }} disabled={!actions.onCycleMode}
-          onClick={actions.onCycleMode} title={actions.onCycleMode ? t('chat.modeCycle') : modeText}>
-          <i style={{ background: TONE[status.mode.tone] }} />{modeText}
-        </button>
-      )}
+      <div className="cc-st-scroll" ref={stripRef} onScroll={syncFade}
+        data-l={fade.l ? '' : undefined} data-r={fade.r ? '' : undefined}>
+        {status.mode && (
+          <button type="button" className={`cc-st-pill${actions.onCycleMode ? ' is-btn' : ''}`}
+            style={{ color: TONE[status.mode.tone] }} disabled={!actions.onCycleMode}
+            onClick={actions.onCycleMode} title={actions.onCycleMode ? t('chat.modeCycle') : modeText}>
+            <i style={{ background: TONE[status.mode.tone] }} />{modeText}
+          </button>
+        )}
 
-      {ctx && (
-        <Chip onClick={() => toggle('info')} expanded={panel === 'info'}
-          title={`${fmtTokens(ctx.used)} / ${fmtTokens(ctx.window)}`}>
-          <Ring percent={ctx.percent} color={ctxColor} />
-          <span style={{ color: ctxColor, fontVariantNumeric: 'tabular-nums' }}>{pct}%</span>
-        </Chip>
-      )}
+        {ctx && (
+          <Chip onClick={() => toggle('info')} expanded={panel === 'info'}
+            title={`${fmtTokens(ctx.used)} / ${fmtTokens(ctx.window)}`}>
+            <Ring percent={ctx.percent} color={ctxColor} />
+            <span style={{ color: ctxColor, fontVariantNumeric: 'tabular-nums' }}>{pct}%</span>
+          </Chip>
+        )}
 
-      {status.quota != null && (
-        <Chip title={t('chat.quotaTitle')}>
-          <Ring percent={status.quota} color="var(--warn)" />
-          <span style={{ color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>{Math.round(status.quota)}%</span>
-        </Chip>
-      )}
+        {status.quota != null && (
+          <Chip title={t('chat.quotaTitle')}>
+            <Ring percent={status.quota} color="var(--warn)" />
+            <span style={{ color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>{Math.round(status.quota)}%</span>
+          </Chip>
+        )}
 
-      {status.tasks && (
-        <Chip onClick={() => toggle('tasks')} expanded={panel === 'tasks'} title={status.tasks.doing || t('chat.taskPanel')}>
-          <ChecklistIcon size={13} />
-          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{status.tasks.done}/{status.tasks.total}</span>
-          <span className="cc-st-chev" style={{ transform: panel === 'tasks' ? 'rotate(-90deg)' : 'rotate(90deg)' }}>
-            <ChevronRight size={11} />
-          </span>
-        </Chip>
-      )}
+        {status.tasks && (
+          <Chip onClick={() => toggle('tasks')} expanded={panel === 'tasks'} title={status.tasks.doing || t('chat.taskPanel')}>
+            <ChecklistIcon size={13} />
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>{status.tasks.done}/{status.tasks.total}</span>
+            <span className="cc-st-chev" style={{ transform: panel === 'tasks' ? 'rotate(-90deg)' : 'rotate(90deg)' }}>
+              <ChevronRight size={11} />
+            </span>
+          </Chip>
+        )}
 
-      {/* 失败数：整条里唯一的红。点了跳到最近一次——「哪儿挂了」是看到这个数字后的下一个问题 */}
-      {!!status.errors && (
-        <Chip onClick={actions.onJumpError} tone="var(--danger)" title={t('chat.errorsTitle', { count: status.errors })}>
-          <WarnIcon size={12} />
-          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{status.errors}</span>
-        </Chip>
-      )}
+        {/* 失败数：整条里唯一的红。点了跳到最近一次——「哪儿挂了」是看到这个数字后的下一个问题 */}
+        {!!status.errors && (
+          <Chip onClick={actions.onJumpError} tone="var(--danger)" title={t('chat.errorsTitle', { count: status.errors })}>
+            <WarnIcon size={12} />
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>{status.errors}</span>
+          </Chip>
+        )}
 
-      {status.branch && (
-        <Chip onClick={actions.onOpenGit} title={status.cwd || status.branch}>
-          <BranchIcon size={12} />
-          <span className="cc-st-ellip">{status.branch}</span>
-        </Chip>
-      )}
+        {status.branch && (
+          <Chip onClick={actions.onOpenGit} title={status.cwd || status.branch}>
+            <BranchIcon size={12} />
+            <span className="cc-st-ellip">{status.branch}</span>
+          </Chip>
+        )}
 
-      {status.elapsed != null && (
-        <Chip onClick={() => toggle('info')} expanded={panel === 'info'} title={t('chat.elapsedTitle')}>
-          <ClockIcon size={12} />
-          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtElapsed(status.elapsed)}</span>
-        </Chip>
-      )}
+        {status.elapsed != null && (
+          <Chip onClick={() => toggle('info')} expanded={panel === 'info'} title={t('chat.elapsedTitle')}>
+            <ClockIcon size={12} />
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtElapsed(status.elapsed)}</span>
+          </Chip>
+        )}
 
-      <span style={{ flex: 1 }} />
+      </div>
 
-      {/* 「回到底部」并进这条：它本来是右下角的悬浮圆钮，跟这里重复，合并后少一个浮层，
-          顺带把未读数带上——上滚离底之后，新消息有多少是这条唯一能回答的问题。 */}
+      {/* 「回到底部」钉在滚动条带**外面**——它是动作，不能被横滑滑走。
+          它原本是右下角的悬浮圆钮，跟这里重复；合并后少一个浮层，顺带带上未读数：
+          上滚离底之后「新消息有多少」是这条唯一能回答的问题。 */}
       {unread > 0 && (
         <button type="button" className="cc-st-jump" style={{ background: accent }} onClick={onJump} title={t('chat.jumpToBottom')}>
           <ArrowToBottom size={13} />

--- a/frontend/src/chat/tool-parts.tsx
+++ b/frontend/src/chat/tool-parts.tsx
@@ -162,10 +162,15 @@ export function CommandRow({ command, description, output, isError, status, labe
 }
 
 // 可折叠卡片：Edit / Write / apply_patch / TodoWrite / 子代理 / 计划这些有内容可看的。
-export function ToolCard({ icon, label, title, tone = 'neutral', status, defaultOpen, raw, children }: {
+// 给了 path 时标题就是**可点的文件名**：点它在右栏打开这个文件，展开/收起交给左边的箭头。
+// 不这么分的话，Edit 卡片上唯一像链接的东西（文件名）点下去只会把卡片展开，
+// 而人点文件名的意图从来都是「打开它」。
+export function ToolCard({ icon, label, title, path, line, tone = 'neutral', status, defaultOpen, raw, children }: {
   icon?: ReactNode
   label: string
   title?: string
+  path?: string
+  line?: number
   tone?: Tone
   status?: ToolStatus
   defaultOpen?: boolean
@@ -173,17 +178,27 @@ export function ToolCard({ icon, label, title, tone = 'neutral', status, default
   children?: ReactNode
 }) {
   const { t } = useI18n()
+  const { openFile } = useChatActions()
   const [open, setOpen] = useState(!!defaultOpen)
   const [rawOpen, setRawOpen] = useState(false)
+  const toggle = () => setOpen((v) => !v)
+  // 标题能点开文件时，展开就只交给箭头/标签那半边——否则点文件名会同时开文件又展开卡片
+  const linked = !!(path && openFile)
   return (
     <div className="cc-toolcard" style={{ borderLeft: `2px solid ${TONE[tone].line}` }}>
-      <div className="cc-toolcard-head" role="button" tabIndex={0} aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen((v) => !v) } }}>
-        <span className="cc-cmd-chev" style={{ transform: open ? 'rotate(90deg)' : 'none' }}><ChevronRight size={12} /></span>
-        {icon && <span style={{ flex: '0 0 auto', color: TONE[tone].line, display: 'flex' }}>{icon}</span>}
-        <span style={{ flex: '0 0 auto', color: 'var(--text-dim)' }}>{label}</span>
-        {title && <span className="cc-toolval" style={{ fontFamily: MONO }} title={title}>{title}</span>}
+      <div className="cc-toolcard-head" role={linked ? undefined : 'button'} tabIndex={linked ? undefined : 0}
+        aria-expanded={linked ? undefined : open}
+        onClick={linked ? undefined : toggle}
+        onKeyDown={linked ? undefined : (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle() } }}>
+        <button type="button" className="cc-toolcard-toggle" aria-expanded={open} aria-label={open ? t('common.collapse') : t('common.expand')}
+          onClick={linked ? toggle : undefined} disabled={!linked} tabIndex={linked ? 0 : -1}>
+          <span className="cc-cmd-chev" style={{ transform: open ? 'rotate(90deg)' : 'none' }}><ChevronRight size={12} /></span>
+          {icon && <span style={{ flex: '0 0 auto', color: TONE[tone].line, display: 'flex' }}>{icon}</span>}
+          <span style={{ flex: '0 0 auto', color: 'var(--text-dim)' }}>{label}</span>
+        </button>
+        {title && (linked
+          ? <PathLink path={path!} line={line} text={title} />
+          : <span className="cc-toolval" style={{ fontFamily: MONO }} title={title}>{title}</span>)}
         {!title && <span style={{ flex: 1 }} />}
         <StatusChip status={status} />
       </div>

--- a/frontend/src/chat/tool-render.tsx
+++ b/frontend/src/chat/tool-render.tsx
@@ -166,7 +166,7 @@ const edit: Renderer = (c) => {
   const oldText = isNew ? '' : s(c.o?.old_string ?? c.o?.old_str)
   const newText = isNew ? s(c.o?.content) : s(c.o?.new_string ?? c.o?.new_str ?? c.o?.new_source)
   return withError(c, (
-    <ToolCard icon={<PencilIcon />} label={c.name} title={shortPath(path, c.keep)} tone="warn" status={c.status}>
+    <ToolCard icon={<PencilIcon />} label={c.name} title={shortPath(path, c.keep)} path={path} tone="warn" status={c.status}>
       <DiffPane oldText={oldText} newText={newText} path={path}
         badge={isNew ? c.t('chat.diffNew') : c.t('chat.diffEdit')} badgeTone={isNew ? 'ok' : 'warn'} />
     </ToolCard>
@@ -177,7 +177,7 @@ const multiEdit: Renderer = (c) => {
   const path = s(c.o?.file_path)
   const edits: any[] = Array.isArray(c.o?.edits) ? c.o.edits : []
   return withError(c, (
-    <ToolCard icon={<PencilIcon />} label={c.name} title={`${shortPath(path, c.keep)} · ${edits.length}`} tone="warn" status={c.status}>
+    <ToolCard icon={<PencilIcon />} label={c.name} title={`${shortPath(path, c.keep)} · ${edits.length}`} path={path} tone="warn" status={c.status}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-2)' }}>
         {edits.map((e, i) => (
           <DiffPane key={i} oldText={s(e?.old_string)} newText={s(e?.new_string)} path={path}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2032,6 +2032,28 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   color: var(--text-dim);
   border-top: 1px solid var(--border-subtle);
 }
+/* chip 条带：手机上七八个一行放不下 → 横滑。
+   两侧渐隐沿用快捷键条那套 data-l/data-r（见 .tt-keyrow），不另发明一套。
+   overscroll-behavior-x:contain 是必须的：不然横滑会冒泡成浏览器的「返回」手势，
+   在手机上表现为「想看后面几个 chip，结果整页退出去了」。 */
+.cc-st-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  touch-action: pan-x;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+.cc-st-scroll::-webkit-scrollbar { height: 0; }
+.cc-st-scroll > * { flex: 0 0 auto; }
+.cc-st-scroll[data-l][data-r] { mask-image: linear-gradient(90deg, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%); }
+.cc-st-scroll[data-l]:not([data-r]) { mask-image: linear-gradient(90deg, transparent 0, #000 20px); }
+.cc-st-scroll[data-r]:not([data-l]) { mask-image: linear-gradient(90deg, #000 calc(100% - 20px), transparent 100%); }
 .cc-st-pill {
   flex: 0 0 auto;
   display: inline-flex;
@@ -2127,7 +2149,11 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 @media (pointer: coarse) {
-  .cc-st-pill, .cc-st-jump { min-height: 28px; }
+  /* 命中区 ≥44：这条只有一行，撑到 44 只还一次 16px，
+     比工具行那种连排划算得多（那儿撑 44 的代价是每行都还）。 */
+  .cc-statusbar { min-height: 44px; }
+  .cc-st-pill, .cc-st-jump, .cc-st-item.is-btn { min-height: 36px; }
+  .cc-st-scroll { min-height: 36px; }
 }
 
 /* ── 语法高亮（highlight.js 类 → 主题变量；不引外部 CSS，随黑白主题切换） ── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1905,6 +1905,22 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   outline: none;
 }
 .cc-toolcard-head:hover { background: var(--list-hover); }
+/* 标题变成文件链接之后，展开/收起收在左半边这颗（箭头 + 图标 + 工具名）。
+   它不是 linked 时禁用并让出 tab 焦点——那时整行本身就是按钮。 */
+.cc-toolcard-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+.cc-toolcard-toggle:disabled { cursor: inherit; }
+.cc-toolcard-toggle:focus-visible { outline: 1px solid var(--accent-border); outline-offset: 2px; border-radius: var(--r-xs); }
 .cc-toolcard-head:focus-visible { box-shadow: inset 0 0 0 1px var(--accent-border); }
 .cc-toolcard-body { padding: var(--sp-1) 0 var(--sp-2) 20px; }
 .cc-toolraw {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -654,10 +654,29 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
   border: 1px solid var(--border-subtle); border-radius: 18px;
   background: var(--bg-base); color: var(--text-bright); font-size: var(--fs-meta); cursor: pointer;
 }
-/* 名字吃掉所有余量 → 右侧那簇（状态角标 / 会话数 / 箭头）自然贴到胶囊右缘。
-   不给 grow 的话内容全挤在左边，胶囊右半截空着，看着像没画完。
-   名字再在这条余量里居中：短名字时左右留白对称，长名字撑满后居中自然失效（等同左对齐）。 */
-.tt-sesshead .pill .tt-name { flex: 1 1 auto; justify-content: center; }
+/* 名字**绝对居中**，两侧簇各贴一边。
+   之前用「名字 flex:1 + justify-content:center」只是在余量里居中——左边是 8px 的状态点、
+   右边是箭头(+计数)，两侧不等宽，名字就整体偏了；一出现会话计数偏得更多。
+   绝对定位之后，两侧簇宽度差多少都不影响名字落在胶囊正中。 */
+.tt-sesshead .pill { position: relative; }
+.tt-sesshead .pill .tt-name {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  /* 两侧各留 50：够放下 8 的点、15 的箭头和 18 的计数，名字不会压到它们身上 */
+  max-width: calc(100% - 100px);
+  justify-content: center;
+  pointer-events: none;
+}
+.tt-sesshead .pill .ri { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; }
+/* 待确认时状态比名字要紧：回到流式布局，名字左对齐让位给「待确认」角标 */
+.tt-sesshead .pill.wait .tt-name {
+  position: static;
+  transform: none;
+  max-width: none;
+  flex: 1 1 auto;
+  justify-content: flex-start;
+}
 .tt-sesshead .pill .ca { flex: 0 0 auto; display: inline-flex; opacity: .55; }
 .tt-sesshead .pill .d { width: 8px; height: 8px; flex: 0 0 auto; border-radius: 50%; position: relative; }
 /* 有 Agent 在跑：状态点带一圈呼吸。静态点分不出「在干活」和「卡住了」。 */


### PR DESCRIPTION
> 前两笔是 #166 合并后才推上去的，没赶上那趟车（#166 合的是它的第一个 commit），这里重新带上。

## 一、Read/Edit 的路径开到**右栏**，不顶掉对话

之前点路径，文件开在 A 栏 —— 而 A 栏的首 tab 就是会话（终端/对话）本身，于是「想一边看代码一边看对话」的动作，结果是把对话顶掉了，正好相反。

改成一律开到 B 栏（右栏），A 栏留着对话。已经在 A 栏开着的挪过来，不留两份。`hasLeading` 为假时（纯文件页没有会话首 tab）`side` 不生效 —— 那儿开哪栏都不挡事，无故拆出一个空栏反而怪。

## 二、Edit / Write 卡片的**文件名**现在可点

之前卡片标题是纯文本，点了只会展开卡片；只有展开后 diff 头部那个路径才可点。而人点文件名的意图从来都是「打开它」—— 那是卡片上唯一长得像链接的东西。

给了 `path` 时标题就是 `PathLink`，展开/收起收到左边那颗（箭头 + 图标 + 工具名）。两个动作分开，不会点一下同时开文件又展开卡片。没有 `path` 时维持原状。

## 三、概览项目卡整张可点

原来右上角那条「进入项目 ›」是**全卡唯一的入口**，卡片其余部分点了没反应 —— 等于把一个 300px 宽的目标缩成一个 60px 的小链接。

- 整张卡 = 进入项目（`role=button` + Enter/Space 可达）
- 会话行 = 进那个会话，`stopPropagation` 不冒泡成进项目
- 卡内「看板」「去收尾」同理
- 行内文字链删掉，右上角只留一枚箭头当方向暗示

指针落在会话行/卡内链接上时，用 `:has()` 把卡片自己的 hover 收回去 —— 高亮要指明「点下去会中哪个」，两层同时亮等于没说。

## 四、状态条在手机上横滑

chip 现在有七八个，392 宽放不下。包进一条可滚动条带，**回底钮钉在条带外面** —— 它是动作，不能被横滑滑走。

- 两侧渐隐沿用快捷键条那套 `data-l`/`data-r` + `mask-image`（`.tt-keyrow`），不另发明一套；用 `ResizeObserver` 同时观察条带与每个 chip：chip 数量会随会话变（多冒出一个「失败」就可能从放得下变成放不下），只在挂载时量一次会算错
- **`overscroll-behavior-x: contain` 是必须的** —— 不然横滑到头会冒泡成浏览器的「返回」手势，表现为「想看后面几个 chip，结果整页退出去了」
- 粗指针下整条长到 44：这条只有一行，撑 44 只还一次 16px，比工具行那种连排划算得多

## 五、灵动岛名字改成绝对居中

上一版用「名字 `flex:1` + `justify-content:center`」，那**只是在余量里居中**：左边 8px 的状态点、右边 15px 的箭头（多会话时还多一个 18px 计数），两侧不等宽，名字整体偏左，有计数时偏得更多。我当时量到 3px 就判断「看不出来」——**这个判断是错的，有计数的情况没量**。

改成绝对定位居中：右侧那簇裹成 `.ri` 贴右缘，名字 `left:50% + translateX(-50%)` 落在胶囊正中，两侧簇宽度差多少都不影响。待确认时例外 —— 回到流式布局让位给「待确认」角标，那种时候状态比名字要紧。

## 验证

- `typecheck` / `i18n:check`(1558 键) / **vitest 180 passed**（`FileWorkspace` 新增 3 条：side 开成第二栏且会话首 tab 还在、不带 side 沿用旧行为、没有首 tab 时不拆空栏）/ `build` / `go build` / `go test` 全绿
- 踩坑记一笔：意图是 window 事件触发的，测试里断言前 React 状态还没提交，得包在 `act()` 里

## 未验收

**真机没跑**。重启后端会把 web 会话踢下线，登录要口令 + 两步验证码；而这批全是前端改动，`dist` 是后端从磁盘直接服务的，本来就不需要重启。所以这批只有单测覆盖，没在真机上亲眼看过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
