### PR TITLE
fix(backend): agent 判定只看启动段，prompt 里提到对方不再认错人

### DIFF
--- a/backend/api/agent_kind_test.go
+++ b/backend/api/agent_kind_test.go
@@ -1,0 +1,58 @@
+package api
+
+import "testing"
+
+// 会话跑的是哪个 agent，只能看启动段，不能扫整条命令行：prompt 就在 argv 里。
+// 真机上出过这事——一个 codex 会话的 prompt 里写了「claude 分析到了一些东西」，
+// 整条 Contains("claude") 就把它标成了 Claude 会话（图标、工具条、对话视图全跟着错）。
+func TestAgentKindIgnoresPromptText(t *testing.T) {
+	cases := []struct {
+		name   string
+		argv   []string
+		claude bool
+		codex  bool
+	}{
+		{
+			name:  "codex 的 prompt 里提到 claude",
+			argv:  []string{"node", "/home/ai/.local/bin/codex", "分析下。claude分析到了一些东西，你也看下"},
+			codex: true,
+		},
+		{
+			name:  "rust codex 直接把 prompt 当 argv[1]",
+			argv:  []string{"codex", "claude 说要先切分支"},
+			codex: true,
+		},
+		{
+			name:   "claude 的 prompt 里提到 codex",
+			argv:   []string{"node", "/home/ai/.local/bin/claude", "把 codex 那版实现也读一下"},
+			claude: true,
+		},
+		{
+			name:   "npm 全局装的 claude：argv[1] 是 cli.js，得靠整条路径认",
+			argv:   []string{"/usr/bin/node", "/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js"},
+			claude: true,
+		},
+		{
+			name: "claude 把 codex 当 MCP server 拉起来的不算会话",
+			argv: []string{"codex", "mcp-server"},
+		},
+		{
+			name: "ttmux 自己（codex-web）不算",
+			argv: []string{"/home/ai/codes/ttmux/backend/codex-web", "-web", "/home/ai/codes/ttmux/frontend/dist"},
+		},
+		{
+			name: "光是 cwd/参数里带名字，不是在跑 agent",
+			argv: []string{"bash", "-lc", "grep -r claude /home/ai/codes/codex-notes"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := argvIsClaude(c.argv); got != c.claude {
+				t.Errorf("argvIsClaude = %v, want %v (argv=%q)", got, c.claude, c.argv)
+			}
+			if got := argvIsCodex(c.argv); got != c.codex {
+				t.Errorf("argvIsCodex = %v, want %v (argv=%q)", got, c.codex, c.argv)
+			}
+		})
+	}
+}

--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -79,24 +79,79 @@ func procChildren() map[int][]int {
 	return m
 }
 
