### PR TITLE
fix(web): 分隔条位置刷新后留在原处，不再弹回默认位

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,17 @@ Claude Code and Codex render their own alternate-screen TUIs inside our panes. A
 scrolls, resizes, or replays those panes has to account for alternate-screen mode (mouse-wheel
 synthesis, not copy-mode) and for redraw quirks on narrow widths.
 
+## Preferences Arrive Late
+
+`usePreferences()` serves defaults until the `/preferences` GET lands, so the first render of any
+component that seeds local state from a preference gets the *default*, not the stored value. Two
+rules follow. Gate the one-shot hydration on `preferencesLoaded()`, never on "the effect has run
+once" — that flag gets set on mount, before the real values exist, and the stored value is then
+silently discarded forever (a dragged splitter kept writing `dockWidth` to disk and kept snapping
+back to the default on every refresh). And for anything **visible** — widths, collapsed state —
+mirror it to `localStorage` so the first paint is already correct; the server value stays the
+authority, it just no longer moves the layout under the user a beat after load.
+
 # Gates
 
 ## Quality

--- a/frontend/src/FileWorkspace.tsx
+++ b/frontend/src/FileWorkspace.tsx
@@ -198,11 +198,19 @@ export default function FileWorkspace({
 
   // 两栏：宽度比(左栏占比，拖分隔条调整) + 左右易位
   const panesRef = useRef<HTMLDivElement>(null)
-  const [splitFrac, setSplitFrac] = useState(0.5)
+  // 占比同样记 localStorage：分隔条是用户拖出来的，刷新后自己挪回正中间就是把这次调整丢了
+  const clampFrac = (v: number) => Math.min(0.85, Math.max(0.15, v))
+  const [splitFrac, setSplitFrac] = useState(() => {
+    const s = Number(localStorage.getItem('ttmux.fileSplitFrac'))
+    return Number.isFinite(s) && s > 0 ? clampFrac(s) : 0.5
+  })
   const [swapped, setSwapped] = useState(false)
   const leftGroup: Group = swapped ? 'B' : 'A'
 
-  const clampFrac = (v: number) => Math.min(0.85, Math.max(0.15, v))
+  const fracRef = useRef(splitFrac)
+  fracRef.current = splitFrac
+  // 拖动期间每帧都写 localStorage 没必要，松手落一次盘就够
+  const saveFrac = (v: number) => localStorage.setItem('ttmux.fileSplitFrac', String(v))
   const startSplitResize = (e: React.PointerEvent<HTMLDivElement>) => {
     resize.start(e, {
       onMove: (ev) => {
@@ -210,6 +218,7 @@ export default function FileWorkspace({
         const r = el.getBoundingClientRect(); if (r.width <= 0) return
         setSplitFrac(clampFrac((ev.clientX - r.left) / r.width))
       },
+      onEnd: () => saveFrac(fracRef.current),
     })
   }
 
@@ -465,8 +474,12 @@ export default function FileWorkspace({
                   role="separator" aria-orientation="vertical" tabIndex={0}
                   aria-label={t('file.dragResize')} aria-valuemin={15} aria-valuemax={85} aria-valuenow={Math.round(splitFrac * 100)}
                   onPointerDown={startSplitResize} title={t('file.dragResize')}
-                  onDoubleClick={() => setSplitFrac(0.5)}
-                  onKeyDown={(e) => railKey(e, (dir, big) => setSplitFrac((f) => clampFrac(f + dir * (big ? 0.1 : 0.02))), () => setSplitFrac(0.5))} />
+                  onDoubleClick={() => { setSplitFrac(0.5); saveFrac(0.5) }}
+                  onKeyDown={(e) => railKey(
+                    e,
+                    (dir, big) => { const n = clampFrac(fracRef.current + dir * (big ? 0.1 : 0.02)); setSplitFrac(n); saveFrac(n) },
+                    () => { setSplitFrac(0.5); saveFrac(0.5) },
+                  )} />
               )}
               {pane(g as Group)}
             </Fragment>

--- a/frontend/src/preferences.ts
+++ b/frontend/src/preferences.ts
@@ -74,7 +74,30 @@ const DEFAULTS: Preferences = {
   _migrated: false,
 }
 
-let cache: Preferences = { ...DEFAULTS }
+/**
+ * 工作区尺寸的**首帧镜像**。
+ *
+ * 偏好的权威在服务端，而那是一次异步 GET：首帧手里只有 DEFAULTS，分隔条先按
+ * 42vw 画一次，偏好回来再跳到用户拖出来的宽度——每刷新一次，分隔条当着面挪一次。
+ * 这里在本地留一份同样的值，首帧就拿它开画；服务端回来仍然是权威，值一致时
+ * 肉眼什么都看不到（只有换了台设备才会有一次修正）。尺寸本来也是最该按浏览器
+ * 记的东西：手机和桌面读的是同一份偏好，但画出来的从来不是同一个布局。
+ */
+const WORKSPACE_MIRROR = 'ttmux.workspace'
+
+function readWorkspaceMirror(): Partial<WorkspacePreference> {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_MIRROR)
+    const v = raw ? JSON.parse(raw) : null
+    return v && typeof v === 'object' && !Array.isArray(v) ? v : {}
+  } catch { return {} }
+}
+
+function writeWorkspaceMirror(ws: WorkspacePreference) {
+  try { localStorage.setItem(WORKSPACE_MIRROR, JSON.stringify(ws)) } catch {}
+}
+
+let cache: Preferences = { ...DEFAULTS, workspace: { ...WORKSPACE_DEFAULTS, ...readWorkspaceMirror() } }
 let listeners = new Set<() => void>()
 let loaded = false
 
@@ -118,6 +141,7 @@ export async function loadPreferences() {
     const r = await api('GET', '/preferences')
     // workspace 是嵌套对象：整体展开会让服务端存的旧结构缺字段变 undefined，单独深合一层
     cache = { ...DEFAULTS, ...r?.data, workspace: { ...WORKSPACE_DEFAULTS, ...r?.data?.workspace } }
+    writeWorkspaceMirror(cache.workspace)
     if (!cache._migrated) {
       migrateFromLocalStorage()
     }
@@ -132,6 +156,7 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null
 
 export function savePreferences(partial: Partial<Preferences>) {
   cache = { ...cache, ...partial }
+  if (partial.workspace) writeWorkspaceMirror(cache.workspace)
   notify()
   // debounce server writes to avoid rapid-fire PUTs
   if (saveTimer) clearTimeout(saveTimer)

--- a/frontend/src/shell/useWorkspaceLayout.ts
+++ b/frontend/src/shell/useWorkspaceLayout.ts
@@ -8,7 +8,7 @@
 // 挤破；空间不够就整体切 Focus，绝不横向溢出。
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLayout, type WindowSize } from '../layout'
-import { usePreferences, saveWorkspace } from '../preferences'
+import { usePreferences, preferencesLoaded, saveWorkspace } from '../preferences'
 import { useInspectorOpen } from './inspector'
 
 /** 尺寸契约，与 index.css 的 --canvas-min / --dock-* 同源（14 §8.2）。 */
@@ -198,16 +198,26 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   const [insWidth, setInsWidthLocal] = useState(ws.inspectorWidth || 0)
   const hydrated = useRef(false)
 
-  // 偏好从服务端到达后同步一次（首屏时 usePreferences 还是默认值）
+  /**
+   * 偏好从服务端到达后同步一次。
+   *
+   * 判「到达」必须问 `preferencesLoaded()`，不能拿"effect 跑过一次"充数：偏好是
+   * 异步 GET 的，mount 那一跑手里还是默认值，旧写法在那时就把 hydrated 置了位，
+   * 真正带着用户宽度的那一跑被 early-return 挡掉——**拖过的分隔条存了却从没读回来**，
+   * 每次刷新都弹回 42vw 默认位。
+   *
+   * 用户已经动过手（拖/收/聚焦）之后就不再回填：偏好 GET 与他的操作可能撞在一起，
+   * 那时候盖回去等于当着面把他刚拖的位置抹掉。
+   */
   useEffect(() => {
-    if (hydrated.current) return
+    if (hydrated.current || !preferencesLoaded()) return
     hydrated.current = true
     setDockOpenLocal(ws.dockOpen)
     setFocusLocal(ws.workspaceFocus)
     setNavCollapsedLocal(ws.navCollapsed)
     setWidthLocal(ws.dockWidth || 0)
     setInsWidthLocal(ws.inspectorWidth || 0)
-  }, [ws.dockOpen, ws.workspaceFocus, ws.navCollapsed, ws.dockWidth, ws.inspectorWidth])
+  }, [ws])
 
   const splitCapable = layout.size === 'large'
   const navWidth = splitCapable ? (navCollapsed ? NAV_RAIL : NAV_WIDTH) : NAV_RAIL
@@ -237,16 +247,19 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   }, [insWidth, insBounds])
 
   const setDockOpen = useCallback((open: boolean) => {
+    hydrated.current = true
     setDockOpenLocal(open)
     saveWorkspace({ dockOpen: open })
   }, [])
 
   const setFocus = useCallback((target: FocusTarget) => {
+    hydrated.current = true
     setFocusLocal(target)
     saveWorkspace({ workspaceFocus: target })
   }, [])
 
   const setDockWidth = useCallback((next: number) => {
+    hydrated.current = true
     const { min, max } = dockBounds(workspaceWidth)
     const clamped = Math.round(Math.max(min, Math.min(max, next)))
     setWidthLocal(clamped)
@@ -257,12 +270,14 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
   const dockRenderWidth = effectiveDockWidth({ workspaceWidth, dockWidth, inspectorWidth, inspectorOpen: inspectorOpen && hasDock })
 
   const setInspectorWidth = useCallback((next: number) => {
+    hydrated.current = true
     const clamped = Math.round(Math.max(insBounds.min, Math.min(insBounds.max, next)))
     setInsWidthLocal(clamped)
     saveWorkspace({ inspectorWidth: clamped })
   }, [insBounds])
 
   const setNavCollapsed = useCallback((collapsed: boolean) => {
+    hydrated.current = true
     setNavCollapsedLocal(collapsed)
     saveWorkspace({ navCollapsed: collapsed })
   }, [])
@@ -280,13 +295,13 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     inspectorWidth,
     inspectorBounds: insBounds,
     setInspectorWidth,
-    resetInspectorWidth: () => { setInsWidthLocal(0); saveWorkspace({ inspectorWidth: 0 }) },
+    resetInspectorWidth: () => { hydrated.current = true; setInsWidthLocal(0); saveWorkspace({ inspectorWidth: 0 }) },
     canvasFitsInspector: canvasFitsWith({ workspaceWidth, inspectorWidth, hasDock }),
     dockRenderWidth,
     toggleDock: () => setDockOpen(!dockOpen),
     setDockOpen,
     setDockWidth,
-    resetDockWidth: () => { setWidthLocal(0); saveWorkspace({ dockWidth: 0 }) },
+    resetDockWidth: () => { hydrated.current = true; setWidthLocal(0); saveWorkspace({ dockWidth: 0 }) },
     setFocus,
     toggleFocus: () => setFocus(focus === 'dock' ? 'none' : 'dock'),
     setNavCollapsed,

--- a/frontend/src/shell/workspace-restore.test.tsx
+++ b/frontend/src/shell/workspace-restore.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+// 分隔条的位置存了，就必须读得回来。
+//
+// 这条测试对着一个真实回归：偏好是异步 GET 的，而 useWorkspaceLayout 里那句
+// 「只同步一次」用的是"effect 跑过没有"——mount 那一跑手里还是默认值，标志位就此置上，
+// 真正带着用户宽度的那一跑被 early-return 挡掉。表现是 dockWidth 一直在写进
+// preferences.json，界面却每次刷新都把分隔条挪回 42vw 默认位。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const SAVED = 1100
+const VIEWPORT = 1920
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+// 偏好模块在**导入时**就读一次本地镜像，所以每个用例都要在布好 localStorage 之后重新导入
+async function freshModules() {
+  vi.resetModules()
+  const prefs = await import('../preferences')
+  const layout = await import('./useWorkspaceLayout')
+  return { ...prefs, ...layout }
+}
+
+describe('工作区分隔条位置的恢复', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.innerWidth = VIEWPORT
+    // large 档才有并排分栏；min-width 一律命中 → 'large'，指针留在细指针档
+    vi.stubGlobal('matchMedia', vi.fn((q: string) => ({
+      matches: q.includes('min-width'),
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    })))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/preferences')) {
+        // /api 统一 { data } 包一层
+        return jsonResponse({ data: { _migrated: true, workspace: { dockWidth: SAVED, navCollapsed: true } } })
+      }
+      return jsonResponse({ data: {} })
+    }))
+  })
+
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('偏好从服务端回来后，dockWidth 用的是存下来的值', async () => {
+    const m = await freshModules()
+    const { result } = renderHook(() => m.useWorkspaceLayout(true))
+
+    // 首帧还没有偏好：拿该档默认（42vw）。旧实现正是在这一刻把标志位置上，于是到此为止
+    expect(result.current.dockWidth).toBe(m.defaultDockWidth(VIEWPORT, VIEWPORT - m.NAV_WIDTH))
+
+    await m.loadPreferences()
+    await waitFor(() => expect(result.current.dockWidth).toBe(SAVED))
+  })
+
+  it('本地镜像让首帧就画在存下来的位置上（不必等 GET 回来才跳一次）', async () => {
+    localStorage.setItem('ttmux.workspace', JSON.stringify({ dockWidth: SAVED, navCollapsed: true }))
+    const m = await freshModules()
+    const { result } = renderHook(() => m.useWorkspaceLayout(true))
+    expect(result.current.dockWidth).toBe(SAVED)
+  })
+
+  it('用户拖过之后不再被服务端那份盖掉', async () => {
+    const m = await freshModules()
+    const { result } = renderHook(() => m.useWorkspaceLayout(true))
+    result.current.setDockWidth(700)
+    await waitFor(() => expect(result.current.dockWidth).toBe(700))
+
+    await m.loadPreferences()
+    await waitFor(() => expect(localStorage.getItem('ttmux.workspace')).toBeTruthy())
+    expect(result.current.dockWidth).toBe(700)
+  })
+})


