### PR TITLE
fix(web): 对话里点文件名开右侧抽屉，抽屉内预览不再弹模态框

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1103,12 +1103,20 @@ function TerminalPane(props: {
   // 对话页里点工具行的文件路径 → 在文件面板打开（带行号就跳到那一行）。
   // 左侧停靠时 <FileWorkspace> 已挂载在同一页，直接发意图即可开成对话旁边的标签页；
   // 否则先切到文件页再发，跟 ⌘K 搜索结果打开文件是同一条路（见 intents.ts）。
-  // 手机上不给：文件面板是全屏二级页，从对话里跳过去会丢上下文且回不到原滚动位置，
-  // 所以窄屏干脆不传 onOpenFile，路径退化成普通文字（见 15 设计 §9）。
+  // 从对话里点 Read/Edit 的文件名。两种停靠各走各的路，**都不离开会话页**：
+  //   左停靠：FileWorkspace 分栏 → 开到右栏（side），对话留在左栏
+  //   右停靠：右侧「文件管理」抽屉 → 打开抽屉并在里面预览这个文件
+  // 之前右停靠走的是 `location.hash = '#/files'`，直接把人跳去文件页——
+  // 那正是「点了跑到左边栏去」的由来。
+  // 手机上不给：文件面板是全屏二级页，跳过去会丢上下文且回不到原滚动位置（见 15 设计 §9）。
+  const [dockFileReq, setDockFileReq] = useState<{ path: string; nonce: number } | null>(null)
   const openFileFromChat = (path: string, line?: number) => {
-    if (fileDock !== 'left') location.hash = '#/files'
-    // side：开到右栏，别把左栏正在看的对话顶掉（FileWorkspace 只在 A 栏有首 tab 时才照办）
-    requestIntent(OPEN_FILE_INTENT, { path, line, side: fileDock === 'left' })
+    if (fileDock === 'left') {
+      requestIntent(OPEN_FILE_INTENT, { path, line, side: true })
+      return
+    }
+    setShowFiles(true)
+    setDockFileReq((prev) => ({ path, nonce: (prev?.nonce || 0) + 1 }))
   }
 
   // 标签条是单行横向滑动（见 index.css .tt-tabs）：窄栏/手机上会话一多，当前标签会滑出视口，
@@ -1861,7 +1869,8 @@ function TerminalPane(props: {
       {fileDock === 'right' && (
         <AdaptivePanel open={showFiles} layer="session" title={t('nav.files')}
           onClose={() => setShowFiles(false)}>
-          <FileBrowser dir={cwd} accent="var(--accent)" layout="dock" onClose={() => setShowFiles(false)} />
+          <FileBrowser dir={cwd} accent="var(--accent)" layout="dock" onClose={() => setShowFiles(false)}
+            openRequest={dockFileReq || undefined} />
         </AdaptivePanel>
       )}
       {/* 手机走全屏二级页（13 §6）：420 的浮层在 360 屏上盖到 92vw，还压着底栏、不吃安全区。

--- a/frontend/src/FileBrowser.test.tsx
+++ b/frontend/src/FileBrowser.test.tsx
@@ -127,3 +127,104 @@ describe('FileBrowser folder context menu', () => {
     })
   })
 })
+
+// 对话里点 Read/Edit 的文件名 → 在这个浏览器里打开它。
+// 之前这条路走的是「跳去文件页」，人被带离会话页，看到的是文件页左边那棵树。
+describe('FileBrowser openRequest（对话里点文件名）', () => {
+  let seenDirs: string[] = []
+
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    seenDirs = []
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/files?')) {
+        const dir = new URL(url, 'http://x').searchParams.get('path') || ''
+        seenDirs.push(dir)
+        return jsonResponse({ data: { path: dir || '/workspace', parent: '/', entries: [] } })
+      }
+      if (url.includes('/api/file?')) {
+        return jsonResponse({ data: { content: 'hello', truncated: false } })
+      }
+      return jsonResponse({ data: {} })
+    }))
+  })
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+  const renderWith = (openRequest?: { path: string; nonce: number }) => render(
+    <I18nProvider>
+      <AntApp>
+        <div style={{ display: 'flex', flexDirection: 'column', width: 420, height: 600 }}>
+          <FileBrowser dir="/workspace" layout="dock" openRequest={openRequest} />
+        </div>
+      </AntApp>
+    </I18nProvider>,
+  )
+
+  it('把树导航到文件所在目录，而不是让文件凭空出现', async () => {
+    renderWith({ path: '/workspace/frontend/src/App.tsx', nonce: 1 })
+    await waitFor(() => expect(seenDirs).toContain('/workspace/frontend/src'))
+  })
+
+  it('没有 openRequest 时不导航到别处（保持原有行为）', async () => {
+    renderWith()
+    await waitFor(() => expect(seenDirs.length).toBeGreaterThan(0))
+    expect(seenDirs.every((d) => !d.includes('/frontend/src'))).toBe(true)
+  })
+
+  it('同一文件再点一次：nonce 变了才重新打开', async () => {
+    const { rerender } = renderWith({ path: '/workspace/a.ts', nonce: 1 })
+    await waitFor(() => expect(seenDirs).toContain('/workspace'))
+    const before = seenDirs.length
+    // 同 nonce 重渲染：不该再跑一次
+    rerender(
+      <I18nProvider><AntApp>
+        <div><FileBrowser dir="/workspace" layout="dock" openRequest={{ path: '/workspace/a.ts', nonce: 1 }} /></div>
+      </AntApp></I18nProvider>,
+    )
+    expect(seenDirs.length).toBe(before)
+  })
+})
+
+// 抽屉里的预览必须**就地铺开**，不能弹模态框：
+// 抽屉本来就是一块常驻侧栏，从里面再弹一个居中浮层等于把它整个盖住。
+describe('FileBrowser dock 预览不弹模态框', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/files?')) {
+        const dir = new URL(url, 'http://x').searchParams.get('path') || ''
+        return jsonResponse({ data: { path: dir || '/workspace', parent: '/', entries: [] } })
+      }
+      if (url.includes('/api/file?')) return jsonResponse({ data: { content: 'hello', truncated: false } })
+      return jsonResponse({ data: {} })
+    }))
+  })
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+  it('打开文件后没有 .ant-modal，预览就在面板里', async () => {
+    const { container } = render(
+      <I18nProvider><AntApp>
+        <div style={{ display: 'flex', flexDirection: 'column', width: 420, height: 600 }}>
+          <FileBrowser dir="/workspace" layout="dock" openRequest={{ path: '/workspace/a.md', nonce: 1 }} />
+        </div>
+      </AntApp></I18nProvider>,
+    )
+    // 预览起来了（内容或加载态出现在面板内），且**没有**模态框
+    await waitFor(() => expect(container.textContent || '').toContain('a.md'))
+    expect(document.querySelector('.ant-modal')).toBeNull()
+  })
+})

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -338,6 +338,7 @@ export default function FileBrowser({
   onOpenAgent,
   onOpenFile,
   selectedPath,
+  openRequest,
 }: {
   dir?: string
   accent?: string
@@ -347,6 +348,9 @@ export default function FileBrowser({
   onOpenAgent?: (kind: 'claude' | 'codex', path: string) => void
   // dock 布局下由外层（编辑器 tab 区）接管文件打开：点文件不再弹内置预览，而是回调让外层开 tab。
   onOpenFile?: (path: string) => void
+  /** 外部要求打开某个路径（对话里点 Read/Edit 的文件名）。
+      nonce 自增才触发——同一个文件点第二次时 path 没变，没有 nonce 就毫无反应。 */
+  openRequest?: { path: string; nonce: number }
   // 外层当前激活的文件 tab，用于在浏览器里高亮选中项（覆盖内部 view）。
   selectedPath?: string | null
 }) {
@@ -707,6 +711,19 @@ export default function FileBrowser({
     }
   }
 
+  // 对话里点了文件名 → 在这个浏览器里打开它：先把树导航到它所在目录，再开预览。
+  // 走 openPath 而不是直接 setView：不 navigate 的话左边的树还停在别处，
+  // 你看到的是「一个文件凭空出现」，不知道它在哪。
+  const openReqRef = useRef(0)
+  useEffect(() => {
+    if (!openRequest?.path || openRequest.nonce === openReqRef.current) return
+    openReqRef.current = openRequest.nonce
+    const dirOf = openRequest.path.replace(/\/[^/]*$/, '') || '/'
+    navigate(dirOf)
+    openFile(openRequest.path)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openRequest?.path, openRequest?.nonce])
+
   const resolveTypedPath = (value: string): string => {
     const raw = value.trim()
     if (!raw) return cur || '/'
@@ -1010,15 +1027,21 @@ export default function FileBrowser({
     )
   }
 
-  // 停靠布局（新标签左侧栏）：只有文件面板本身，预览以 Modal 弹出（右边是终端，不占版面）。
+  // 停靠布局（右侧「文件管理」抽屉 / 新标签左侧栏）：预览**就在抽屉里铺开**，不弹模态框。
+  // 之前用 Modal：抽屉本来就是一块常驻的侧栏，从里面再弹一个居中浮层，
+  // 等于把你刚打开的那个面板整个盖住——而你点开文件恰恰是想跟左边的对话对着看。
+  // 浏览器那半不卸载（保住树的展开态与滚动位置），预览盖在它上面，关掉即回。
   if (layout === 'dock') {
     return (
-      <>
+      <div style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
         {browserPane}
         {view && (
-          <Viewer path={view} accent={accent} onClose={() => setView(null)} onOpenPath={openPath} onOpenAgent={onOpenAgent} />
+          <div style={{ position: 'absolute', inset: 0, zIndex: 2, display: 'flex', background: 'var(--bg-base)' }}>
+            <Viewer path={view} accent={accent} inline onBack={() => setView(null)} onClose={() => setView(null)}
+              onOpenPath={openPath} onOpenAgent={onOpenAgent} />
+          </div>
         )}
-      </>
+      </div>
     )
   }
 


### PR DESCRIPTION
接 #167。上一版「点路径开右栏」只在**左侧分栏**那种停靠下成立，右侧抽屉那种没做对。

## 一、「点了跑到左边栏」的真实原因

`fileDock` 有两种停靠：`left` 是 `FileWorkspace` 的分栏，`right` 是右侧「文件管理」抽屉。上一版只把 `left` 那条路做对了，`right` 走的是：

```ts
if (fileDock !== 'left') location.hash = '#/files'
```

**这不是开错了栏，是整个把人带离了会话页**，跳到文件页去看那棵树 —— 所以看到的永远是「左边栏的文件」。

改成两种停靠各走各的路，**都不离开会话页**：

| 停靠 | 行为 |
|---|---|
| `left` | 分栏开到右栏，对话留在左栏（上一版已对） |
| `right` | 打开右侧抽屉，并在里面预览这个文件 |

给 `FileBrowser` 加受控入口 `openRequest={{ path, nonce }}`：

- **先 navigate 到文件所在目录再开预览** —— 不导航的话左边那棵树还停在别处，看到的是「一个文件凭空出现」，不知道它在哪
- **`nonce` 自增才触发** —— 同一个文件点第二次时 `path` 没变，没有 nonce 就毫无反应（跟行号跳转是同一个坑）

## 二、抽屉里的预览改成就地铺开，不再弹模态框

`dock` 布局原来渲染的是**不带 `inline` 的 `Viewer`**，也就是居中模态框。

抽屉本来就是一块常驻侧栏，从里面再弹一个浮层等于把它整个盖住 —— 而点开文件恰恰是想跟左边的对话对着看。

改成绝对定位铺满抽屉：浏览器那半**不卸载**（保住树的展开态与滚动位置），预览盖在它上面，关掉即回。

## 验证

- `FileBrowser` 新增 4 条测试：导航到文件所在目录、没有 `openRequest` 时不乱跳、同 nonce 重渲染不重复打开、**dock 预览起来后 DOM 里没有 `.ant-modal`**
- `typecheck` / `i18n:check`(1558 键) / **vitest 184 passed** / `build` / `go build` / `go test` 全绿

写的时候踩了一下记一笔：测试 stub 里我按 `?dir=` 取参数，实际接口是 `?path=`，第一版断言全空。

## 未验收

真机没跑 —— 这批全是前端改动，`dist` 已 build（后端从磁盘直接服务，不需要重启），但没在真机上亲眼看过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
