### PR TITLE
feat(web): 实时回显收成卡片，不再原样倒 TUI 尾巴

### DIFF
--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -4,13 +4,14 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Button, Input, App as AntApp } from 'antd'
 import { api, upload, makeClipboardImageFile } from '../api'
-import { PromptPanel, detectPrompt } from '../prompt'
+import { PromptPanel } from '../prompt'
 import { usePreferences } from '../preferences'
 import { useI18n } from '../i18n'
 import { VoiceInput } from './VoiceInput'
 import type { Block, Msg } from './types'
 import { groupRuns } from './runs'
 import { ToolRun } from './ToolRun'
+import { LiveTail } from './LiveTail'
 import { useLayout } from '../layout'
 import { ArrowToBottom, ArrowUp, FileTextIcon, PaperclipIcon, StopIcon } from '../icons'
 import { ChatActionsProvider } from './actions'
@@ -119,6 +120,14 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
     }
   }
 
+  // TUI 会把用户刚发的那句回显在框里，实时回显要按它去重
+  const lastUserText = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') return messages[i].blocks.map((b) => b.text || '').join('\n').trim()
+    }
+    return ''
+  }, [messages])
+
   const hidden = Math.max(0, messages.length - limit)
   const visible = hidden > 0 ? messages.slice(-limit) : messages
   // 连着的同族工具调用并成运行组（设计 16）。分组只能在这一层做：Claude 每次工具调用
@@ -226,8 +235,9 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
                 ? <ToolRun key={it.run.key} run={it.run} isLast={i === items.length - 1} />
                 : renderMessage(it.msg, it.index)))
               : visible.map(renderMessage)}
-            {pending}
-            {busy && <LiveTail name={name} />}
+            {/* 实时回显自带「正在生成」那颗脉冲点，扒不到东西时才退回省略号气泡——
+                两个都画等于同一件事说两遍（见截图里那块重复） */}
+            {busy ? <LiveTail name={name} accent={accent} idle={pending} lastUser={lastUserText} /> : pending}
           </div>
           {/* 「回到底部」已并进下方状态条（带未读数）；状态条一个字段都没有时（刚进页面、
               转录还没扫出状态）才退回这颗悬浮钮，免得离底了没处点。 */}
@@ -287,52 +297,5 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
       </div>
     </div>
     </ChatActionsProvider>
