### PR TITLE
fix(web): 手指档点按钮点空、hover 粘住、浮层吞点击

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -984,13 +984,18 @@ function TBtn({ icon, label, on, tone = 'accent', title, onClick, onMouseDown }:
   icon?: ReactNode; label?: ReactNode; on?: boolean; tone?: 'accent' | 'ok'; title?: ReactNode
   onClick?: () => void; onMouseDown?: (e: React.MouseEvent) => void
 }) {
+  const { coarse } = useLayout()
   const btn = (
     <button type="button" className={`tt-tbtn${on ? ' on' : ''}${tone === 'ok' ? ' ok' : ''}${label ? '' : ' tt-ico'}`}
-      onClick={onClick} onMouseDown={onMouseDown}>
+      onClick={onClick} onMouseDown={onMouseDown}
+      aria-label={typeof title === 'string' ? title : undefined}
+      title={coarse && typeof title === 'string' ? title : undefined}>
       {icon}{label != null && <span>{label}</span>}
     </button>
   )
-  return title ? <Tooltip title={title} mouseEnterDelay={0.35}>{btn}</Tooltip> : btn
+  // 粗指针不挂 Tooltip：触屏没有 mouseleave，浮层收不掉，而 .ant-tooltip 是
+  // pointer-events: auto，会把它盖住那片区域后续的点全吞掉（同 Projects 的 ActBtn）。
+  return title && !coarse ? <Tooltip title={title} mouseEnterDelay={0.35}>{btn}</Tooltip> : btn
 }
 
 // ── 终端面板（多标签 + 工具栏 + 快捷键栏），桌面右栏与手机覆盖层共用 ──

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -136,6 +136,8 @@ const PRJ_CSS = `
 /* 动作区（.tt-act 幽灵按钮见 index.css）：按钮自带边框和命中区，不再靠
    「平时半透明、hover 才显形」——那对手指档等于不存在，键盘用户也摸不着。 */
 .prj-row .acts{display:flex;gap:6px;flex:0 0 auto;margin-top:2px;flex-wrap:wrap;justify-content:flex-end}
+/* 换行时行距给到 10：按钮视觉 36、命中区 44，行距不到 8 两行的命中区就会叠在一起 */
+html[data-pointer="coarse"] .prj-row .acts{row-gap:10px}
 .prj-row.warn{background:rgba(210,153,34,.05);border:1px solid rgba(210,153,34,.18);margin-bottom:4px}
 .prj-row.warn:hover{background:rgba(210,153,34,.09)}
 .prj-row.warn::before{display:none}
@@ -254,14 +256,21 @@ const CLI_KINDS = ['shell', 'claude', 'codex'] as const
 
 // 行尾动作钮：一行四五个动作写成汉字太吵，收成图标方钮。
 // 图标不写进文案（图标硬规则）：label 只给字，Tooltip 和 aria-label 都用它，图标在调用处传。
+//
+// 粗指针下**不挂 Tooltip**：触屏点一下就把浮层弹出来，之后没有 mouseleave 让它收，
+// 它就一直悬在按钮上方那一条；而 antd 的 .ant-tooltip 是 pointer-events: auto，
+// 于是它盖住的那块区域后续的点全被吞掉——表现就是「点了没有该有的动作」。
+// 手指档靠 aria-label + 原生 title 说明动作，不弹浮层。
 export const ActBtn = ({ icon, label, tone, onClick }: {
   icon: ReactNode; label: string; tone?: 'danger' | 'ok'; onClick?: () => void
-}) => (
-  <Tooltip title={label}>
+}) => {
+  const { coarse } = useLayout()
+  const btn = (
     <button type="button" className={`tt-act ico${tone ? ' ' + tone : ''}`} aria-label={label}
-      onClick={onClick}>{icon}</button>
-  </Tooltip>
-)
+      title={coarse ? label : undefined} onClick={onClick}>{icon}</button>
+  )
+  return coarse ? btn : <Tooltip title={label}>{btn}</Tooltip>
+}
 
 export const dot = (on: boolean, color?: string) => (
   <span style={{

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1142,8 +1142,9 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   transition: background .14s ease, color .14s ease, box-shadow .14s ease;
 }
 .tt-tbtn.tt-ico { padding: 0 6px; }
-.tt-tbtn:hover { background: var(--list-hover); color: var(--text-bright); }
-.tt-tbtn:active { transform: translateY(.5px); }
+/* hover 只给细指针：触屏没有 mouseleave，:hover 会粘在最后点过的那枚上不走 */
+html[data-pointer="fine"] .tt-tbtn:hover { background: var(--list-hover); color: var(--text-bright); }
+.tt-tbtn:active { background: var(--list-hover); transform: translateY(.5px); }
 .tt-tbtn:focus-visible { outline: 2px solid var(--accent-border); outline-offset: 1px; }
 
 /* 开启态：软色底 + 主色字，**不描边**。原来是满强度的蓝色描边圈（行内拼色拼坏了，见
@@ -1151,10 +1152,10 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
    静态只留一层底色说「这个面板开着」；指到它时才浮出一道同色细内环当反馈——
    环只在 hover 出现、不常驻，一排按钮就不会被边框切碎。 */
 .tt-tbtn.on { background: var(--accent-soft); color: var(--accent); }
-.tt-tbtn.on:hover { background: var(--accent-soft); color: var(--accent);
-  box-shadow: inset 0 0 0 1px var(--accent-border); }
 .tt-tbtn.on.ok { background: var(--ok-soft); color: var(--ok); }
-.tt-tbtn.on.ok:hover { background: var(--ok-soft); color: var(--ok);
+html[data-pointer="fine"] .tt-tbtn.on:hover { background: var(--accent-soft); color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent-border); }
+html[data-pointer="fine"] .tt-tbtn.on.ok:hover { background: var(--ok-soft); color: var(--ok);
   box-shadow: inset 0 0 0 1px var(--ok-border); }
 
 /* 右侧只读工具（翻页 / 字号 / 重绘重连）收进分段组，视觉上跟左侧动作区分开 */
@@ -1225,17 +1226,26 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   background: transparent; color: var(--text-dim);
   font: inherit; font-size: var(--fs-meta); line-height: 1; white-space: nowrap; cursor: pointer;
   transition: color .15s, border-color .15s, background .15s; }
-.tt-act:hover { color: var(--text-bright); border-color: var(--border); background: var(--list-hover); }
+/* hover 装饰只给细指针。触屏点完不会有 mouseleave，:hover 会一直粘在最后点过的那枚上，
+   点下一枚时上一枚才带着 .15s 过渡褪掉——一排按钮轮流亮灭，看着就是在抖。
+   手指档只留 :active 的按下反馈。 */
+html[data-pointer="fine"] .tt-act:hover { color: var(--text-bright); border-color: var(--border); background: var(--list-hover); }
+html[data-pointer="fine"] .tt-act.danger:hover { color: var(--danger); border-color: var(--danger-border); background: var(--danger-soft); }
+html[data-pointer="fine"] .tt-act.ok:hover { color: var(--ok); border-color: var(--ok-border); background: var(--ok-soft); }
+.tt-act:active { background: var(--list-hover); }
+.tt-act.danger:active { background: var(--danger-soft); color: var(--danger); }
+.tt-act.ok:active { background: var(--ok-soft); color: var(--ok); }
 .tt-act:focus-visible { outline: 1px solid var(--accent-border); outline-offset: 1px; }
-.tt-act.danger:hover { color: var(--danger); border-color: var(--danger-border); background: var(--danger-soft); }
-.tt-act.ok:hover { color: var(--ok); border-color: var(--ok-border); background: var(--ok-soft); }
 /* 图标钮：一行四五个动作写成汉字太吵，收成方钮，动作名走 Tooltip + aria-label
    （图标不写进文案，见图标硬规则——文案只写字，图标在调用处给） */
 .tt-act.ico { width: 26px; padding: 0; }
-/* 粗指针：视觉 36，命中区靠伪元素撑到 44（不撑视觉尺寸） */
+/* 粗指针：视觉 36，命中区靠伪元素撑到 44（不撑视觉尺寸）。
+   左右各外扩半个 gap（.acts 的 gap 是 6）：不桥接的话两枚钮之间就留着 6px 死区，
+   而 .acts 上挂着 stopPropagation——点进缝里按钮没触发、行也没打开，彻底没反应。
+   上下只补到 44 为止，且相邻两行的命中区不许叠（见 .acts 的 row-gap）。 */
 html[data-pointer="coarse"] .tt-act { height: 36px; padding: 0 14px; position: relative; }
 html[data-pointer="coarse"] .tt-act.ico { width: 36px; padding: 0; }
-html[data-pointer="coarse"] .tt-act::after { content: ''; position: absolute; left: 0; right: 0;
+html[data-pointer="coarse"] .tt-act::after { content: ''; position: absolute; left: -4px; right: -4px;
   top: 50%; height: var(--tap); transform: translateY(-50%); }
 
 /* 分支名片：以前是 antd 的青色 Tag（#39c5cf，全站唯一一支青，还不在令牌里）。


### PR DESCRIPTION
#174 把行尾动作换成图标钮之后，粗指针（手机）上出现「点了会抖、点了没反应」。真机 CDP 量出来是**三条独立的回归**，都只在 `data-pointer=coarse` 下犯，桌面完全看不见 —— 这也是为什么本地验收没拦住。

## 1. 两枚图标钮之间 6px 死区，点进去什么都不发生

```
修前  按钮间空档命中谁: [{"gap":6,"hit":"acts"} × 3]
      .acts 是否吞事件: {"stop":true}