-func processCmdline(pid int) string {
+// processArgv 返回进程的 argv（小写）。/proc 读不到时退回 ps，按空格切——
+// 那条路只用来兜底，切不准也只影响判断精度，不影响正确性。
+func processArgv(pid int) []string {
 	b, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err == nil {
-		return strings.ToLower(strings.ReplaceAll(string(b), "\x00", " "))
+		args := strings.Split(strings.TrimRight(string(b), "\x00"), "\x00")
+		for i := range args {
+			args[i] = strings.ToLower(args[i])
+		}
+		return args
 	}
 	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
 	if err != nil {
-		return ""
+		return nil
 	}
-	return strings.ToLower(strings.TrimSpace(string(out)))
+	return strings.Fields(strings.ToLower(strings.TrimSpace(string(out))))
 }
 
-// cmdlineHasClaude 判断进程命令行是否是 claude。
-func cmdlineHasClaude(pid int) bool {
-	cl := processCmdline(pid)
-	// 命令行里出现独立的 claude 段（claude / .../claude / node ... claude）
-	return strings.Contains(cl, "claude") && !strings.Contains(cl, "claude-code-webui")
+// jsRuntime 判断 argv[0] 是不是「真正跑的是 argv[1] 那个脚本」的运行时。
+// claude / codex 都是 node 脚本，装法不同 argv[1] 也不同：
+// `/home/ai/.local/bin/codex`、`.../@anthropic-ai/claude-code/cli.js` 都要认得出。
+func jsRuntime(arg0 string) bool {
+	base := filepath.Base(arg0)
+	switch base {
+	case "node", "nodejs", "bun", "deno", "npx", "npm", "sh", "bash", "zsh":
+		return true
+	}
+	return false
 }
+
+// agentLaunchArgs 取 argv 里「能代表跑的是哪个 CLI」的那一两段：argv[0]，
+// 以及 argv[0] 是 node 这类运行时时的脚本路径 argv[1]。
+//
+// **不能拿整条命令行去 Contains**：prompt 就在 argv 里。一句「claude 分析到了什么」
+// 会让一个 codex 会话被认成 claude——真机上就这么把派生出来的 Codex 会话标成了 Claude。
+// 反过来，rust 版 codex 的 argv[1] 直接就是 prompt，所以 argv[1] 只在运行时那档才看。
+func agentLaunchArgs(argv []string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+	if jsRuntime(argv[0]) && len(argv) > 1 {
+		return argv[0] + " " + argv[1]
+	}
+	return argv[0]
+}
+
+// agentExcluded 排除项要看到子命令（`codex mcp-server`），所以扫 argv 前三段——
+// 再往后就是 prompt，不能扫。
+func agentExcluded(argv []string, marks ...string) bool {
+	if len(argv) > 3 {
+		argv = argv[:3]
+	}
+	head := strings.Join(argv, " ")
+	for _, m := range marks {
+		if strings.Contains(head, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// argvIsClaude / argvIsCodex：判定只看启动段，测试直接喂 argv。
+func argvIsClaude(argv []string) bool {
+	return strings.Contains(agentLaunchArgs(argv), "claude") && !agentExcluded(argv, "claude-code-webui")
+}
+
+func argvIsCodex(argv []string) bool {
+	return strings.Contains(agentLaunchArgs(argv), "codex") &&
+		!agentExcluded(argv, "codex-web", "mcp-server", "app-server")
+}
+
+// cmdlineHasClaude 判断进程跑的是不是 claude。
+func cmdlineHasClaude(pid int) bool { return argvIsClaude(processArgv(pid)) }
 
 // treeMatch 从 pid 起 DFS 子进程树，任一进程命中 match 即返回 true。
 func treeMatch(pid int, children map[int][]int, depth int, match func(int) bool) bool {

--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -25,13 +25,7 @@ import (
 // cmdlineHasCodex 判断进程命令行是否是交互式 codex CLI。
 // 排除 codex-web（ttmux 自身）、mcp-server（Claude Code 会把 codex 当 MCP server 启动）、
 // app-server（Codex 桌面端/VS Code 插件的后台服务）。
-func cmdlineHasCodex(pid int) bool {
-	cl := processCmdline(pid)
-	return strings.Contains(cl, "codex") &&
-		!strings.Contains(cl, "codex-web") &&
-		!strings.Contains(cl, "mcp-server") &&
-		!strings.Contains(cl, "app-server")
-}
+func cmdlineHasCodex(pid int) bool { return argvIsCodex(processArgv(pid)) }
 
 func codexSessionsRoot() string {
 	home, _ := os.UserHomeDir()


### PR DESCRIPTION
## 现象

派生出来的 Codex 会话，任务行、标签页、工具条上标的都是 Claude 的品牌标。

## 真因

会话跑的是哪个 agent，全靠 `/sessions/:name/claude` 与 `/sessions/:name/codex`，
而这两个接口拿**整条命令行**去 `Contains("claude")`。prompt 就在 argv 里：

```
$ tr '\0' '\n' < /proc/3326074/cmdline
node
/home/ai/.local/bin/codex
开工前先做三件事…… claude分析到了一些东西，你也看下      ← 命中的是这一段
```

任务描述里提一句对方的名字，会话就被认成另一个 agent —— 图标、工具条那枚标、
能不能切进对话视图，全跟着错。

## 改法

只看「启动段」：`argv[0]`，以及 `argv[0]` 是 node/bun/sh 这类运行时时的脚本路径 `argv[1]`。

- rust 版 codex 的 `argv[1]` 直接就是 prompt，所以 `argv[1]` 只在运行时那一档才看；
- npm 全局装的 claude，`argv[1]` 是 `@anthropic-ai/claude-code/cli.js`，所以比整条路径而不是 basename；
- 排除项（`codex mcp-server` / `codex-web` / `app-server`）要看到子命令，扫 argv 前三段，再往后就是 prompt。

判定抽成 `argvIsClaude` / `argvIsCodex`，测试直接喂 argv。

## 验证

`backend/api/agent_kind_test.go` 七个用例：prompt 提到对方（两种启动形态）、npm 全局装法、
`codex mcp-server`、`codex-web`、`bash -lc "grep -r claude ..."`。`check.sh quick` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)