-  )
-}
-
-// 把终端实况(capture)清洗成「干净的实时回复」：去掉方框线、底部输入框/提示、spinner 行，
-// 只留正在生成的正文尾部。启发式、随 TUI 版本可能要微调，但作为实时预览足够。
-const LEAD_BOX = /^[\s│┃|╎┆┊╭╰├╞┝─━═>❯]+/u
-const TAIL_BOX = /[\s│┃|╎┆┊╮╯┤╡┥─━═]+$/u
-const BOX_ONLY = /^[\s─━═│┃╭╮╰╯├┤┬┴┼╞╡╪.·]*$/u
-const NOISE = /(esc to interrupt|esc to cancel|enter to select|tab\/arrow|to navigate|\? for shortcuts|ctrl\+|shift\+tab|bypass permissions|↑↓|tokens?\b|⧉|auto-?accept|for newline)/i
-const SPINNER = /^[\s]*[●○◯⏺✶✳✻∗*•·✢✦✧✺✷+✽][\s]*$/u
-
-function cleanTail(raw: string): string {
-  const out: string[] = []
-  for (let l of String(raw).replace(/\r/g, '').split('\n')) {
-    l = l.replace(LEAD_BOX, '').replace(TAIL_BOX, '').replace(/^[●○◯⏺✶✳✻∗•·]\s?/u, '')
-    if (!l.trim() || BOX_ONLY.test(l) || SPINNER.test(l) || NOISE.test(l)) continue
-    out.push(l)
-  }
-  return out.slice(-10).join('\n')
-}
-
-function LiveTail({ name }: { name: string }) {
-  const { t } = useI18n()
-  const [text, setText] = useState('')
-  useEffect(() => {
-    let stop = false
-    const poll = async () => {
-      try {
-        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/capture?lines=40`)
-        const raw = r.data || ''
-        // 交互式选择框交给 PromptPanel 专门渲染，这里不再重复显示（避免被截断/错乱）
-        if (!stop) setText(detectPrompt(raw) ? '' : cleanTail(raw))
-      } catch {}
-    }
-    poll()
-    const t = setInterval(poll, 800)
-    return () => { stop = true; clearInterval(t) }
-  }, [name])
-  if (!text) return null
-  return (
-    <div style={{ margin: '4px 0', border: '1px solid var(--border)', borderRadius: 8, background: 'var(--bg-base)', overflow: 'hidden' }}>
-      <div style={{ fontSize: 11, color: 'var(--text-dim)', padding: '4px 8px', display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span className="cc-pulse" style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--ok)', display: 'inline-block' }} />
-        {t('chat.liveTerminalOutput')}
-      </div>
-      <pre style={{ margin: 0, padding: '0 8px 8px', maxHeight: 160, overflow: 'auto', fontFamily: 'ui-monospace, monospace', fontSize: 11.5, lineHeight: 1.45, color: 'var(--text-dim)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{text}</pre>
-    </div>
   )
 }

--- a/frontend/src/chat/LiveTail.test.ts
+++ b/frontend/src/chat/LiveTail.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { parseTail } from './LiveTail'
+
+// 真机上扒到的那一帧（截图 2026-08-05 15:30）：TUI 的树枝、字符图标、回显、会话名全在里面
+const RAW = [
+  '╭──────────────────────────────────────╮',
+  '│ 合入合入                             │',
+  '',
+  '  Running 1 shell command…',
+  '  └  $ gh pr merge 170 --squash --delete-branch 2>&1 | tail -5',
+  '  └  ✔ 修 shell 命令行渲染：截断 JSON',
+  '  ✔ 后端透出会话状态 status',
+  '  □ 补测试 + 全套校验 + 真机验收',
+  'refine-chat-tool-rendering',
+  '  ✻ ',
+  '  esc to interrupt · ctrl+_ to undo',
+  '╰──────────────────────────────────────╯',
+].join('\n')
+
+describe('parseTail', () => {
+  const lines = parseTail(RAW, { session: 'refine-chat-tool-rendering', lastUser: '合入合入' })
+
+  it('剥掉框线与树枝，`└` 和 `⎿` 也算框线', () => {
+    expect(lines.every((l) => !/[└⎿│╭╰]/.test(l.text))).toBe(true)
+  })
+
+  it('用户刚发的那句和会话名不重复回显', () => {
+    expect(lines.some((l) => l.text === '合入合入')).toBe(false)
+    expect(lines.some((l) => l.text === 'refine-chat-tool-rendering')).toBe(false)
+  })
+
+  it('命令行认出来并去掉 $', () => {
+    const cmd = lines.find((l) => l.kind === 'cmd')
+    expect(cmd?.text).toBe('gh pr merge 170 --squash --delete-branch 2>&1 | tail -5')
+  })
+
+  it('待办认成结构，字符图标不进文本（显示时换成 SVG）', () => {
+    const todos = lines.filter((l) => l.kind === 'todo') as { text: string; done: boolean }[]
+    expect(todos).toHaveLength(3)
+    expect(todos[0]).toMatchObject({ done: true, text: '修 shell 命令行渲染：截断 JSON' })
+    expect(todos[2]).toMatchObject({ done: false, text: '补测试 + 全套校验 + 真机验收' })
+    expect(todos.every((x) => !/[✔✓□☐]/.test(x.text))).toBe(true)
+  })
+
+  it('状态行单列一类，提示行与 spinner 丢掉', () => {
+    expect(lines.filter((l) => l.kind === 'action').map((l) => l.text)).toEqual(['Running 1 shell command…'])
+    expect(lines.some((l) => /esc to interrupt/.test(l.text))).toBe(false)
+    expect(lines.some((l) => l.text === '✻')).toBe(false)
+  })
+
+  it('只留最后 10 行', () => {
+    expect(parseTail(Array.from({ length: 40 }, (_, i) => `行 ${i}`).join('\n'))).toHaveLength(10)
+  })
+
+  it('空输入不炸', () => {
+    expect(parseTail('')).toEqual([])
+  })
+})

--- a/frontend/src/chat/LiveTail.tsx
+++ b/frontend/src/chat/LiveTail.tsx
@@ -1,0 +1,125 @@
+// 实时回显（会话还在生成时，从终端 capture 里扒出来的那截）。
+//
+// 从前是把 TUI 尾巴原样倒出来的一坨 pre：`└` 框线、`✔ □` 字符图标、会话名、
+// 连用户自己刚发的那句都回显一遍，还跟上面的「正在生成」气泡重复说了两次。
+// 现在收成一张卡，和运行组同一套语言：一条左脊 + 一个头 + 一段带终端底的身子，
+// 行按类型画（命令 / 待办 / 正文），字符图标一律换成 SVG（图标硬规则）。
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { api } from '../api'
+import { detectPrompt } from '../prompt'
+import { useI18n } from '../i18n'
+import { CheckIcon, ChevronRight, CircleIcon } from '../icons'
+import { CopyBtn } from './tool-parts'
+import { MONO } from './blocks'
+
+// 方框线：TUI 用来画树枝和边框的字符，一律剥掉（`└⎿` 这两个此前漏了，于是原样漏进页面）
+const LEAD_BOX = /^[\s│┃|╎┆┊╭╰├╞┝└┗╘╙⎿─━═>❯⏵]+/u
+const TAIL_BOX = /[\s│┃|╎┆┊╮╯┤╡┥─━═]+$/u
+const BOX_ONLY = /^[\s─━═│┃╭╮╰╯├┤┬┴┼╞╡╪.·]*$/u
+const NOISE = /(esc to interrupt|esc to cancel|enter to select|tab\/arrow|to navigate|\? for shortcuts|ctrl\+|shift\+tab|bypass permissions|↑↓|tokens?\b|⧉|auto-?accept|for newline)/i
+const SPINNER = /^[\s]*[●○◯⏺✶✳✻∗*•·✢✦✧✺✷+✽][\s]*$/u
+
+// 下面这些字符是**解析** TUI 输出用的，不是拿来显示的——显示一律换成 SVG。
+const DONE = /^[✔✓☑]\s*/u
+const TODO_MARK = /^[□☐○◻⬜]\s*/u
+const CMD = /^\$\s+/
+// 「Running 1 shell command…」这类状态行：TUI 自己的进度提示，收成一行淡字
+const ACTION = /^(running|waiting|thinking|working|compacting|searching|reading|editing)\b/i
+
+export type TailLine =
+  | { kind: 'action' | 'text'; text: string }
+  | { kind: 'cmd'; text: string }
+  | { kind: 'todo'; text: string; done: boolean }
+
+/** 把 capture 的尾巴清成结构化的几行。纯函数，好测。 */
+export function parseTail(raw: string, opts: { session?: string; lastUser?: string } = {}): TailLine[] {
+  const skip = new Set([opts.session, (opts.lastUser || '').trim()].filter(Boolean) as string[])
+  const out: TailLine[] = []
+  for (let l of String(raw).replace(/\r/g, '').split('\n')) {
+    l = l.replace(LEAD_BOX, '').replace(TAIL_BOX, '').replace(/^[●○◯⏺✶✳✻∗•·]\s?/u, '')
+    const v = l.trim()
+    if (!v || BOX_ONLY.test(l) || SPINNER.test(l) || NOISE.test(l)) continue
+    // 用户刚发的那句、会话名——TUI 会把它们回显在框里，重复一遍没有意义
+    if (skip.has(v)) continue
+    if (CMD.test(v)) { out.push({ kind: 'cmd', text: v.replace(CMD, '') }); continue }
+    if (DONE.test(v)) { out.push({ kind: 'todo', text: v.replace(DONE, ''), done: true }); continue }
+    if (TODO_MARK.test(v)) { out.push({ kind: 'todo', text: v.replace(TODO_MARK, ''), done: false }); continue }
+    if (ACTION.test(v)) { out.push({ kind: 'action', text: v }); continue }
+    out.push({ kind: 'text', text: v })
+  }
+  return out.slice(-10)
+}
+
+export function LiveTail({ name, accent, idle, lastUser }: {
+  name: string
+  accent: string
+  /** 还没扒到任何东西时显示的东西（「正在生成」那颗省略号） */
+  idle?: ReactNode
+  /** 用户刚发的那句：TUI 会回显，去重用 */
+  lastUser?: string
+}) {
+  const { t } = useI18n()
+  const [raw, setRaw] = useState('')
+  const [open, setOpen] = useState(true)
+  useEffect(() => {
+    let stop = false
+    const poll = async () => {
+      try {
+        const r = await api('GET', `/sessions/${encodeURIComponent(name)}/capture?lines=40`)
+        const data = r.data || ''
+        // 交互式选择框交给 PromptPanel 专门渲染，这里不再重复显示（避免被截断/错乱）
+        if (!stop) setRaw(detectPrompt(data) ? '' : data)
+      } catch { /* 轮询失败就保持上一帧，别把卡片抖没 */ }
+    }
+    poll()
+    const timer = setInterval(poll, 800)
+    return () => { stop = true; clearInterval(timer) }
+  }, [name])
+
+  const lines = useMemo(() => parseTail(raw, { session: name, lastUser }), [raw, name, lastUser])
+  if (!lines.length) return <>{idle}</>
+
+  const copy = lines.map((l) => (l.kind === 'cmd' ? `$ ${l.text}` : l.text)).join('\n')
+  const toggle = () => setOpen((v) => !v)
+  return (
+    <div className="cc-live" style={{ borderLeftColor: accent }}>
+      <div className="cc-live-head" role="button" tabIndex={0} aria-expanded={open} onClick={toggle}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle() } }}>
+        <span className="cc-cmd-chev" style={{ transform: open ? 'rotate(90deg)' : 'none' }}><ChevronRight size={12} /></span>
+        <span className="cc-pulse" style={{ width: 6, height: 6, borderRadius: '50%', background: accent, display: 'inline-block', flex: '0 0 auto' }} />
+        <span style={{ flex: '0 0 auto' }}>{t('chat.liveTerminalOutput')}</span>
+        <span className="cc-run-last">{open ? '' : lines[lines.length - 1]?.text || ''}</span>
+        <CopyBtn text={copy} />
+      </div>
+      {open && (
+        <div className="cc-live-body">
+          {lines.map((l, i) => {
+            if (l.kind === 'cmd') {
+              return (
+                <div key={i} className="cc-live-line is-cmd">
+                  <span style={{ flex: '0 0 auto', color: 'var(--ok)', fontFamily: MONO, fontWeight: 600 }}>$</span>
+                  <span className="cc-live-text">{l.text}</span>
+                </div>
+              )
+            }
+            if (l.kind === 'todo') {
+              return (
+                <div key={i} className="cc-live-line">
+                  <span style={{ flex: '0 0 auto', display: 'flex', marginTop: 3, color: l.done ? 'var(--ok)' : 'var(--text-dimmer)' }}>
+                    {l.done ? <CheckIcon size={12} /> : <CircleIcon size={12} />}
+                  </span>
+                  <span className="cc-live-text" style={{ color: l.done ? 'var(--text-dimmer)' : 'var(--text-dim)' }}>{l.text}</span>
+                </div>
+              )
+            }
+            return (
+              <div key={i} className={`cc-live-line${l.kind === 'action' ? ' is-action' : ''}`}>
+                <span className="cc-live-text">{l.text}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2096,6 +2096,50 @@ html[data-size="compact"] .cc-cmd-desc-inline { display: none; }
 html[data-size="compact"] .cc-run-slot { width: auto; }
 @media (min-width: 900px) { .cc-run-slot { min-width: 46px; } }
 
+/* 实时回显（chat/LiveTail.tsx）：跟运行组同一套外壳，只是脊是强调色、身子铺终端底。
+   它是「当下正在发生」的那块，所以底色比历史区重一档——但外壳不能是第三种长相。 */
+.cc-live {
+  margin: var(--sp-2) 0;
+  border-left: 2px solid var(--accent);
+  border-radius: 0 var(--r-xs) var(--r-xs) 0;
+  background: color-mix(in srgb, var(--bg-container) 55%, transparent);
+  overflow: hidden;
+}
+.cc-live-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  padding: 4px var(--sp-2) 4px 7px;
+  font-size: var(--fs-meta);
+  color: var(--text-dim);
+  cursor: pointer;
+  outline: none;
+}
+.cc-live-head:hover { background: var(--list-hover); }
+.cc-live-head:focus-visible { box-shadow: inset 0 0 0 1px var(--accent-border); }
+.cc-live-body {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-term);
+  padding: var(--sp-2) var(--sp-2) var(--sp-2) 7px;
+  max-height: 200px;
+  overflow: auto;
+}
+.cc-live-line { display: flex; align-items: flex-start; gap: 6px; min-width: 0; }
+.cc-live-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: var(--fs-meta);
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+.cc-live-line.is-cmd .cc-live-text { color: var(--text-bright); }
+.cc-live-line.is-action .cc-live-text { color: var(--text-dimmer); }
+@media (pointer: coarse) { .cc-live-head { min-height: 44px; } }
+
 /* 粗指针命中区（设计系统 §「粗指针下命中区 ≥44」）。
    这里**不能**用「伪元素往外撑、不撑视觉尺寸」那套：工具行是连排的，行距只有 1~2px，
    44 的伪元素会往上下各溢出 10px 压到邻行，而后面的兄弟节点画在上层——


### PR DESCRIPTION
生成中那块「实时输出（终端）」是把 capture 的尾巴直接塞进一个 `pre`：

- `└` 树枝没剥掉（`LEAD_BOX` 漏了 `└┗╘╙⎿⏵` 这几个字符）
- `✔ □` 字符图标原样显示（违反图标硬规则）
- 会话名、以及用户刚发的那句被 TUI 回显进来，页面上又跟着打了一遍
- 上面还另有一个「正在生成」气泡，同一件事说两遍

改成一张卡，跟运行组同一套外壳：一条左脊（强调色）+ 一个可折叠的头 + 一段铺终端底的身子。

解析拆成纯函数 `parseTail()`：

- 框线字符补全，树枝不再漏进页面
- 按会话名与最近一条用户消息去重
- `$ cmd` 认成命令行；`✔ / □` 认成待办（**字符只用于解析**，显示换成 `CheckIcon` / `CircleIcon`）；`Running …` 这类认成状态行；其余是正文
- 「正在生成」并进卡头那颗脉冲点，扒不到东西时才退回原来的省略号气泡

新增 `LiveTail.test.ts`(7)，用例直接取真机上那一帧。`typecheck` / `i18n:check`(1568) / `vitest` **213 passed** / `build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)