### PR TITLE
feat(web): 文件抽屉分「文件夹 / 文件」两栏，中间可拖

### DIFF
--- a/frontend/src/FileBrowser.test.tsx
+++ b/frontend/src/FileBrowser.test.tsx
@@ -228,3 +228,65 @@ describe('FileBrowser dock 预览不弹模态框', () => {
     expect(document.querySelector('.ant-modal')).toBeNull()
   })
 })
+
+// 抽屉够宽时「文件夹 / 文件」并排两栏，中间可拖；窄了自动退回单栏。
+// jsdom 不排版，所以用 getBoundingClientRect 桩来喂宽度。
+describe('FileBrowser dock 两栏与分界拖动', () => {
+  let panelWidth = 800
+  let nativeRect: typeof Element.prototype.getBoundingClientRect
+
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    class RO {
+      constructor(private cb: () => void) {}
+      observe() { this.cb() }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', RO)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/files?')) {
+        const dir = new URL(url, 'http://x').searchParams.get('path') || ''
+        return jsonResponse({ data: { path: dir || '/workspace', parent: '/', entries: [] } })
+      }
+      if (url.includes('/api/file?')) return jsonResponse({ data: { content: 'hello', truncated: false } })
+      return jsonResponse({ data: {} })
+    }))
+    nativeRect = Element.prototype.getBoundingClientRect
+    Element.prototype.getBoundingClientRect = function () {
+      return { width: panelWidth, height: 600, top: 0, left: 0, right: panelWidth, bottom: 600, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+    }
+  })
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = nativeRect
+    cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals()
+  })
+
+  const renderDock = () => render(
+    <I18nProvider><AntApp>
+      <div style={{ display: 'flex', flexDirection: 'column', height: 600 }}>
+        <FileBrowser dir="/workspace" layout="dock" openRequest={{ path: '/workspace/a.md', nonce: 1 }} />
+      </div>
+    </AntApp></I18nProvider>,
+  )
+
+  it('够宽时并排两栏，中间有可拖的分界', async () => {
+    panelWidth = 800
+    const { container } = renderDock()
+    await waitFor(() => expect(container.querySelector('[data-resize-handle="filetree"]')).not.toBeNull())
+    expect(document.querySelector('.ant-modal')).toBeNull()
+  })
+
+  it('窄到放不下两栏时退回单栏——宁可少一栏，也不要两栏都残', async () => {
+    panelWidth = 420
+    const { container } = renderDock()
+    await waitFor(() => expect(container.textContent || '').toContain('a.md'))
+    expect(container.querySelector('[data-resize-handle="filetree"]')).toBeNull()
+  })
+})

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -1,8 +1,9 @@
 // 文件侧栏 —— 在 Claude / Codex 对话页右侧浏览工作目录、查看文件内容（类似 codex 右侧边栏）。
 // 单层可导航列表：目录在前可进入、↑ 回上级、点文件在弹层里查看正文。
