### PR TITLE
fix(web): 止住整页横跳 · hover 全局关进细指针 · 手指档不出浮层提示

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,30 @@ Reach for `<button type="button">` by default; `<a>` only when it really navigat
 `useLayout()` is the only way to read layout size. NEVER read `window.innerWidth` and never call
 `matchMedia` yourself. Pure style differences key off `data-size` / `data-pointer` on `<html>`.
 Under a coarse pointer, hit targets are ≥44px — grow the hit area with a pseudo-element, not the
-visual size.
+visual size, and overshoot the gap between neighbouring icon buttons by 4px (3px still misses at
+dpr 2.75).
+
+## Hover Belongs to the Mouse
+
+Every `:hover` rule is written `:where(html[data-pointer="fine"]) X:hover`. Touch has no
+`mouseleave`, so a bare `:hover` sticks to the last thing a finger touched: the previously tapped
+button stays lit and a row of buttons flickers as you work down it. `:where()` adds no
+specificity, so the gate changes nothing about the cascade. Anything hidden until hover
+(`opacity: 0` copy/close/download buttons) needs a coarse rule that keeps it visible, or the phone
+can never reach it. `npm run hover:check` (`frontend/scripts/hover-scope-audit.mjs`) enforces both
+halves and runs inside `npm run build`.
+
+Tooltips are mouse furniture too: under a coarse pointer `.ant-tooltip` is hidden site-wide,
+because a tooltip opened by a long press never gets a `mouseleave` and its overlay then eats the
+next tap. An icon-only button therefore carries its name in `aria-label`, not only in a Tooltip.
+
+## The Document Never Scrolls
+
+`html, body { overflow: hidden }` — the app is a fixed-height shell and every page scrolls inside
+its own container. One pixel of document overflow summons a 10px document scrollbar, which takes
+10px off the workspace and slides the canvas and the terminal dock sideways; on a 150%-scaled
+display the fractional rounding flips it back and forth with every burst of terminal output, and
+buttons move out from under the cursor between mousedown and mouseup.
 
 ## Icons: SVG Only
 
@@ -132,7 +155,7 @@ synthesis, not copy-mode) and for redraw quirks on narrow widths.
 - Run `scripts/dev/quality/check.sh full` before opening or updating a PR with runtime behavior
   changes.
 - Frontend changes must additionally pass
-  `npm run typecheck && npm run i18n:check && npx vitest run && npm run build`.
+  `npm run typecheck && npm run i18n:check && npm run hover:check && npx vitest run && npm run build`.
 - Install the tracked Git hooks with `bash scripts/dev/install-git-hooks.sh`; it sets
   `core.hooksPath=.githooks` and `commit.template=.gitmessage`.
 - Never commit `.env`, generated dependency folders, coverage output, or hard-coded secrets.

--- a/docs/development/web-ui-checklist.md
+++ b/docs/development/web-ui-checklist.md
@@ -50,6 +50,17 @@ chrome goto https://127.0.0.1:13579/ && chrome eval "document.title"
 | 弹层是否被误关 | 触发后等 1.5s 再查节点是否还在 |
 | 布局是否溢出 | `document.documentElement.scrollWidth <= innerWidth` |
 
+## 1.4 「点了没反应 / 界面在抖」的四个惯犯
+
+这四条都不是「按钮坏了」，而是按钮**在被点的那一刻跑了或者被盖住了**。截图和 typecheck 全看不出来。
+
+| 现象 | 真因 | 验法 | 防线 |
+|---|---|---|---|
+| 上一次点过的按钮一直亮着，一排钮轮流亮灭 | 触屏没有 `mouseleave`，`:hover` 粘在最后点过的那枚上 | 手指档下 `getComputedStyle` 量点过的钮，背景不该变 | 所有 hover 写成 `:where(html[data-pointer="fine"]) X:hover`，`npm run hover:check` 守 |
+| 点一下没反应，再点才生效 | antd Tooltip 在触屏由「长按」触发，弹出后没有 mouseleave 收不回去，`pointer-events:auto` 的浮层停在按钮上方吃掉下一次点击 | `elementFromPoint(按钮中心)` 命中 `.ant-tooltip` | 手指档全局 `.ant-tooltip{display:none}`；图标钮的名字靠 `aria-label` |
+| 整条工作区连着终端面板横跳 ~10px，点击落到隔壁 | 文档溢出 1px → 冒出文档滚动条 → 可用宽少 10px → Canvas 与 Dock 一起重排（高分屏小数舍入下每来一段输出抖一次） | `document.body.style.minHeight='calc(100% + 1px)'` 前后量目标 rect.x，**不该动** | `html, body { overflow: hidden }`：外壳定高，滚动都在内部容器 |
+| 两枚图标钮之间的缝点不中 | 缝落在带 `stopPropagation` 的父节点上 | 沿按钮排横扫 `elementFromPoint`，每一列都要命中某枚钮 | 命中区伪元素左右各外扩 4px（真机 dpr 2.75 下 3px 不够） |
+
 ## 1.5 「花屏」先分类，再动手
 
 终端花屏有两类，长得一样但修法相反。**别靠截图猜**，用 `__roamTermDiag(true)` 把 xterm 的可视区
@@ -96,6 +107,13 @@ chrome goto https://127.0.0.1:13579/ && chrome eval "document.title"
 - [ ] **点终端空白处：弹框不消失**，且这一下点击落到终端（命中测试）。
 - [ ] 点选项能把按键注入会话；点右上角 × 只关这一条。
 - [ ] `.ant-modal-wrap` 的 `pointer-events` 必须是 `none`（否则整页点击被吃）。
+
+### C.5 指针档差异（手指 / 鼠标各跑一遍）
+
+- [ ] 手指档点过的按钮不留 hover 残留（点 A 再点 B，A 要回到静止态）。
+- [ ] 手指档 `.ant-tooltip` 不出现（`getComputedStyle(el).display === 'none'`）。
+- [ ] 行尾图标钮连排：逐列 `elementFromPoint` 都命中钮，缝里也不落到行本身。
+- [ ] 终端吐输出时整页不横移：量任一固定元素的 `rect.x`，连续采样 3s 不变。
 
 ### D. 手机专属
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run i18n:check && vite build && node scripts/compress-dist.mjs",
+    "build": "npm run i18n:check && npm run hover:check && vite build && node scripts/compress-dist.mjs",
     "i18n:check": "node scripts/i18n-audit.mjs",