```

`.acts` 的 `gap:6px` 落在两枚 36px 方钮中间，命中的是 `.acts` 自己 —— 而任务行的 `.acts` 上挂着 `onClick={e => e.stopPropagation()}`，于是点在缝里：按钮没触发、行也没打开，**彻底没反应**。手指落点有 ±8px 抖动，四枚钮三条缝，点空是必然的。

旧的文字链接不会这样：它们的命中区伪元素是 `left:-6px; right:-6px`，正好把缝桥接上了；换成 `.tt-act` 时写成了 `left:0; right:0`。

改成左右各外扩 4px。**不是半个 gap 的 3px** —— dpr 2.75 下分数像素会吃掉边界，实测 `-3px` 仍留 2px 死区：

```
修前 -0px:  LL..RRR   （. = 谁都没命中）
     -3px:  LL..RRR
修后 -4px:  LLLRRRR   全覆盖
```

## 2. `:hover` 在触屏上粘住 → 一排按钮轮流亮灭（就是「抖动」）

```
修前  :hover 是否被指针档包住:
  .tt-act:hover / .tt-act.danger:hover / .tt-act.ok:hover     inHover:false
  .tt-tbtn:hover / .tt-tbtn.on:hover / .tt-tbtn.on.ok:hover   inHover:false