-import { type ReactNode, Fragment, createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { type PointerEvent as ReactPointerEvent, type ReactNode, Fragment, createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { AutoComplete, Button, ConfigProvider, Dropdown, Input, Modal, Spin, App as AntApp, Tooltip, type MenuProps } from 'antd'
 import { api, upload } from './api'
+import { usePointerResize } from './PointerResize'
 import { useI18n } from './i18n'
 import { download as p2pDownload } from './p2p/download'
 import { pathLabelKey, type P2PPathLabel } from './p2p/labels'
@@ -328,6 +329,13 @@ function FileTree({
 
   return <>{renderLevel(root, rootEntries, 0)}</>
 }
+
+// 「文件夹 / 文件」两栏的尺寸契约（dock 布局用）
+const TREE_MIN = 180        // 树再窄就只剩省略号
+const TREE_MAX = 480
+const TREE_DEFAULT = 260
+const PREVIEW_MIN = 280     // 预览再窄读不了代码
+const SPLIT_MIN = TREE_MIN + PREVIEW_MIN + 5   // 面板窄于此只显示一栏
 
 export default function FileBrowser({
   dir,
@@ -711,9 +719,40 @@ export default function FileBrowser({
     }
   }
 
+  // 「文件夹 / 文件」两栏的分界：可拖，记 localStorage。
+  const dockRef = useRef<HTMLDivElement>(null)
+  const [dockW, setDockW] = useState(0)
+  useEffect(() => {
+    const el = dockRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => setDockW(el.getBoundingClientRect().width))
+    ro.observe(el)
+    setDockW(el.getBoundingClientRect().width)
+    return () => ro.disconnect()
+  }, [])
+  const [treeW, setTreeW] = useState(() => {
+    const v = Number(localStorage.getItem('ttmux.fileTreeW'))
+    return v >= TREE_MIN && v <= TREE_MAX ? v : TREE_DEFAULT
+  })
+  const treeWRef = useRef(treeW)
+  treeWRef.current = treeW
+  const dockResize = usePointerResize()
+  const startTreeResize = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const startX = e.clientX
+    const startW = treeW
+    // 预览至少留 PREVIEW_MIN：拖到把预览挤没了，这个分栏就白做了
+    const cap = Math.max(TREE_MIN, Math.min(TREE_MAX, (dockRef.current?.getBoundingClientRect().width || TREE_MAX) - PREVIEW_MIN))
+    dockResize.start(e, {
+      onMove: (ev) => setTreeW(Math.min(cap, Math.max(TREE_MIN, startW + ev.clientX - startX))),
+      onEnd: () => localStorage.setItem('ttmux.fileTreeW', String(treeWRef.current)),
+    })
+  }
+
   // 对话里点了文件名 → 在这个浏览器里打开它：先把树导航到它所在目录，再开预览。
   // 走 openPath 而不是直接 setView：不 navigate 的话左边的树还停在别处，
   // 你看到的是「一个文件凭空出现」，不知道它在哪。
+  // 两栏并排的下限：窄于这个宽度就只显示一栏。420 的抽屉硬塞两栏，
+  // 树只剩 160、预览只剩 250，两边都没法看——宁可少一栏，也不要两栏都残。
   const openReqRef = useRef(0)
   useEffect(() => {
     if (!openRequest?.path || openRequest.nonce === openReqRef.current) return
@@ -1027,17 +1066,33 @@ export default function FileBrowser({
     )
   }
 
-  // 停靠布局（右侧「文件管理」抽屉 / 新标签左侧栏）：预览**就在抽屉里铺开**，不弹模态框。
-  // 之前用 Modal：抽屉本来就是一块常驻的侧栏，从里面再弹一个居中浮层，
-  // 等于把你刚打开的那个面板整个盖住——而你点开文件恰恰是想跟左边的对话对着看。
-  // 浏览器那半不卸载（保住树的展开态与滚动位置），预览盖在它上面，关掉即回。
+  // 停靠布局（右侧「文件管理」抽屉 / 新标签左侧栏）：**树和文件两栏并排，中间可拖**，
+  // 而且不弹模态框——抽屉本来就是一块常驻侧栏，从里面再弹个居中浮层等于把它整个盖住，
+  // 而你点开文件恰恰是想「一边看树、一边看文件、还一边看左边的对话」。
+  //
+  // 面板窄到放不下两栏时（< SPLIT_MIN）自动退回单栏：预览盖住树，左上角给返回。
+  // 420 宽硬塞两栏的结果是两边都没法看——宁可少一栏，也不要两栏都残。
   if (layout === 'dock') {
+    const twoPane = !!view && dockW >= SPLIT_MIN
     return (
-      <div style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-        {browserPane}
+      <div ref={dockRef} style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, display: 'flex' }}>
+        <div style={{
+          flex: twoPane ? `0 0 ${treeW}px` : '1 1 auto',
+          minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column',
+        }}>
+          {browserPane}
+        </div>
+        {twoPane && (
+          <div data-resize-handle="filetree" onPointerDown={startTreeResize}
+            title={t('file.dragResize')} className="tt-split-rail"
+            style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
+        )}
         {view && (
-          <div style={{ position: 'absolute', inset: 0, zIndex: 2, display: 'flex', background: 'var(--bg-base)' }}>
-            <Viewer path={view} accent={accent} inline onBack={() => setView(null)} onClose={() => setView(null)}
+          <div style={twoPane
+            ? { flex: '1 1 auto', minWidth: 0, minHeight: 0, display: 'flex' }
+            : { position: 'absolute', inset: 0, zIndex: 2, display: 'flex', background: 'var(--bg-base)' }}>
+            <Viewer path={view} accent={accent} inline
+              onBack={twoPane ? undefined : () => setView(null)} onClose={() => setView(null)}
               onOpenPath={openPath} onOpenAgent={onOpenAgent} />
           </div>
         )}


### PR DESCRIPTION
接 #168。上一版把预览做成**盖住树** —— 能看文件了，但看不到它在哪。

抽屉的价值恰恰是「一边看树、一边看文件、还一边看左边的对话」，盖住一半等于把这个价值砍掉三分之一。

## 改成两栏并排，中间可拖

| 项 | 值 | 为什么 |
|---|---|---|
| 树宽 | `[180, 480]`，默认 260 | 再窄就只剩省略号 |
| 拖动上限 | 给预览留够 280 | 拖到把预览挤没了，这个分栏就白做了 |
| 记忆 | `localStorage`（`ttmux.fileTreeW`） | 跟文件栏宽度同一套做法 |

分界条复用 `usePointerResize` 与 `.tt-split-rail`，跟 `FileWorkspace` 的分栏把手是同一个交互。

## 窄了自动退回单栏

面板窄于 **465**（树 180 + 预览 280 + 把手 5）时只显示一栏：预览盖住树、左上角给返回。

420 的抽屉硬塞两栏，树只剩 160、预览只剩 250 —— **两边都没法看**。宁可少一栏，也不要两栏都残。

宽度用 `ResizeObserver` 量，而抽屉本身（Inspector 列）就能拖宽 —— 拖到够宽两栏自己会出来，不需要额外的开关。

## 验证

- 测试新增 2 条：够宽时存在 `[data-resize-handle="filetree"]` 且 DOM 里无 `.ant-modal`；窄时没有分界（退回单栏）。jsdom 不排版，用 `getBoundingClientRect` 桩喂宽度
- `typecheck` / `i18n:check`(1558 键) / **vitest 186 passed** / `build` / `go build` / `go test` 全绿

## 未验收

真机没跑 —— 纯前端改动，`dist` 已 build（后端从磁盘直接服务，不需要重启），但没在真机上亲眼看过两栏与拖动的手感。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