+    "hover:check": "node scripts/hover-scope-audit.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/scripts/hover-scope-audit.mjs
+++ b/frontend/scripts/hover-scope-audit.mjs
@@ -1,0 +1,169 @@
+/*
+ * 守两条触屏规矩（详见 src/index.css 文件头）：
+ *
+ * 1. 每条 :hover 规则都要写成 `:where(html[data-pointer="fine"]) X:hover`。
+ *    触屏没有 mouseleave，:hover 会粘在最后点过的那枚元素上不走——一排按钮轮流亮灭，
+ *    用户看到的就是「点一下在抖，而且没反应」。
+ * 2. 只在 hover 里现身的东西（opacity:0 / display:none 的复制、关闭、下载键），
+ *    必须另有一条手指档常显规则，否则手机上永远够不着。
+ *
+ * 覆盖 src 下的 .css，以及 .tsx 里用模板字符串塞进 <style> 的那几坨样式。
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const root = new URL('..', import.meta.url).pathname
+const srcDir = join(root, 'src')
+const FINE = ':where(html[data-pointer="fine"])'
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) walk(path, out)
+    else if (/\.(css|tsx)$/.test(name)) out.push(path)
+  }
+  return out
+}
+
+/** 逐条规则切出「选择器 + 声明」；@keyframes 里的 0%/100% 不是选择器，跳过。 */
+function rules(text) {
+  const out = []
+  const stack = []
+  let i = 0
+  let start = 0
+  while (i < text.length) {
+    if (text.startsWith('/*', i)) {
+      const end = text.indexOf('*/', i + 2)
+      i = end === -1 ? text.length : end + 2
+      continue
+    }
+    const ch = text[i]
+    if (ch === '{') {
+      const prelude = text.slice(start, i)
+      const head = prelude.trim()
+      const atRule = head.startsWith('@')
+      if (!atRule && !stack.some((s) => s.skip)) {
+        const close = matchingBrace(text, i)
+        out.push({
+          selector: stripComments(prelude),
+          decls: stripComments(text.slice(i + 1, close === -1 ? text.length : close)),
+          line: text.slice(0, i).split('\n').length,
+        })
+      }
+      stack.push({ skip: atRule && /keyframes/.test(head) })
+      i += 1
+      start = i
+      continue
+    }
+    if (ch === '}') {
+      stack.pop()
+      i += 1
+      start = i
+      continue
+    }
+    i += 1
+  }
+  return out
+}
+
+function stripComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+function matchingBrace(text, open) {
+  let depth = 0
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    else if (text[i] === '}' && --depth === 0) return i
+  }
+  return -1
+}
+
+/** 顶层逗号切分：`:has(a, b)` 里的逗号不算。 */
+function splitTop(selector) {
+  const parts = []
+  let depth = 0
+  let cur = ''
+  for (const ch of selector) {
+    if (ch === '(' || ch === '[') depth++
+    else if (ch === ')' || ch === ']') depth--
+    if (ch === ',' && depth === 0) {
+      parts.push(cur)
+      cur = ''
+    } else cur += ch
+  }
+  parts.push(cur)
+  return parts
+}
+
+/** .tsx 里只有模板字符串那几段是 CSS，按「出现选择器块」的形态粗取即可。 */
+function cssOf(path, text) {
+  if (path.endsWith('.css')) return text
+  const chunks = [...text.matchAll(/`([^`]*)`/g)].map((m) => m[1])
+  return chunks.filter((c) => /:hover|data-pointer|\{[^{}]*:[^{}]*\}/.test(c)).join('\n')
+}
+
+const issues = []
+const revealed = [] // hover 里靠 opacity 现身的目标类
+const hidden = new Set() // 静态就 opacity:0 的类（藏起来等 hover 的）
+const coarseClasses = new Set() // 手指档规则点过名的类
+
+const lastClass = (sel) => (sel.match(/\.[A-Za-z0-9_-]+/g) || []).pop()
+
+for (const abs of walk(srcDir)) {
+  const file = relative(root, abs)
+  const text = cssOf(abs, readFileSync(abs, 'utf8'))
+  if (!text) continue
+  for (const rule of rules(text)) {
+    for (const part of splitTop(rule.selector)) {
+      const sel = part.trim()
+      if (!sel) continue
+      if (/data-pointer="coarse"/.test(sel)) {
+        for (const cls of sel.match(/\.[A-Za-z0-9_-]+/g) || []) coarseClasses.add(cls)
+      }
+      if (!sel.includes(':hover')) {
+        const cls = lastClass(sel)
+        if (cls && /(^|;)\s*opacity\s*:\s*0\s*(;|$)/.test(rule.decls)) hidden.add(cls)
+        continue
+      }
+      if (!sel.startsWith(FINE)) {
+        issues.push(
+          `${file}:${rule.line}: :hover 没关进细指针，触屏上会粘住\n` +
+            `  ${sel}\n  改成：${FINE} ${sel.replace(FINE, '').trim()}`,
+        )
+        continue
+      }
+      // hover 现身：:hover 之后还有后代，且这条把它的 opacity 拉回来
+      const tail = sel.slice(sel.lastIndexOf(':hover') + ':hover'.length)
+      const target = lastClass(tail)
+      if (target && /(^|;)\s*opacity\s*:\s*1\s*(;|$)/.test(rule.decls)) {
+        revealed.push({ file, line: rule.line, sel, target })
+      }
+    }
+  }
+}
+
+// .css 里的 @media (pointer: coarse) 也算给了手指档兜底
+for (const abs of walk(srcDir)) {
+  const text = cssOf(abs, readFileSync(abs, 'utf8'))
+  for (const m of text.matchAll(/@media[^{]*pointer:\s*coarse[^{]*\{/g)) {
+    const block = text.slice(m.index, matchingBrace(text, m.index + m[0].length - 1) + 1)
+    for (const cls of block.match(/\.[A-Za-z0-9_-]+/g) || []) coarseClasses.add(cls)
+  }
+}
+
+for (const r of revealed) {
+  if (hidden.has(r.target) && !coarseClasses.has(r.target)) {
+    issues.push(
+      `${r.file}:${r.line}: ${r.target} 只在 hover 时现身，手指档没有常显规则——手机上够不着\n` +
+        `  ${r.sel}\n  补一条：html[data-pointer="coarse"] ${r.target} { opacity: 1 }`,
+    )
+  }
+}
+
+if (issues.length) {
+  console.error(`hover 作用域检查未通过（${issues.length} 处）：\n`)
+  for (const issue of issues) console.error(issue + '\n')
+  process.exit(1)
+}
+console.log('hover 作用域检查通过')

--- a/frontend/src/Overview.tsx
+++ b/frontend/src/Overview.tsx
@@ -31,13 +31,13 @@ const OV_CSS = `
 .ov-new{flex:0 0 auto;display:inline-flex;align-items:center;gap:var(--sp-2);height:34px;padding:0 var(--sp-4);
   border:0;border-radius:var(--r-sm);background:var(--accent-solid);color:#fff;
   font-size:var(--fs-sm);font-weight:600;cursor:pointer;transition:filter .15s}
-.ov-new:hover{filter:brightness(1.08)}
+:where(html[data-pointer="fine"]) .ov-new:hover{filter:brightness(1.08)}
 /* 窄档：状态条是页头下方的一条横条（它挂在页头的 .acts 槽里，靠 100% 宽换行成整条） */
 .ov .tt-pagehead .acts{width:100%;margin-left:0}
 .ov .tt-pagehead .acts>.ov-sum{flex:1}
 .ov-sum button{display:inline-flex;align-items:center;gap:var(--sp-2);padding:var(--sp-1);margin:calc(var(--sp-1) * -1);border:0;border-radius:var(--r-xs);
   background:none;color:var(--text-dim);font:inherit;cursor:pointer}
-.ov-sum button:hover{color:var(--text-bright);background:var(--list-hover)}
+:where(html[data-pointer="fine"]) .ov-sum button:hover{color:var(--text-bright);background:var(--list-hover)}
 .ov-sum b{font-family:ui-monospace,monospace;font-weight:700;font-size:var(--fs-sm);color:var(--text-bright)}
 .ov-sum .d{width:6px;height:6px;border-radius:50%;background:var(--ok);flex:0 0 auto}
 .ov-sum .d.a{background:#d29922}.ov-sum .d.p{background:#a371f7}
@@ -58,10 +58,10 @@ const OV_CSS = `
   background:radial-gradient(circle at 100% 0,rgba(210,153,34,.13),transparent 38%),
     linear-gradient(145deg,rgba(210,153,34,.09),rgba(210,153,34,.025));
   transition:border-color .15s,transform .15s}
-.ov-card:hover{border-color:rgba(210,153,34,.55);transform:translateY(-1px)}
+:where(html[data-pointer="fine"]) .ov-card:hover{border-color:rgba(210,153,34,.55);transform:translateY(-1px)}
 .ov-card.p{border-color:rgba(163,113,247,.28);
   background:radial-gradient(circle at 100% 0,rgba(163,113,247,.13),transparent 38%),rgba(163,113,247,.04)}
-.ov-card.p:hover{border-color:rgba(163,113,247,.55)}
+:where(html[data-pointer="fine"]) .ov-card.p:hover{border-color:rgba(163,113,247,.55)}
 .ov-card .ty{display:flex;align-items:center;gap:var(--sp-2);font-size:var(--fs-meta);font-weight:600;color:#e3b341}
 .ov-card.p .ty{color:#a371f7}
 .ov-card .ty .pj{color:var(--text-dimmer);font-weight:400}
@@ -78,15 +78,15 @@ const OV_CSS = `
 .ov-proj{min-width:0;background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:var(--r-card);
   padding:var(--sp-3) var(--sp-3) var(--sp-2);display:flex;flex-direction:column;gap:var(--sp-1);transition:border-color .15s}
 .ov-proj{cursor:pointer}
-.ov-proj:hover{border-color:rgba(88,166,255,.35);background:var(--bg-elevated)}
+:where(html[data-pointer="fine"]) .ov-proj:hover{border-color:rgba(88,166,255,.35);background:var(--bg-elevated)}
 .ov-proj:focus-visible{outline:1px solid var(--accent-border);outline-offset:2px}
 /* 指针落在会话行/卡内链接上时，把卡片自己的 hover 收回去：
    高亮要指明「点下去会中哪个」，两层同时亮等于没说 */
-.ov-proj:has(.ov-trow:hover),.ov-proj:has(.ov-foot a:hover){background:var(--bg-container)}
-.ov-proj:has(.ov-trow:hover) .hd .go,.ov-proj:has(.ov-foot a:hover) .hd .go{color:var(--text-dimmer);transform:none}
+:where(html[data-pointer="fine"]) .ov-proj:has(.ov-trow:hover),:where(html[data-pointer="fine"]) .ov-proj:has(.ov-foot a:hover){background:var(--bg-container)}
+:where(html[data-pointer="fine"]) .ov-proj:has(.ov-trow:hover) .hd .go,:where(html[data-pointer="fine"]) .ov-proj:has(.ov-foot a:hover) .hd .go{color:var(--text-dimmer);transform:none}
 /* 右上角只留一枚箭头当方向暗示：整张卡都能点，再写一遍「进入项目」是废话 */
 .ov-proj .hd .go{flex:0 0 auto;display:inline-flex;color:var(--text-dimmer);transition:color .15s,transform .15s}
-.ov-proj:hover .hd .go{color:var(--accent);transform:translateX(2px)}
+:where(html[data-pointer="fine"]) .ov-proj:hover .hd .go{color:var(--accent);transform:translateX(2px)}
 .ov-proj .hd{display:flex;align-items:center;gap:8px}
 .ov-ico{width:28px;height:28px;flex:0 0 auto;display:grid;place-items:center;border-radius:var(--r-sm);
   font-size:12px;font-weight:800}
@@ -99,7 +99,7 @@ const OV_CSS = `
 .ov-trow{display:flex;align-items:center;gap:var(--sp-2);min-height:32px;padding:var(--sp-1) var(--sp-2);
   border-radius:var(--r-xs);font-size:var(--fs-sm);cursor:pointer;transition:background .14s}
 .ov-trow:first-of-type{margin-top:6px}
-.ov-trow:hover{background:var(--list-hover)}
+:where(html[data-pointer="fine"]) .ov-trow:hover{background:var(--list-hover)}
 .ov-trow .t{min-width:0;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .ov-trow .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer);white-space:nowrap}
 .ov-foot{display:flex;align-items:center;gap:var(--sp-2);min-height:28px;margin-top:var(--sp-1);
@@ -109,12 +109,12 @@ const OV_CSS = `
 .ov-more{padding-left:var(--sp-2);font-size:var(--fs-meta);color:var(--text-dimmer)}
 .ov-rest{grid-column:1/-1;display:flex;align-items:center;justify-content:center;min-height:0;
   padding:var(--sp-2);cursor:pointer;font-size:var(--fs-meta);color:var(--text-dimmer)}
-.ov-rest:hover{color:var(--text-dim);border-color:rgba(88,166,255,.35)}
+:where(html[data-pointer="fine"]) .ov-rest:hover{color:var(--text-dim);border-color:rgba(88,166,255,.35)}
 
 .ov-loose{padding:var(--sp-3);border-radius:var(--r-card);background:var(--bg-container)}
 .ov-loose .row{display:flex;align-items:center;gap:var(--sp-2);min-height:32px;padding:var(--sp-1) 0;font-size:var(--fs-sm);
   color:var(--text-dim);cursor:pointer}
-.ov-loose .row:hover{color:var(--text-bright)}
+:where(html[data-pointer="fine"]) .ov-loose .row:hover{color:var(--text-bright)}
 .ov-loose .tm{margin-left:auto;flex:0 0 auto;font-size:var(--fs-meta);color:var(--text-dimmer)}
 
 /* 最近活动：≥1180 时是右侧 sticky 侧轨；窄于此它只是网格的第二行，自然落回页尾 */
@@ -134,7 +134,7 @@ const OV_CSS = `
 .ov-ev time{display:block;margin-top:var(--sp-1);font-size:var(--fs-micro);color:var(--text-dimmer)}
 
 .ov-go-i{margin-left:3px;vertical-align:-1px;opacity:.75}
-a:hover>.ov-go-i,button:hover>.ov-go-i,.ov-card:hover .ov-go-i{opacity:1}
+:where(html[data-pointer="fine"]) a:hover>.ov-go-i,:where(html[data-pointer="fine"]) button:hover>.ov-go-i,:where(html[data-pointer="fine"]) .ov-card:hover .ov-go-i{opacity:1}
 .ov-mono{font-family:ui-monospace,'SF Mono',Menlo,Consolas,monospace}
 .ov-in{animation:ovIn .34s cubic-bezier(.2,.85,.3,1) backwards}
 @keyframes ovIn{from{opacity:0;transform:translateY(6px)}}

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -73,7 +73,7 @@ const PRJ_CSS = `
 .prj-composer{background:var(--bg-elevated);
   border:1px solid var(--border-subtle);border-radius:var(--r-card);
   transition:border-color .2s,box-shadow .2s;padding:4px 4px 10px}
-.prj-composer:hover{border-color:var(--border)}
+:where(html[data-pointer="fine"]) .prj-composer:hover{border-color:var(--border)}
 .prj-composer:focus-within{border-color:var(--accent-border);box-shadow:0 0 0 3px var(--accent-soft)}
 .prj-composer textarea{font-size:var(--fs-body) !important;line-height:1.75 !important;padding:10px 12px 4px !important}
 /* 控制条：组内 6、组间 16，分组只靠间距不画线（换行后竖线会孤零零吊在行尾）。
@@ -98,7 +98,7 @@ const PRJ_CSS = `
   font-size:var(--fs-meta);cursor:pointer;white-space:nowrap;user-select:none;color:var(--text-dim);
   border:1px solid var(--border);background:rgba(177,186,196,.03);
   transition:color .15s,border-color .15s,background .15s}
-.prj-pill:hover{color:var(--text-bright);border-color:var(--text-dim)}
+:where(html[data-pointer="fine"]) .prj-pill:hover{color:var(--text-bright);border-color:var(--text-dim)}
 .prj-pill.on{color:var(--accent);border-color:var(--accent-border);background:var(--accent-soft)}
 .prj-pill.dis{opacity:.4;cursor:not-allowed}
 
@@ -112,7 +112,7 @@ const PRJ_CSS = `
 .prj-tab{padding:8px 13px 9px;font-size:13px;color:var(--text-dim);cursor:pointer;user-select:none;
   display:inline-flex;align-items:center;gap:6px;border-bottom:2px solid transparent;margin-bottom:-1px;
   transition:color .15s}
-.prj-tab:hover{color:var(--text-bright)}
+:where(html[data-pointer="fine"]) .prj-tab:hover{color:var(--text-bright)}
 .prj-tab.on{color:var(--text-bright);border-bottom-color:var(--accent);font-weight:600}
 .prj-tab .n{font-size:10.5px;font-family:ui-monospace,monospace;color:var(--text-dimmer);
   background:rgba(177,186,196,.08);border-radius:999px;padding:1px 6px}
@@ -128,8 +128,8 @@ const PRJ_CSS = `
   border-radius:10px;cursor:pointer;transition:background .15s}
 .prj-row::before{content:'';position:absolute;left:0;top:9px;bottom:9px;width:2px;border-radius:2px;
   background:transparent;transition:background .15s}
-.prj-row:hover{background:var(--list-hover)}
-.prj-row:hover::before{background:rgba(88,166,255,.5)}
+:where(html[data-pointer="fine"]) .prj-row:hover{background:var(--list-hover)}
+:where(html[data-pointer="fine"]) .prj-row:hover::before{background:rgba(88,166,255,.5)}
 /* 选中行：细蓝边 + 淡底，和 hover 区分得开（14 §6.3.1） */
 .prj-row.on{background:var(--accent-soft);box-shadow:inset 0 0 0 1px var(--accent-border)}
 .prj-row.on::before{background:var(--accent)}
@@ -139,7 +139,7 @@ const PRJ_CSS = `
 /* 换行时行距给到 10：按钮视觉 36、命中区 44，行距不到 8 两行的命中区就会叠在一起 */
 html[data-pointer="coarse"] .prj-row .acts{row-gap:10px}
 .prj-row.warn{background:rgba(210,153,34,.05);border:1px solid rgba(210,153,34,.18);margin-bottom:4px}
-.prj-row.warn:hover{background:rgba(210,153,34,.09)}
+:where(html[data-pointer="fine"]) .prj-row.warn:hover{background:rgba(210,153,34,.09)}
 .prj-row.warn::before{display:none}
 
 /* sticky subheader（14 §6.1）：筛选与排序不该跟着列表滚走 */
@@ -173,7 +173,7 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
 .prj-chip{display:inline-flex;align-items:center;gap:var(--sp-2);height:28px;padding:0 var(--sp-3);border-radius:var(--r-pill);
   border:1px solid var(--border);background:transparent;color:var(--text-dim);font-size:12px;
   cursor:pointer;white-space:nowrap;transition:color .15s,border-color .15s,background .15s}
-.prj-chip:hover{color:var(--text-bright);border-color:#8b949e}
+:where(html[data-pointer="fine"]) .prj-chip:hover{color:var(--text-bright);border-color:#8b949e}
 .prj-chip.on{color:var(--accent);border-color:var(--accent-border);background:var(--accent-soft)}
 .prj-chip .n{font-family:ui-monospace,monospace;font-size:var(--fs-micro);color:var(--text-dimmer)}
 .prj-chip.on .n{color:var(--accent)}
@@ -189,7 +189,7 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
   gap:var(--sp-3);min-height:36px;padding:var(--sp-1) var(--sp-2);border-radius:var(--r-sm);
   cursor:pointer;transition:background .14s}
 .prj-quiet+.prj-quiet{border-top:1px solid var(--border-subtle)}
-.prj-quiet:hover{background:var(--list-hover)}
+:where(html[data-pointer="fine"]) .prj-quiet:hover{background:var(--list-hover)}
 .prj-quiet .nm{font-size:var(--fs-sm);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .prj-quiet .p{font-family:ui-monospace,monospace;font-size:var(--fs-meta);color:var(--text-dimmer);
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -199,12 +199,12 @@ html[data-size="compact"] .prj-quiet .p{display:none}
 .prj-card{background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:var(--r-card);
   padding:var(--sp-3) var(--sp-4);cursor:pointer;display:flex;flex-direction:column;gap:8px;
   transition:border-color .18s,transform .18s,box-shadow .18s}
-.prj-card:hover{border-color:rgba(88,166,255,.45);transform:translateY(-1px);box-shadow:var(--card-hover-shadow)}
+:where(html[data-pointer="fine"]) .prj-card:hover{border-color:rgba(88,166,255,.45);transform:translateY(-1px);box-shadow:var(--card-hover-shadow)}
 .prj-card:focus-visible{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
 .prj-card .prj-acts{opacity:.25;transition:opacity .15s;display:inline-flex;gap:var(--sp-3);align-items:center}
 /* 次要操作 hover 才出现，但键盘走到时同样要看得见——否则纯键盘用户够不着（14 §6.1） */
 .prj-card:focus-within .prj-acts,.prj-card:focus-visible .prj-acts{opacity:1}
-.prj-card:hover .prj-acts{opacity:1}
+:where(html[data-pointer="fine"]) .prj-card:hover .prj-acts{opacity:1}
 html[data-pointer="coarse"] .prj-card .prj-acts{opacity:1}
 .prj-card .prj-acts .pinned{opacity:1}
 
@@ -212,14 +212,14 @@ html[data-pointer="coarse"] .prj-card .prj-acts{opacity:1}
 .prj-wtrow{padding:13px 16px}
 .prj-wtrow+.prj-wtrow{border-top:1px solid var(--border-subtle)}
 .prj-subrow{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:8px;cursor:pointer;transition:background .14s}
-.prj-subrow:hover{background:var(--list-hover)}
+:where(html[data-pointer="fine"]) .prj-subrow:hover{background:var(--list-hover)}
 .prj-peek{flex:1;min-width:60px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
   font-family:ui-monospace,monospace;font-size:11px;color:var(--text-dimmer);
   background:var(--bg-term);border:1px solid var(--border-subtle);border-radius:6px;padding:3px 8px}
 .prj-addline{display:flex;align-items:center;gap:8px;padding:6px 10px;margin-top:2px;
   border:1px dashed var(--border);border-radius:8px;color:var(--text-dim);font-size:12.5px;
   transition:border-color .15s,color .15s}
-.prj-addline:hover{border-color:#8b949e;color:var(--text-bright)}
+:where(html[data-pointer="fine"]) .prj-addline:hover{border-color:#8b949e;color:var(--text-bright)}
 
 .prj-empty{color:var(--text-dimmer);font-size:12.5px;padding:14px 12px}
 
@@ -241,7 +241,7 @@ html[data-pointer="coarse"] .prj-card .prj-acts{opacity:1}
 .prj-fork .wt-ab{font-family:ui-monospace,monospace;font-size:12px;display:inline-flex;align-items:center;gap:1px}
 .prj-fork .wt-ab.up{color:var(--ok)} .prj-fork .wt-ab.dn{color:#d29922}
 .prj-fork .wt-acts{flex:0 0 auto;display:flex;gap:6px;align-items:center;opacity:.55;transition:opacity .15s}
-.prj-fork:hover .wt-acts,.prj-fork .wt-acts:focus-within{opacity:1}
+:where(html[data-pointer="fine"]) .prj-fork:hover .wt-acts,.prj-fork .wt-acts:focus-within{opacity:1}
 html[data-pointer="coarse"] .prj-fork .wt-acts{opacity:1}
 .prj-fork.merged .col,.prj-fork.ext .col{opacity:.75}
 `

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,13 @@
    黑/白主题：ThemeProvider 从 theme.tsx 的 THEME_TOKENS 统一写入 CSS 变量。
    终端画布的颜色由 Terminal.tsx 读取同名变量并随主题切换。 */
 
+/* ── hover 一律写成 `:where(html[data-pointer="fine"]) X:hover`（全站硬约定）──
+   触屏没有 mouseleave：手指点过的那枚会一直带着 :hover 不走，于是「上一次点的按钮」
+   永远亮着，看起来像点错了；再叠上 :active 的位移，连点两下就是在抖。
+   `:where()` 不贡献特异性，加上这层前缀不改变任何层叠关系，只是把 hover 关进细指针。
+   代价：hover 里藏起来的东西（opacity:0 的复制/关闭/下载键）在手指档必须另给一条
+   常显规则，否则手机上永远够不着。scripts/hover-scope-audit.mjs 会守住这两条。 */
+
 /* 启动前 fallback。运行后由 ThemeProvider 按当前主题覆盖这些变量。 */
 :root {
   color-scheme: dark;
@@ -152,6 +159,11 @@ html[data-pointer="coarse"] { --ctl-h: max(var(--ctl-h), 40px); }
 html, body, #root { height: 100%; margin: 0; }
 /* 禁掉移动端「下拉刷新」与滚动链/边缘回弹：轻微下拉不再误触整页刷新 */
 html, body { overscroll-behavior: none; }
+/* 文档本身**不滚动**：这是个定高外壳，每一页的滚动都在内部容器里（实测五条路由
+   scrollHeight == clientHeight）。不写这条，任何一处溢出 1px 都会冒出 10px 宽的文档
+   滚动条，整条工作区连着右侧终端面板横跳 10px：150% 缩放的屏上小数高度来回舍入，
+   于是终端每吐一段输出就抖一次，按钮在按下和抬起之间跑掉，点击落到别处。 */
+html, body { overflow: hidden; }
 body {
   background: var(--bg-base);
   /* 精修字体栈：优先界面无衬线 + 中文黑体；数字等宽对齐更整齐 */
@@ -197,7 +209,7 @@ body {
   background: var(--border-subtle);
   transition: width .15s, background .15s;
 }
-.tt-split-rail:hover::after,
+:where(html[data-pointer="fine"]) .tt-split-rail:hover::after,
 .tt-split-rail:active::after,
 .tt-split-rail:focus-visible::after { width: 2px; background: var(--accent); }
 .tt-split-rail:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
@@ -243,7 +255,7 @@ body {
   cursor: pointer;
   transition: border-color .15s, transform .15s;
 }
-.tt-session-capsule:hover { border-color: var(--accent-border); transform: translateY(-1px); }
+:where(html[data-pointer="fine"]) .tt-session-capsule:hover { border-color: var(--accent-border); transform: translateY(-1px); }
 .tt-session-capsule .d { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--ok); }
 .tt-session-capsule .nm { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tt-session-capsule .n {
@@ -291,7 +303,7 @@ body {
 .tt-nav.rail .tt-nav-item,
 .tt-nav.rail .tt-nav-account,
 .tt-nav.rail .tt-nav-collapse { justify-content: center; padding: 0; }
-.tt-nav-item:hover, .tt-nav-account:hover, .tt-nav-collapse:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .tt-nav-item:hover, :where(html[data-pointer="fine"]) .tt-nav-account:hover, :where(html[data-pointer="fine"]) .tt-nav-collapse:hover { background: var(--list-hover); color: var(--text-bright); }
 /* 图标槽：导航项 / 终端开关 / 账户 / 收起 用同一个 20px 方槽，图标才在一条竖线上。
    账户那枚以前是「蓝底圆角块」，在一列裸图标里自成一格——同一列里不要两种图标语言。 */
 .tt-nav-item .ic, .tt-nav-account .av, .tt-nav-collapse .ic {
@@ -326,7 +338,7 @@ body {
 .tt-nav-foot { display: flex; flex-direction: column; gap: 4px; padding-top: 8px; border-top: 1px solid var(--border-subtle); }
 .tt-nav-account .dots { margin-left: auto; flex: 0 0 auto; display: flex; color: var(--text-dimmer); }
 
-.tt-top-create:hover { border-color: var(--accent-border); color: var(--accent); }
+:where(html[data-pointer="fine"]) .tt-top-create:hover { border-color: var(--accent-border); color: var(--accent); }
 
 /* ── 顶栏搜索框 ──
    实底（比顶栏亮一档）+ 32 高，不是描边框。旧版与顶栏同色、只有一圈 1px 边，
@@ -340,7 +352,7 @@ body {
   font-size: var(--fs-meta); cursor: pointer;
   transition: border-color .12s, color .12s;
 }
-.tt-topsearch:hover { border-color: var(--accent-border); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .tt-topsearch:hover { border-color: var(--accent-border); color: var(--text-bright); }
 .tt-topsearch .ph { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tt-topsearch kbd {
   margin-left: auto; flex: 0 0 auto; padding: 1px 5px;
@@ -421,7 +433,7 @@ html[data-size="compact"] .tt-palette {
   font-size: var(--fs-micro); cursor: pointer;
   max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.tt-palette-foot button:hover:not(:disabled) { border-color: var(--accent-border); color: var(--accent); }
+:where(html[data-pointer="fine"]) .tt-palette-foot button:hover:not(:disabled) { border-color: var(--accent-border); color: var(--accent); }
 .tt-palette-foot button:disabled { opacity: .5; cursor: default; }
 .tt-palette-foot kbd { color: var(--text-dimmer); }
 .tt-palette-foot .hint { margin-left: auto; color: var(--text-dimmer); font-size: var(--fs-micro); }
@@ -524,7 +536,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   color: var(--text-dim); cursor: pointer;
   transition: background .12s, color .12s;
 }
-.mc-ib:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .mc-ib:hover { background: var(--list-hover); color: var(--text-bright); }
 .mc-ib:focus-visible { outline: 1px solid var(--accent-border); outline-offset: -1px; }
 .mc-ib.is-dim { color: var(--text-dimmer); }
 .mc-ib.is-on { color: var(--accent); }
@@ -542,7 +554,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   box-shadow: inset 0 0 0 1px var(--border-subtle);
   transition: box-shadow .12s, background .12s;
 }
-.mc-omni:hover { box-shadow: inset 0 0 0 1px var(--border); }
+:where(html[data-pointer="fine"]) .mc-omni:hover { box-shadow: inset 0 0 0 1px var(--border); }
 .mc-omni.is-focus { background: var(--bg-elevated); box-shadow: inset 0 0 0 2px var(--accent-border); }
 .mc-omni.is-readonly { cursor: default; }
 /* 失焦态：域名亮、其余灰——不聚焦时人只需要认出「这是哪个站」，协议和路径是噪音 */
@@ -568,7 +580,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   width: 24px; height: 24px; border: 0; border-radius: 50%; background: transparent;
   color: var(--text-dimmer); cursor: pointer;
 }
-.mc-omni-x:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .mc-omni-x:hover { background: var(--list-hover); color: var(--text-bright); }
 .mc-omni-go {
   flex: 0 0 auto; border: 0; background: transparent; cursor: pointer;
   padding: 0 var(--sp-2); color: var(--accent); font-size: var(--fs-sm); font-weight: 600;
@@ -580,7 +592,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   border: 0; border-radius: var(--r-pill); background: var(--list-hover);
   color: var(--text-dim); font-size: var(--fs-micro); cursor: pointer; white-space: nowrap;
 }
-.mc-lead:hover { color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .mc-lead:hover { color: var(--text-bright); }
 .mc-lead b { color: var(--text-bright); font-weight: 600; }
 /* 状态点是画出来的圆，不是 ● 字符 */
 .mc-dot {
@@ -603,7 +615,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
 }
 .mc-chip b { color: var(--text-bright); font-weight: 600; }
 .mc-chip.is-btn { cursor: pointer; }
-.mc-chip.is-btn:hover { color: var(--text-bright); box-shadow: inset 0 0 0 1px var(--border); }
+:where(html[data-pointer="fine"]) .mc-chip.is-btn:hover { color: var(--text-bright); box-shadow: inset 0 0 0 1px var(--border); }
 .mc-chip.is-on { background: var(--accent-soft); color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent-border); }
 .mc-chip.is-on b { color: var(--accent); }
 @media (pointer: coarse) { .mc-chip { min-height: 36px; } }
@@ -635,7 +647,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   border-radius: var(--r-xs) var(--r-xs) 0 0;
   color: var(--text-dim); font-size: var(--fs-meta); cursor: pointer; user-select: none;
 }
-.mc-tab:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .mc-tab:hover { background: var(--list-hover); color: var(--text-bright); }
 .mc-tab.is-on { background: var(--bg-container); color: var(--text-bright); }
 .mc-tab-fav { flex: 0 0 auto; width: 14px; height: 14px; border-radius: 4px; background: var(--bg-elevated); }
 .mc-tab.is-on .mc-tab-fav { background: var(--ok); box-shadow: 0 0 0 3px var(--ok-soft); border-radius: 50%; width: 7px; height: 7px; margin: 0 3px; }
@@ -645,8 +657,8 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   flex: 0 0 auto; display: grid; place-items: center; width: 18px; height: 18px;
   border-radius: var(--r-xs); color: var(--text-dimmer); opacity: 0;
 }
-.mc-tab:hover .mc-tab-x, .mc-tab.is-on .mc-tab-x { opacity: 1; }
-.mc-tab-x:hover { background: var(--danger-soft); color: var(--danger); }
+:where(html[data-pointer="fine"]) .mc-tab:hover .mc-tab-x, .mc-tab.is-on .mc-tab-x { opacity: 1; }
+:where(html[data-pointer="fine"]) .mc-tab-x:hover { background: var(--danger-soft); color: var(--danger); }
 .mc-tab-add { width: 28px; height: 28px; margin-bottom: 3px; }
 @media (pointer: coarse) { .mc-tab-x { opacity: 1; } }
 
@@ -673,7 +685,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   min-height: 44px; margin-top: 2px; border: 1px dashed var(--border); border-radius: var(--r-sm);
   background: transparent; color: var(--text-dim); font-size: var(--fs-sm); cursor: pointer;
 }
-.mc-newtab:hover { color: var(--text-bright); border-color: var(--accent-border); }
+:where(html[data-pointer="fine"]) .mc-newtab:hover { color: var(--text-bright); border-color: var(--accent-border); }
 
 /* 应用启动器（手机镜像页）：搜索 + 列表，替掉那个 160px 的 Select */
 .mc-menu {
@@ -687,7 +699,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   border: 0; border-radius: var(--r-xs); background: transparent; color: var(--text-bright);
   font-size: var(--fs-sm); cursor: pointer; text-align: left;
 }
-.mc-appitem:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .mc-appitem:hover { background: var(--list-hover); }
 .mc-appitem .ic {
   flex: 0 0 auto; width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center;
   background: var(--bg-base); color: var(--text-dimmer); font-size: var(--fs-micro); font-weight: 700;
@@ -771,7 +783,7 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   /* 破坏性动作不常驻：12 行 12 个红色「关闭」是界面在冲用户喊。
      :focus-within 一起写——只挂 hover 的话键盘用户永远够不着。 */
   .tt-srow .acts { justify-self: end; opacity: 0; transition: opacity .14s; }
-  .ant-list-item:hover .tt-srow .acts,
+  :where(html[data-pointer="fine"]) .ant-list-item:hover .tt-srow .acts,
   .ant-list-item:focus-within .tt-srow .acts,
   .tt-srow .acts:focus-within { opacity: 1; }
 }
@@ -962,7 +974,7 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
   border: 0; border-radius: 8px; background: transparent; color: var(--text-dimmer);
   font-size: 13px; cursor: pointer;
 }
-.tt-sessdock-x:hover { background: var(--danger-soft); color: var(--danger); }
+:where(html[data-pointer="fine"]) .tt-sessdock-x:hover { background: var(--danger-soft); color: var(--danger); }
 .tt-page > * {
   width: 100%;
   min-width: 0;
@@ -1045,7 +1057,7 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   background: var(--scroll-thumb); border-radius: 8px;
   border: 2px solid transparent; background-clip: content-box;
 }
-*::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); background-clip: content-box; }
+:where(html[data-pointer="fine"]) *::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); background-clip: content-box; }
 *::-webkit-scrollbar-corner { background: transparent; }
 
 /* 会话工具栏：单行横向滑动（手机上原本换行占 3 行）；子项不收缩、隐藏滚动条 */