```

触屏点完不会有 `mouseleave`，`:hover` 就留在最后点过的那枚上；点下一枚时上一枚才带着 `.15s` 过渡褪掉 —— 连点几下就是一排按钮此起彼伏地亮灭。`.danger:hover` 最刺眼：点完「收尾」那枚会一直红着。

这条是 #174 新引入的：原来的文字链接 hover 只换个字色，粘住了看不出来；新按钮 hover 会上底色和边框。

所有 hover 装饰移到 `html[data-pointer="fine"]` 下 —— **走设计系统的单一断点入口，不另开 `@media (hover: hover)`**，避免出现第二个真相来源。手指档只留 `:active` 的按下反馈。

## 3. antd Tooltip 浮层 `pointer-events: auto`，吞掉后续点击

```
修前  tooltip: {"pe":"auto","innerPe":"auto","rect":{"x":244,"y":401,"w":44,"h":34}}
      按钮:                                        y ≈ 447–483
```

`ActBtn` / `TBtn` 新包的 Tooltip 在触屏上点一下就弹出，之后没有 `mouseleave` 让它收，浮层一直悬在按钮正上方那 34px；`.ant-tooltip` 的 `pointer-events` 是 `auto`，**它盖住的那片区域后续的点全被吃掉** —— 表现就是「点了没有该有的动作」。空间不够时 antd 会把浮层翻到下方，那就压住下一行。

粗指针下不再挂 Tooltip，动作名走 `aria-label` + 原生 `title`。

## 4. 换行时两行命中区会叠

按钮视觉 36、命中区 44，`.acts` 换行后 `row-gap: 6` 不够；粗指针下给到 10。

## 验收

真机 adb + CDP，硬刷后逐条量：

| 项 | 结果 |
|---|---|
| 缝里逐像素扫 | 修前 `LL..RRR`（2px 死区）→ 修后 `LLLRRRR` 全覆盖 |
| 手指档合成 hover | 无浮层、无 hover 底色（`background: rgba(0,0,0,0)`）|
| 细指针下 | 选择器仍匹配（`html[data-pointer="fine"] .tt-act` → true），命中区伪元素不生成（`height: auto`）|
| 跨行垂直命中冲突 | 0 |
| 按钮可达性 | `title` / `aria-label` 都在 |

`typecheck / i18n:check / vitest 226 / build` 与 `scripts/dev/quality/check.sh full` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