### PR DESCRIPTION
## 问题

拖过的分隔条，每刷新一次自己挪回默认位（42vw）。

宽度其实一直在存：`~/.roam/preferences.json` 里 `workspace.dockWidth` 每次拖完都在更新。
坏的是**读**这一侧——`useWorkspaceLayout` 里那句「偏好到了同步一次」判的是"effect 跑过没有"：

```js
useEffect(() => {
  if (hydrated.current) return
  hydrated.current = true      // ← mount 那一跑就置位了，此时手里还是默认值
  setWidthLocal(ws.dockWidth || 0)
}, [ws.dockWidth, ...])
```

偏好是异步 GET 的，mount 那一跑拿到的是 `DEFAULTS`；等真正带着用户宽度的那一跑进来，
已经被 early-return 挡掉了。于是「存了，但从来没读回来」。

（在应用内切页面时是好的——那时组件挂载晚于偏好到达。只有刷新会踩。）

## 改动

1. **判「偏好到了」改问 `preferencesLoaded()`**，不拿"跑过一次"充数。
2. **用户动过手之后不再回填**：偏好 GET 可能和他的拖拽撞在一起，那时候盖回去等于当面把刚拖的位置抹掉。
3. **加一份 localStorage 首帧镜像**：只修 1 的话还剩一次可见的跳——首帧只能画默认值，
   偏好回来才跳到存的宽度。镜像让首帧就画对；服务端仍是权威，值一致时肉眼看不到变化。
   尺寸本来也最该按浏览器记：手机和桌面读的是同一份偏好，画出来的从来不是同一个布局。
4. 文件工作区 A｜B 那条分隔条同样落盘（此前每次刷新回 0.5）。
5. `AGENTS.md` 加一节 **Preferences Arrive Late**，把这两条钉成规则。

## 验收

- 新增 `workspace-restore.test.tsx` 三条：服务端值必须被应用 / 首帧就用镜像 / 用户拖过之后不被盖。
  把 hydration 那句改回旧写法，第一条立刻变红。
- 浏览器（headless CDP，1600 宽窗口）：两轮 `ignoreCache` 硬刷新，分隔条稳在 `968`
  （存的 1837 钳到该窗口上界），位置不动；旧代码这里是 672。
- 手机真机（adb + CDP）：文档仍不滚（766/766），内页滚动器正常。
- `scripts/dev/quality/check.sh full` 通过；229 条前端测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