@@ -1096,7 +1108,7 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   color: var(--text-dim); font-size: var(--fs-meta); line-height: 1; white-space: nowrap; cursor: pointer;
   transition: background .12s, color .12s;
 }
-.tt-tab:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .tt-tab:hover { background: var(--list-hover); color: var(--text-bright); }
 .tt-tab.on { background: var(--bg-base); color: var(--text-bright); font-weight: 600;
   box-shadow: inset 0 2px 0 var(--accent); }
 .tt-tab .tt-wait { flex: 0 0 auto; color: var(--warn); font-weight: 600; }
@@ -1128,8 +1140,8 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px;
   border-radius: 5px; color: var(--text-dimmer); opacity: 0; transition: opacity .12s ease;
 }
-.tt-tab:hover .tt-x, .tt-tab.on .tt-x { opacity: 1; }
-.tt-tab .tt-x:hover { background: var(--danger-soft); color: var(--danger); }
+:where(html[data-pointer="fine"]) .tt-tab:hover .tt-x, .tt-tab.on .tt-x { opacity: 1; }
+:where(html[data-pointer="fine"]) .tt-tab .tt-x:hover { background: var(--danger-soft); color: var(--danger); }
 /* 触屏没有 hover，关闭按钮常显 */
 @media (pointer: coarse) { .tt-tab .tt-x { opacity: 1; } }
 
@@ -1142,8 +1154,7 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
   transition: background .14s ease, color .14s ease, box-shadow .14s ease;
 }
 .tt-tbtn.tt-ico { padding: 0 6px; }
-/* hover 只给细指针：触屏没有 mouseleave，:hover 会粘在最后点过的那枚上不走 */
-html[data-pointer="fine"] .tt-tbtn:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .tt-tbtn:hover { background: var(--list-hover); color: var(--text-bright); }
 .tt-tbtn:active { background: var(--list-hover); transform: translateY(.5px); }
 .tt-tbtn:focus-visible { outline: 2px solid var(--accent-border); outline-offset: 1px; }
 
@@ -1153,9 +1164,9 @@ html[data-pointer="fine"] .tt-tbtn:hover { background: var(--list-hover); color:
    环只在 hover 出现、不常驻，一排按钮就不会被边框切碎。 */
 .tt-tbtn.on { background: var(--accent-soft); color: var(--accent); }
 .tt-tbtn.on.ok { background: var(--ok-soft); color: var(--ok); }
-html[data-pointer="fine"] .tt-tbtn.on:hover { background: var(--accent-soft); color: var(--accent);
+:where(html[data-pointer="fine"]) .tt-tbtn.on:hover { background: var(--accent-soft); color: var(--accent);
   box-shadow: inset 0 0 0 1px var(--accent-border); }
-html[data-pointer="fine"] .tt-tbtn.on.ok:hover { background: var(--ok-soft); color: var(--ok);
+:where(html[data-pointer="fine"]) .tt-tbtn.on.ok:hover { background: var(--ok-soft); color: var(--ok);
   box-shadow: inset 0 0 0 1px var(--ok-border); }
 
 /* 右侧只读工具（翻页 / 字号 / 重绘重连）收进分段组，视觉上跟左侧动作区分开 */
@@ -1185,7 +1196,7 @@ html[data-pointer="fine"] .tt-tbtn.on.ok:hover { background: var(--ok-soft); col
 /* ── 卡片：细边框 + 克制悬浮（边框微亮 + 极轻阴影，不位移） ── */
 .ant-card { border-color: var(--border-subtle); }
 .ant-card-bordered { border-color: var(--border-subtle); }
-.ant-card-hoverable:hover {
+:where(html[data-pointer="fine"]) .ant-card-hoverable:hover {
   border-color: var(--border);
   box-shadow: var(--card-hover-shadow);
   transform: translateY(-1px);
@@ -1202,7 +1213,13 @@ html[data-pointer="fine"] .tt-tbtn.on.ok:hover { background: var(--ok-soft); col
 /* ── 列表：行距舒展、分隔线更淡、hover 轻微提亮并圆角 ── */
 .ant-list-split .ant-list-item { border-block-end-color: var(--border-subtle); }
 .ant-list-item { border-radius: 8px; padding-inline: 8px; }
-.ant-list-item:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .ant-list-item:hover { background: var(--list-hover); }
+
+/* ── Tooltip 在手指档整体不出现 ──
+   悬浮提示本来就是鼠标的东西：触屏上它由「按住」触发，弹出来又没有 mouseleave 收回，
+   于是一层 pointer-events:auto 的浮层就停在按钮上方，把接下来的点全吃了（表现为「点了没反应」）。
+   Tooltip 只承载补充说明，藏掉不丢功能；Popover / Popconfirm 是点开的，不在此列。 */
+html[data-pointer="coarse"] .ant-tooltip { display: none; }
 
 /* ── 输入框：聚焦细发光，克制 ── */
 .ant-input:focus, .ant-input-focused,
@@ -1226,12 +1243,10 @@ html[data-pointer="fine"] .tt-tbtn.on.ok:hover { background: var(--ok-soft); col
   background: transparent; color: var(--text-dim);
   font: inherit; font-size: var(--fs-meta); line-height: 1; white-space: nowrap; cursor: pointer;
   transition: color .15s, border-color .15s, background .15s; }
-/* hover 装饰只给细指针。触屏点完不会有 mouseleave，:hover 会一直粘在最后点过的那枚上，
-   点下一枚时上一枚才带着 .15s 过渡褪掉——一排按钮轮流亮灭，看着就是在抖。
-   手指档只留 :active 的按下反馈。 */
-html[data-pointer="fine"] .tt-act:hover { color: var(--text-bright); border-color: var(--border); background: var(--list-hover); }
-html[data-pointer="fine"] .tt-act.danger:hover { color: var(--danger); border-color: var(--danger-border); background: var(--danger-soft); }
-html[data-pointer="fine"] .tt-act.ok:hover { color: var(--ok); border-color: var(--ok-border); background: var(--ok-soft); }
+/* 手指档只留 :active 的按下反馈（hover 约定见文件头） */
+:where(html[data-pointer="fine"]) .tt-act:hover { color: var(--text-bright); border-color: var(--border); background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .tt-act.danger:hover { color: var(--danger); border-color: var(--danger-border); background: var(--danger-soft); }
+:where(html[data-pointer="fine"]) .tt-act.ok:hover { color: var(--ok); border-color: var(--ok-border); background: var(--ok-soft); }
 .tt-act:active { background: var(--list-hover); }
 .tt-act.danger:active { background: var(--danger-soft); color: var(--danger); }
 .tt-act.ok:active { background: var(--ok-soft); color: var(--ok); }
@@ -1260,7 +1275,7 @@ html[data-pointer="coarse"] .tt-act::after { content: ''; position: absolute; le
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .tt-branch > svg { color: var(--text-dimmer); flex: 0 0 auto; }
 .tt-branch.act { cursor: pointer; transition: color .15s, border-color .15s; }
-.tt-branch.act:hover { color: var(--text-bright); border-color: var(--border); }
+:where(html[data-pointer="fine"]) .tt-branch.act:hover { color: var(--text-bright); border-color: var(--border); }
 
 /* Agent 品牌标不套标签框：logo 本身就够认，外面再描一圈边框纯属噪声，
    一行里跟 worktree/等待这些真·标签挤在一起还会打架。裸标 + 可选文字。 */
@@ -1291,35 +1306,35 @@ html[data-pointer="coarse"] .tt-act::after { content: ''; position: absolute; le
 
 /* 文件行下载按钮：hover 行时浮现 */
 .cc-dl { opacity: 0; transition: opacity .15s ease; }
-.cc-filerow:hover .cc-dl, .cc-dl:focus { opacity: 1; }
+:where(html[data-pointer="fine"]) .cc-filerow:hover .cc-dl, .cc-dl:focus { opacity: 1; }
 @media (pointer: coarse) { .cc-dl { opacity: .6; } }
 .cc-filerow { border-radius: 6px; margin: 1px 4px; }
-.cc-filerow:hover { background: rgba(88, 166, 255, .08); }
+:where(html[data-pointer="fine"]) .cc-filerow:hover { background: rgba(88, 166, 255, .08); }
 /* 右键菜单打开期间保持目标行高亮；状态留在菜单组件内，避免重渲染整棵文件列表。 */
 .tt-file-context-open > .cc-filerow { background: var(--accent-soft); }
 /* 手动控制的右键菜单不要被整行触发器拉伸到文件抽屉宽度。 */
 .tt-file-context-menu { width: max-content !important; min-width: 130px !important; }
 /* Git 分组标题上的操作按钮：平时半透明，hover 分组时变实 */
 .cc-git-section-act .cc-dl { opacity: .5; }
-.cc-git-section:hover .cc-git-section-act .cc-dl,
+:where(html[data-pointer="fine"]) .cc-git-section:hover .cc-git-section-act .cc-dl,
 .cc-git-section-act .cc-dl:focus-visible { opacity: 1; }
 /* 手指档没有 hover（13 §7） */
 html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
-.cc-dl:hover { background: rgba(255, 255, 255, .08); color: var(--text-bright) !important; }
+:where(html[data-pointer="fine"]) .cc-dl:hover { background: rgba(255, 255, 255, .08); color: var(--text-bright) !important; }
 .cc-filerow .ant-btn { color: var(--text-dim); }
-.cc-filerow .ant-btn:hover { color: var(--text-bright) !important; background: rgba(255, 255, 255, .06) !important; }
+:where(html[data-pointer="fine"]) .cc-filerow .ant-btn:hover { color: var(--text-bright) !important; background: rgba(255, 255, 255, .06) !important; }
 
 /* 编辑器文件 tab 的关闭键：干净常显 ×；脏文件平时显橙点、hover tab 时变 × 可关（VSCode 行为）。会话 tab 无此键 → 不可关。 */
 .cc-tabx { margin-left: 2px; padding: 0 3px; line-height: 1; border-radius: 4px; display: inline-flex; align-items: center; }
 /* 未保存点：以前是个 ● 字符，字号/基线跟着字体走。改成画出来的圆点，和关闭图标同槽 */
 .cc-tabx .dot { display: none; width: 8px; height: 8px; border-radius: 50%; background: #d29922; }
 .cc-tabx .x { display: inline-flex; width: 8px; height: 8px; align-items: center; justify-content: center; color: var(--text-dim); }
-.cc-filetab:hover .cc-tabx .x { color: var(--text-bright); }
-.cc-tabx:hover { background: rgba(255, 255, 255, .1); }
+:where(html[data-pointer="fine"]) .cc-filetab:hover .cc-tabx .x { color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .cc-tabx:hover { background: rgba(255, 255, 255, .1); }
 .cc-filetab.dirty .cc-tabx .dot { display: block; }
 .cc-filetab.dirty .cc-tabx .x { display: none; }
-.cc-filetab.dirty:hover .cc-tabx .dot { display: none; }
-.cc-filetab.dirty:hover .cc-tabx .x { display: inline-flex; }
+:where(html[data-pointer="fine"]) .cc-filetab.dirty:hover .cc-tabx .dot { display: none; }
+:where(html[data-pointer="fine"]) .cc-filetab.dirty:hover .cc-tabx .x { display: inline-flex; }
 
 .tt-file-detail {
   transform: translateZ(0);
@@ -1349,7 +1364,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   transition: none !important;
   transform: none !important;
 }
-.tt-file-close:hover {
+:where(html[data-pointer="fine"]) .tt-file-close:hover {
   color: var(--text-bright);
   background: var(--list-hover);
 }
@@ -1366,7 +1381,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
 .swarm-topology-node {
   transition: opacity .16s ease, filter .16s ease;
 }
-.swarm-topology-node:hover {
+:where(html[data-pointer="fine"]) .swarm-topology-node:hover {
   filter: drop-shadow(0 10px 22px rgba(1, 4, 9, .35));
 }
 .swarm-topology-pulse {
@@ -1958,7 +1973,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
 
 /* 代码框复制按钮：默认淡出，hover 代码框时浮现 */
 .cc-copy { opacity: 0; transition: opacity .15s ease; }
-.cc-codebox:hover .cc-copy, .cc-copy:focus { opacity: 1; }
+:where(html[data-pointer="fine"]) .cc-codebox:hover .cc-copy, .cc-copy:focus { opacity: 1; }
 @media (pointer: coarse) { .cc-copy { opacity: .6; } }
 
 /* 对话气泡复制：靠近时间显示，桌面 hover 浮现，触屏常显。 */
@@ -1971,7 +1986,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   font: inherit;
   cursor: pointer;
 }
-.cc-msg:hover .cc-msg-copy, .cc-msg-copy:focus { opacity: 1; color: var(--text-dim); }
+:where(html[data-pointer="fine"]) .cc-msg:hover .cc-msg-copy, .cc-msg-copy:focus { opacity: 1; color: var(--text-dim); }
 @media (pointer: coarse) { .cc-msg-copy { opacity: 1; } }
 
 /* ── 工具调用渲染（chat/tool-parts.tsx）────────────────────────────────────
@@ -2008,12 +2023,12 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   opacity: 0;
   transition: opacity .15s ease, color .15s ease;
 }
-.cc-toolrow:hover .cc-toolcopy,
-.cc-cmd:hover .cc-toolcopy,
-.cc-diff:hover .cc-toolcopy,
-.cc-err:hover .cc-toolcopy,
+:where(html[data-pointer="fine"]) .cc-toolrow:hover .cc-toolcopy,
+:where(html[data-pointer="fine"]) .cc-cmd:hover .cc-toolcopy,
+:where(html[data-pointer="fine"]) .cc-diff:hover .cc-toolcopy,
+:where(html[data-pointer="fine"]) .cc-err:hover .cc-toolcopy,
 .cc-toolcopy:focus-visible { opacity: 1; }
-.cc-toolcopy:hover { color: var(--text-bright); background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-toolcopy:hover { color: var(--text-bright); background: var(--list-hover); }
 @media (pointer: coarse) { .cc-toolcopy { opacity: .55; } }
 
 /* 跑着的工具：转圈，不是一枚静态徽标——静态徽标看不出还在动 */
@@ -2042,7 +2057,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   overflow: hidden;
   transition: border-color .15s ease, box-shadow .15s ease;
 }
-.cc-cmd:hover { border-color: color-mix(in srgb, var(--ok) 45%, var(--border)); }
+:where(html[data-pointer="fine"]) .cc-cmd:hover { border-color: color-mix(in srgb, var(--ok) 45%, var(--border)); }
 .cc-cmd.is-open { box-shadow: 0 1px 0 rgba(0, 0, 0, .18); }
 .cc-cmd-head {
   display: flex;
@@ -2054,11 +2069,11 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   outline: none;
 }
 .cc-cmd-head.is-clickable { cursor: pointer; }
-.cc-cmd-head.is-clickable:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-cmd-head.is-clickable:hover { background: var(--list-hover); }
 .cc-cmd-head:focus-visible { box-shadow: inset 0 0 0 1px var(--accent-border); }
 /* 出错的那条：左脊转红，整块底色也带一点，不用再靠人去读文字 */
 .cc-cmd.is-err { border-left-color: var(--danger); background: color-mix(in srgb, var(--bg-term) 92%, var(--danger)); }
-.cc-cmd.is-err:hover { border-color: var(--danger-border); }
+:where(html[data-pointer="fine"]) .cc-cmd.is-err:hover { border-color: var(--danger-border); }
 .cc-cmd-chev {
   flex: 0 0 auto;
   display: inline-flex;
@@ -2122,7 +2137,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   cursor: pointer;
   outline: none;
 }
-.cc-toolcard-head:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-toolcard-head:hover { background: var(--list-hover); }
 /* 标题变成文件链接之后，展开/收起收在左半边这颗（箭头 + 图标 + 工具名）。
    它不是 linked 时禁用并让出 tab 焦点——那时整行本身就是按钮。 */
 .cc-toolcard-toggle {
@@ -2225,12 +2240,12 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   text-overflow: ellipsis;
 }
 .cc-filelist-row.is-link { display: block; width: 100%; text-align: left; border: 0; background: transparent; cursor: pointer; }
-.cc-filelist-row:hover { background: var(--list-hover); color: var(--text-bright); }
-.cc-filelist-row.is-link:hover { color: var(--accent); }
+:where(html[data-pointer="fine"]) .cc-filelist-row:hover { background: var(--list-hover); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .cc-filelist-row.is-link:hover { color: var(--accent); }
 
 /* 可点路径：文件面板接得住才画成链接（接不住时 PathLink 渲染成普通文字） */
 .cc-pathlink { border: 0; background: transparent; padding: 0; text-align: left; color: var(--accent); cursor: pointer; }
-.cc-pathlink:hover { text-decoration: underline; }
+:where(html[data-pointer="fine"]) .cc-pathlink:hover { text-decoration: underline; }
 .cc-pathlink:focus-visible { outline: 1px solid var(--accent-border); outline-offset: 1px; border-radius: 2px; }
 
 /* ── 运行组（chat/ToolRun.tsx，设计 16）───────────────────────────────────
@@ -2253,7 +2268,7 @@ html[data-pointer="coarse"] .cc-git-section-act .cc-dl { opacity: 1; }
   cursor: pointer;
   outline: none;
 }
-.cc-run-head:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-run-head:hover { background: var(--list-hover); }
 .cc-run-head:focus-visible { box-shadow: inset 0 0 0 1px var(--accent-border); }
 .cc-run-ico { flex: 0 0 auto; display: flex; }
 .cc-run-name { flex: 0 0 auto; color: var(--text-dim); }
@@ -2358,7 +2373,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   cursor: pointer;
   outline: none;
 }
-.cc-live-head:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-live-head:hover { background: var(--list-hover); }
 .cc-live-head:focus-visible { box-shadow: inset 0 0 0 1px var(--accent-border); }
 .cc-live-body {
   border-top: 1px solid var(--border-subtle);
@@ -2476,7 +2491,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   cursor: pointer;
   white-space: nowrap;
 }
-.cc-st-pill:hover { border-color: var(--accent-border); }
+:where(html[data-pointer="fine"]) .cc-st-pill:hover { border-color: var(--accent-border); }
 .cc-st-pill i { width: 6px; height: 6px; border-radius: 50%; display: block; }
 .cc-st-item {
   flex: 0 0 auto;
@@ -2492,7 +2507,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   border-radius: var(--r-xs);
 }
 .cc-st-item.is-btn { cursor: pointer; }
-.cc-st-item.is-btn:hover { background: var(--list-hover); }
+:where(html[data-pointer="fine"]) .cc-st-item.is-btn:hover { background: var(--list-hover); }
 .cc-st-chev { display: inline-flex; color: var(--text-dimmer); transition: transform .15s ease; }
 .cc-st-ellip { max-width: 12ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cc-st-item:disabled { cursor: default; }
@@ -2508,7 +2523,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   font: inherit;
   cursor: pointer;
 }
-.cc-st-act:hover { background: color-mix(in srgb, var(--warn) 22%, transparent); }
+:where(html[data-pointer="fine"]) .cc-st-act:hover { background: color-mix(in srgb, var(--warn) 22%, transparent); }
 /* 跳到某条消息后闪一下：一屏里可能有好几条红，得指明是「这一条」 */
 .cc-flash { animation: cc-flash 1.2s ease-out; border-radius: var(--r-sm); }
 @keyframes cc-flash {

--- a/scripts/dev/quality/check.sh
+++ b/scripts/dev/quality/check.sh
@@ -61,6 +61,7 @@ if [ ! -d frontend/node_modules ]; then
   exit 1
 fi
 (cd frontend && npm run i18n:check)
+(cd frontend && npm run hover:check)
 (cd frontend && npm run typecheck)
 
 if [ "$MODE" = "full" ]; then


### PR DESCRIPTION
## 为什么

用户录屏里「点按钮会抖、点了没有该有的动作」。逐帧量下来是三件事叠在一起，都不是按钮本身坏了，
而是**按钮在被点的那一刻跑了或者被盖住了**。

## 1. 整页横跳（这次的主因）

录屏里整条工作区（Canvas 右缘 + 终端面板工具条 + 终端正文）以 ±14 设备像素在来回平移，
Canvas 里左对齐的内容一动不动 —— 典型的「可用宽度变了」而不是「内容滚动了」。

复现与证因果（headless Chrome + CDP）：

```
before: {"x":934,"cw":1610,"overflow":0}
over1 : {"x":924,"cw":1600,"overflow":1}   # 给 body 塞 1px 溢出
after : {"x":934,"cw":1610,"overflow":0}
```

`html/body` 有 `height:100%` 但没关 `overflow`：任何一处溢出 1px 就冒出 10px 宽的文档滚动条，
可用宽少 10px，Canvas 与 Dock 一起重排。150% 缩放的屏上小数高度来回舍入，于是终端每吐一段输出
就抖一次，按钮在 mousedown 和 mouseup 之间跑掉，点击落到别处。

修法是 `html, body { overflow: hidden }` —— 外壳本来就是定高的，五条路由实测文档根本不滚
（`scrollHeight == clientHeight`）；手机上真正的滚动容器是 `main.tt-canvas`，改完照滚。
加上之后同一个 1px 溢出测试位移归零。

## 2. 粘住的 hover（全局收口）

触屏没有 `mouseleave`，`:hover` 会留在最后点过的那枚上。#175 只修了 `.tt-act` / `.tt-tbtn`，
仓库里还有 82 条裸 hover。这次全部改成 `:where(html[data-pointer="fine"]) X:hover`：
`:where()` 不贡献特异性，层叠关系一点没动，只是把 hover 关进细指针。

## 3. Tooltip 吃点击

触屏上 Tooltip 由长按触发、又没有 mouseleave 收回，`pointer-events:auto` 的浮层就停在按钮上方
把下一次点击吃掉。手指档全局 `.ant-tooltip{display:none}`，一次覆盖 51 处调用；
Popover / Popconfirm 是点开的，不受影响。

## 以后怎么不再犯

- 新增 `frontend/scripts/hover-scope-audit.mjs`：守「hover 必须关进细指针」+「hover 里藏起来的
  东西必须另给手指档常显规则」，接进 `npm run build` 和 `scripts/dev/quality/check.sh`。
  自测过：塞一条裸 hover 和一条只在 hover 现身的规则，两条都能被抓出来并给出改法。
- 规则写进 `AGENTS.md`（Hover Belongs to the Mouse / The Document Never Scrolls）。
- 验法写进 `docs/development/web-ui-checklist.md`：四个惯犯一张表（含「给 body 塞 1px 溢出」
  这个复现手法）+ 指针档差异的勾选项。

## 验证

- 桌面 headless Chrome：1px 溢出前后面板 rect.x 不动；dpr 1 / 1.5 两档、五条路由文档都不滚。
- 真机（Android + CDP）：`data-pointer=coarse`，`.ant-tooltip` 计算值 `display:none`，
  项目页/概览页内部容器照常滚动，布局无变化。
- `scripts/dev/quality/check.sh quick` + `vitest`（226 passed）+ `npm run build` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)