### PR TITLE
feat(web): 文件抽屉改成两层折叠，每层各自记宽、各自能拖

### DIFF
--- a/frontend/src/FileBrowser.test.tsx
+++ b/frontend/src/FileBrowser.test.tsx
@@ -289,4 +289,21 @@ describe('FileBrowser dock 两栏与分界拖动', () => {
     await waitFor(() => expect(container.textContent || '').toContain('a.md'))
     expect(container.querySelector('[data-resize-handle="filetree"]')).toBeNull()
   })
+
+  // 面板是从屏幕右缘拉出来的：列表钉在右缘，文件内容往它左边长。
+  // 反过来的话，一点开文件，你刚点的那一列自己跑到左半边去了。
+  it('列表在右、内容在左', async () => {
+    panelWidth = 800
+    const { container } = renderDock()
+    const rail = await waitFor(() => {
+      const r = container.querySelector('[data-resize-handle="filetree"]')
+      if (!r) throw new Error('rail not ready')
+      return r
+    })
+    const cols = Array.from(rail.parentElement!.children)
+    const railAt = cols.indexOf(rail)
+    // 把手左边是预览（带文件名），右边是列表（带路径输入框）
+    expect(cols[railAt - 1].textContent || '').toContain('a.md')
+    expect(cols[railAt + 1].querySelector('input')).not.toBeNull()
+  })
 })

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -17,6 +17,7 @@ import {
   FolderUpIcon, ForwardIcon, IconButton, ListIcon, NewFolderIcon, RefreshIcon, SearchIcon, SortIcon, TreeIcon, UploadIcon,
 } from './file-icons'
 import { Viewer } from './fileview'
+import { requestInspectorWidth } from './shell/inspector'
 import { ArrowUp } from './icons'
 
 interface Entry { name: string; dir: boolean; size: number; mtime: number; ctime: number }
@@ -335,6 +336,7 @@ const TREE_MIN = 180        // 树再窄就只剩省略号
 const TREE_MAX = 480
 const TREE_DEFAULT = 260
 const PREVIEW_MIN = 280     // 预览再窄读不了代码
+const PREVIEW_WANT = 560    // 「够读」的预览：80 列等宽正文 + 两侧留白，点开文件时按这个要列宽
 const SPLIT_MIN = TREE_MIN + PREVIEW_MIN + 5   // 面板窄于此只显示一栏
 
 export default function FileBrowser({
@@ -752,6 +754,17 @@ export default function FileBrowser({
       onEnd: () => localStorage.setItem('ttmux.fileTreeW', String(treeWRef.current)),
     })
   }
+
+  /**
+   * 点开文件就把这一列拉到「够读」——420 的默认列宽分完两栏只剩两百出头的预览，
+   * 分栏等于白做。只加宽不缩窄：用户自己拖出来的更宽值一直算数（见 inspector.ts）。
+   * 关掉预览把请求撤回（归 0），下次再开才会重新算。
+   */
+  useEffect(() => {
+    if (layout !== 'dock') return
+    requestInspectorWidth(view ? treeW + 5 + PREVIEW_WANT : 0)
+  }, [view, layout, treeW])
+  useEffect(() => () => requestInspectorWidth(0), [])
 
   // 对话里点了文件名 → 在这个浏览器里打开它：先把树导航到它所在目录，再开预览。
   // 走 openPath 而不是直接 setView：不 navigate 的话左边的树还停在别处，

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -743,7 +743,12 @@ export default function FileBrowser({
     // 预览至少留 PREVIEW_MIN：拖到把预览挤没了，这个分栏就白做了
     const cap = Math.max(TREE_MIN, Math.min(TREE_MAX, (dockRef.current?.getBoundingClientRect().width || TREE_MAX) - PREVIEW_MIN))
     dockResize.start(e, {
-      onMove: (ev) => setTreeW(Math.min(cap, Math.max(TREE_MIN, startW + ev.clientX - startX))),
+      // 列表在把手**右边**，所以往右拖是把它推窄（符号跟着位置走，不是笔误）
+      onMove: (ev) => {
+        const w = Math.min(cap, Math.max(TREE_MIN, startW - (ev.clientX - startX)))
+        treeWRef.current = w // ref 不等下一次渲染：最后一次 move 与 up 落在同一帧时，onEnd 否则存的是上一个宽度
+        setTreeW(w)
+      },
       onEnd: () => localStorage.setItem('ttmux.fileTreeW', String(treeWRef.current)),
     })
   }
@@ -1072,21 +1077,14 @@ export default function FileBrowser({
   //
   // 面板窄到放不下两栏时（< SPLIT_MIN）自动退回单栏：预览盖住树，左上角给返回。
   // 420 宽硬塞两栏的结果是两边都没法看——宁可少一栏，也不要两栏都残。
+  //
+  // **列表靠右缘，文件内容往左展开。**这块面板是从屏幕右边拉出来的：列表原本铺满整个
+  // 面板、贴着右缘，一点开文件却被挤到左半边，等于你刚点的那一列自己跑了。现在列表钉在
+  // 右缘不动，内容从它左边长出来——新出现的东西占新地方，已经在看的那列不动。
   if (layout === 'dock') {
     const twoPane = !!view && dockW >= SPLIT_MIN
     return (
       <div ref={dockRef} style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, display: 'flex' }}>
-        <div style={{
-          flex: twoPane ? `0 0 ${treeW}px` : '1 1 auto',
-          minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column',
-        }}>
-          {browserPane}
-        </div>
-        {twoPane && (
-          <div data-resize-handle="filetree" onPointerDown={startTreeResize}
-            title={t('file.dragResize')} className="tt-split-rail"
-            style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
-        )}
         {view && (
           <div style={twoPane
             ? { flex: '1 1 auto', minWidth: 0, minHeight: 0, display: 'flex' }
@@ -1096,6 +1094,17 @@ export default function FileBrowser({
               onOpenPath={openPath} onOpenAgent={onOpenAgent} />
           </div>
         )}
+        {twoPane && (
+          <div data-resize-handle="filetree" onPointerDown={startTreeResize}
+            title={t('file.dragResize')} className="tt-split-rail"
+            style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
+        )}
+        <div style={{
+          flex: twoPane ? `0 0 ${treeW}px` : '1 1 auto',
+          minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column',
+        }}>
+          {browserPane}
+        </div>
       </div>
     )
   }

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -331,13 +331,26 @@ function FileTree({
   return <>{renderLevel(root, rootEntries, 0)}</>
 }
 
-// 「文件夹 / 文件」两栏的尺寸契约（dock 布局用）
+/**
+ * dock 布局是**两层折叠**，不是一个定宽面板切两半。
+ *
+ * 先弹出文件夹这层（宽 = LIST_*），点开一个文件再在它左边**叠一层**预览（宽 = PREVIEW_*），
+ * 面板总宽是两层相加。切总宽的做法是错的：420 的面板切完只剩两百出头的预览，读不了代码；
+ * 而且一开文件，你正看着的那一列就自己变窄了。
+ *
+ * 两层各自记宽度、各自能拖：
+ *   · 里把手（两层之间）贴着文件夹层 → 拖它改的是文件夹宽；
+ *   · 外把手（面板左缘）贴着最左那层 → 预览开着时改预览宽，没开时改文件夹宽。
+ * 每根把手都只管紧挨着它的那一层，面板外缘跟着两层之和走。
+ */
+const RAIL = 5
 const TREE_MIN = 180        // 树再窄就只剩省略号
 const TREE_MAX = 480
-const TREE_DEFAULT = 260
+const TREE_DEFAULT = 360
 const PREVIEW_MIN = 280     // 预览再窄读不了代码
-const PREVIEW_WANT = 560    // 「够读」的预览：80 列等宽正文 + 两侧留白，点开文件时按这个要列宽
-const SPLIT_MIN = TREE_MIN + PREVIEW_MIN + 5   // 面板窄于此只显示一栏
+const PREVIEW_MAX = 1200
+const PREVIEW_DEFAULT = 560 // 80 列等宽正文 + 两侧留白
+const SPLIT_MIN = TREE_MIN + PREVIEW_MIN + RAIL   // 面板窄到这个数以下只显示一栏
 
 export default function FileBrowser({
   dir,
@@ -721,7 +734,7 @@ export default function FileBrowser({
     }
   }
 
-  // 「文件夹 / 文件」两栏的分界：可拖，记 localStorage。
+  // ── 两层折叠的尺寸（契约见文件上方 RAIL/TREE_*/PREVIEW_* 那段）──
   const dockRef = useRef<HTMLDivElement>(null)
   const [dockW, setDockW] = useState(0)
   useEffect(() => {
@@ -732,22 +745,69 @@ export default function FileBrowser({
     setDockW(el.getBoundingClientRect().width)
     return () => ro.disconnect()
   }, [])
-  const [treeW, setTreeW] = useState(() => {
-    const v = Number(localStorage.getItem('ttmux.fileTreeW'))
-    return v >= TREE_MIN && v <= TREE_MAX ? v : TREE_DEFAULT
-  })
+
+  const clampTree = (v: number) => Math.min(TREE_MAX, Math.max(TREE_MIN, Math.round(v)))
+  const clampPreview = (v: number) => Math.min(PREVIEW_MAX, Math.max(PREVIEW_MIN, Math.round(v)))
+  const stored = (key: string, fallback: number, clamp: (v: number) => number) => {
+    const v = Number(localStorage.getItem(key))
+    return Number.isFinite(v) && v > 0 ? clamp(v) : fallback
+  }
+  const [treeW, setTreeW] = useState(() => stored('ttmux.fileTreeW', TREE_DEFAULT, clampTree))
+  const [previewW, setPreviewW] = useState(() => stored('ttmux.filePreviewW', PREVIEW_DEFAULT, clampPreview))
   const treeWRef = useRef(treeW)
   treeWRef.current = treeW
+
+  /**
+   * 面板宽 = 两层之和，由这里说了算（不是「面板多宽就切多宽」）。
+   *
+   * askedRef/matchedRef 是为了把「我们请求的宽度」和「用户拖外把手拖出来的宽度」分开：
+   * 请求发出后先等它落地（matched），之后再量到的差值才算是外把手拖的，收进最左那一层。
+   * 不分开的话，首帧量到的旧面板宽会被当成用户意图，把文件夹层的宽度冲掉。
+   */
+  const askedRef = useRef(0)
+  const matchedRef = useRef(false)
+  useEffect(() => {
+    if (layout !== 'dock') return
+    const want = view ? previewW + RAIL + treeW : treeW
+    if (askedRef.current === want) return
+    askedRef.current = want
+    matchedRef.current = false
+    requestInspectorWidth(want)
+  }, [view, layout, treeW, previewW])
+  useEffect(() => () => requestInspectorWidth(0), [])
+
+  /**
+   * 外把手（面板左缘）拖的是最左那一层：预览开着改预览宽，没开改文件夹宽。
+   *
+   * **等它不动了再收**：面板宽度是带过渡的，松手后那几帧量到的是中间态。当场就收的话，
+   * 收到的瞬时值会被当成用户的意图再报回去——实测松手明明到了 985，0.4 秒后自己缩回 872。
+   */
+  const settle = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (layout !== 'dock' || !dockW || !askedRef.current) return
+    if (Math.abs(dockW - askedRef.current) <= 1) { matchedRef.current = true; return }
+    if (!matchedRef.current) return
+    if (settle.current) clearTimeout(settle.current)
+    settle.current = setTimeout(() => {
+      if (view) {
+        const next = clampPreview(dockW - treeW - RAIL)
+        if (next !== previewW) { setPreviewW(next); localStorage.setItem('ttmux.filePreviewW', String(next)) }
+      } else {
+        const next = clampTree(dockW)
+        if (next !== treeW) { setTreeW(next); localStorage.setItem('ttmux.fileTreeW', String(next)) }
+      }
+    }, 400)
+    return () => { if (settle.current) clearTimeout(settle.current) }
+  }, [dockW])
+
+  // 里把手（两层之间）贴着文件夹层：往右拖把它推窄，面板外缘跟着让出来
   const dockResize = usePointerResize()
   const startTreeResize = (e: ReactPointerEvent<HTMLDivElement>) => {
     const startX = e.clientX
     const startW = treeW
-    // 预览至少留 PREVIEW_MIN：拖到把预览挤没了，这个分栏就白做了
-    const cap = Math.max(TREE_MIN, Math.min(TREE_MAX, (dockRef.current?.getBoundingClientRect().width || TREE_MAX) - PREVIEW_MIN))
     dockResize.start(e, {
-      // 列表在把手**右边**，所以往右拖是把它推窄（符号跟着位置走，不是笔误）
       onMove: (ev) => {
-        const w = Math.min(cap, Math.max(TREE_MIN, startW - (ev.clientX - startX)))
+        const w = clampTree(startW - (ev.clientX - startX))
         treeWRef.current = w // ref 不等下一次渲染：最后一次 move 与 up 落在同一帧时，onEnd 否则存的是上一个宽度
         setTreeW(w)
       },
@@ -755,16 +815,6 @@ export default function FileBrowser({
     })
   }
 
-  /**
-   * 点开文件就把这一列拉到「够读」——420 的默认列宽分完两栏只剩两百出头的预览，
-   * 分栏等于白做。只加宽不缩窄：用户自己拖出来的更宽值一直算数（见 inspector.ts）。
-   * 关掉预览把请求撤回（归 0），下次再开才会重新算。
-   */
-  useEffect(() => {
-    if (layout !== 'dock') return
-    requestInspectorWidth(view ? treeW + 5 + PREVIEW_WANT : 0)
-  }, [view, layout, treeW])
-  useEffect(() => () => requestInspectorWidth(0), [])
 
   // 对话里点了文件名 → 在这个浏览器里打开它：先把树导航到它所在目录，再开预览。
   // 走 openPath 而不是直接 setView：不 navigate 的话左边的树还停在别处，
@@ -1110,7 +1160,7 @@ export default function FileBrowser({
         {twoPane && (
           <div data-resize-handle="filetree" onPointerDown={startTreeResize}
             title={t('file.dragResize')} className="tt-split-rail"
-            style={{ flex: '0 0 5px', cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
+            style={{ flex: `0 0 ${RAIL}px`, cursor: 'col-resize', background: 'var(--border)', touchAction: 'none' }} />
         )}
         <div style={{
           flex: twoPane ? `0 0 ${treeW}px` : '1 1 auto',

--- a/frontend/src/fileview/FileView.tsx
+++ b/frontend/src/fileview/FileView.tsx
@@ -227,8 +227,11 @@ export function FileView({
   )
 
   if (inline) {
+    // flex:1 + minWidth:0 缺一不可：这块内容常挂在行向 flex 父级里（抽屉的预览层就是），
+    // 不给 flex 它按内容宽收缩——代码文件表现为「编辑器只占左边一条，右边空一大片」，
+    // Monaco 按容器宽排版，容器多窄它就画多窄，长行还被截掉。
     return (
-      <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--bg-base)' }}>
+      <div style={{ flex: 1, minWidth: 0, height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column', background: 'var(--bg-base)' }}>
         {/* 编辑器 tab 语境(tabbed)：文件名/操作已由外层 tab 承担 → 去掉整条标题栏，编辑器全屏。保存用 Ctrl/Cmd+S。 */}
         {!tabbed && <div style={{ padding: '9px 12px', borderBottom: '1px solid var(--border-subtle)' }}>{titleNode}</div>}
         <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', padding: tabbed ? 0 : 12, position: 'relative' }}>

--- a/frontend/src/shell/inspector-width.test.tsx
+++ b/frontend/src/shell/inspector-width.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-// 点开文件要能读：420 的默认 Inspector 列宽分成两栏后只剩两百出头的预览，
-// 分栏等于白做。面板自己知道要多宽，列宽却在 Shell 手里——这条小道把两边接上。
+// 文件抽屉是两层折叠：文件夹层 + 预览层，面板宽 = 两层之和。宽度由面板自己报，
+// Shell 照办——但只在报的值变化时办一次，否则用户拖外把手会被立刻弹回去（把手等于拖不动）。
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
@@ -28,30 +28,34 @@ describe('文件预览要列宽', () => {
   })
   afterEach(() => { vi.unstubAllGlobals() })
 
-  it('要得比现在宽就加宽，收起预览不缩回去', async () => {
+  it('叠一层预览就加一层的宽，收起来又减回去', async () => {
     const m = await freshModules()
     const { result } = renderHook(() => m.useWorkspaceLayout(true))
     expect(result.current.inspectorWidth).toBe(m.INSPECTOR_DEFAULT)
 
-    m.requestInspectorWidth(825)
-    await waitFor(() => expect(result.current.inspectorWidth).toBe(825))
+    // 只有文件夹层
+    m.requestInspectorWidth(360)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(360))
 
-    // 关掉预览：请求撤回，但列不缩——面板多宽是用户的选择，不该被开合文件反复改
-    m.requestInspectorWidth(0)
-    await new Promise((r) => setTimeout(r, 50))
-    expect(result.current.inspectorWidth).toBe(825)
+    // 点开文件 → 左边叠一层预览：300 + 5 + 500
+    m.requestInspectorWidth(805)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(805))
+
+    // 收起预览 → 退回文件夹层那一层的宽
+    m.requestInspectorWidth(360)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(360))
   })
 
-  it('用户拖得更宽时不动他的宽度', async () => {
+  it('报过的值不再反复施加，外把手才拖得动', async () => {
     const m = await freshModules()
     const { result } = renderHook(() => m.useWorkspaceLayout(true))
-    // 拖到上界（几何还要给 Dock 留位，落地值由 inspectorBounds 说了算）
-    result.current.setInspectorWidth(m.INSPECTOR_MAX)
-    await waitFor(() => expect(result.current.inspectorWidth).toBeGreaterThan(825))
-    const dragged = result.current.inspectorWidth
+    m.requestInspectorWidth(805)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(805))
 
-    m.requestInspectorWidth(825)
-    await new Promise((r) => setTimeout(r, 50))
-    expect(result.current.inspectorWidth).toBe(dragged)
+    // 用户拖外把手：报的值没变，不许把他弹回 805
+    result.current.setInspectorWidth(700)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(700))
+    await new Promise((r) => setTimeout(r, 60))
+    expect(result.current.inspectorWidth).toBe(700)
   })
 })

--- a/frontend/src/shell/inspector-width.test.tsx
+++ b/frontend/src/shell/inspector-width.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+// 点开文件要能读：420 的默认 Inspector 列宽分成两栏后只剩两百出头的预览，
+// 分栏等于白做。面板自己知道要多宽，列宽却在 Shell 手里——这条小道把两边接上。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const VIEWPORT = 1920
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+async function freshModules() {
+  vi.resetModules()
+  return { ...(await import('./inspector')), ...(await import('./useWorkspaceLayout')) }
+}
+
+describe('文件预览要列宽', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.innerWidth = VIEWPORT
+    vi.stubGlobal('matchMedia', vi.fn((q: string) => ({
+      matches: q.includes('min-width'),
+      addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    })))
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: {} })))
+  })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('要得比现在宽就加宽，收起预览不缩回去', async () => {
+    const m = await freshModules()
+    const { result } = renderHook(() => m.useWorkspaceLayout(true))
+    expect(result.current.inspectorWidth).toBe(m.INSPECTOR_DEFAULT)
+
+    m.requestInspectorWidth(825)
+    await waitFor(() => expect(result.current.inspectorWidth).toBe(825))
+
+    // 关掉预览：请求撤回，但列不缩——面板多宽是用户的选择，不该被开合文件反复改
+    m.requestInspectorWidth(0)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(result.current.inspectorWidth).toBe(825)
+  })
+
+  it('用户拖得更宽时不动他的宽度', async () => {
+    const m = await freshModules()
+    const { result } = renderHook(() => m.useWorkspaceLayout(true))
+    // 拖到上界（几何还要给 Dock 留位，落地值由 inspectorBounds 说了算）
+    result.current.setInspectorWidth(m.INSPECTOR_MAX)
+    await waitFor(() => expect(result.current.inspectorWidth).toBeGreaterThan(825))
+    const dragged = result.current.inspectorWidth
+
+    m.requestInspectorWidth(825)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(result.current.inspectorWidth).toBe(dragged)
+  })
+})

--- a/frontend/src/shell/inspector.ts
+++ b/frontend/src/shell/inspector.ts
@@ -68,10 +68,33 @@ export function useInspectorOpen(): boolean {
   return useSyncExternalStore(subscribe, () => stack.length > 0, () => false)
 }
 
+/**
+ * 面板内部要求「这一列至少这么宽」。
+ *
+ * 文件抽屉里点开一个文件会分成两栏，而 420 的默认列宽分完只剩两百出头的预览——
+ * 读不了代码，等于这个分栏白做。面板自己知道要多宽，但列宽在 Shell 手里，
+ * 于是走这条与槽位同样的模块级小道（别为这一个数把 setInspectorWidth 一路 prop 下去）。
+ *
+ * 只加宽不缩窄：用户拖出来的更宽值一直算数，收起预览也不把列缩回去——
+ * 面板宽度是他的选择，不该被开合文件反复改。
+ */
+let wantWidth = 0
+export function requestInspectorWidth(px: number) {
+  const next = Math.max(0, Math.round(px))
+  if (wantWidth === next) return
+  wantWidth = next
+  emit()
+}
+
+export function useInspectorWantWidth(): number {
+  return useSyncExternalStore(subscribe, () => wantWidth, () => 0)
+}
+
 /** 仅供测试 */
 export function resetInspector() {
   slot = null
   stack = []
   seq = 0
+  wantWidth = 0
   snap = { slot: null, top: 0 }
 }

--- a/frontend/src/shell/useWorkspaceLayout.ts
+++ b/frontend/src/shell/useWorkspaceLayout.ts
@@ -9,7 +9,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLayout, type WindowSize } from '../layout'
 import { usePreferences, preferencesLoaded, saveWorkspace } from '../preferences'
-import { useInspectorOpen } from './inspector'
+import { useInspectorOpen, useInspectorWantWidth } from './inspector'
 
 /** 尺寸契约，与 index.css 的 --canvas-min / --dock-* 同源（14 §8.2）。 */
 export const CANVAS_MIN = 560
@@ -275,6 +275,14 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     setInsWidthLocal(clamped)
     saveWorkspace({ inspectorWidth: clamped })
   }, [insBounds])
+
+  // 面板自己要求的最小列宽（文件抽屉展开预览时）：只加宽，不缩窄。
+  // 只在真有这一列的档位生效——手机走全屏二级页，没有列，不该被它改掉这份偏好。
+  const wantInspector = useInspectorWantWidth()
+  useEffect(() => {
+    if (!splitCapable) return
+    if (wantInspector > 0 && wantInspector > inspectorWidth) setInspectorWidth(wantInspector)
+  }, [wantInspector, inspectorWidth, setInspectorWidth, splitCapable])
 
   const setNavCollapsed = useCallback((collapsed: boolean) => {
     hydrated.current = true

--- a/frontend/src/shell/useWorkspaceLayout.ts
+++ b/frontend/src/shell/useWorkspaceLayout.ts
@@ -24,7 +24,9 @@ export const OVERLAY_DOCK = 480
 /** Inspector（Git / Worktree 列）的尺寸契约，见 14-desktop-workspace/panels-desktop.html */
 export const INSPECTOR_MIN = 360
 export const INSPECTOR_DEFAULT = 420
-export const INSPECTOR_MAX = 880
+// 文件抽屉是两层折叠（文件夹层 + 预览层），两层加起来能到一千出头——880 会把预览截短。
+// 真正的上界仍由 inspectorBounds 按剩余空间给，这里只是"用户最多能拖多宽"。
+export const INSPECTOR_MAX = 1200
 /** 面板内左右分栏（列表 ｜ diff）的阈值：280 列表 + 8 + 400 diff + 32 padding */
 export const INSPECTOR_SPLIT = 720
 
@@ -276,13 +278,22 @@ export function useWorkspaceLayout(hasTerms: boolean): WorkspaceLayout {
     saveWorkspace({ inspectorWidth: clamped })
   }, [insBounds])
 
-  // 面板自己要求的最小列宽（文件抽屉展开预览时）：只加宽，不缩窄。
-  // 只在真有这一列的档位生效——手机走全屏二级页，没有列，不该被它改掉这份偏好。
+  /**
+   * 面板自己报的宽度（文件抽屉是两层折叠，宽度＝两层之和，见 FileBrowser 顶部那段）。
+   *
+   * **只在它变化的那一刻应用一次**：盯着 inspectorWidth 反复施加的话，用户拖外把手拖出来的
+   * 宽度会被立刻弹回去——那根把手就等于拖不动了。面板量到自己被拖宽后会把差值收进对应
+   * 那一层并报一个新值，两边由此收敛。
+   *
+   * 只在真有这一列的档位生效——手机走全屏二级页，没有这一列，不该被它改掉这份偏好。
+   */
   const wantInspector = useInspectorWantWidth()
+  const appliedWant = useRef(0)
   useEffect(() => {
-    if (!splitCapable) return
-    if (wantInspector > 0 && wantInspector > inspectorWidth) setInspectorWidth(wantInspector)
-  }, [wantInspector, inspectorWidth, setInspectorWidth, splitCapable])
+    if (!splitCapable || wantInspector === appliedWant.current) return
+    appliedWant.current = wantInspector
+    if (wantInspector > 0) setInspectorWidth(wantInspector)
+  }, [wantInspector, setInspectorWidth, splitCapable])
 
   const setNavCollapsed = useCallback((collapsed: boolean) => {
     hydrated.current = true


### PR DESCRIPTION
右侧「文件管理」抽屉原来是**一个定宽面板切两半**：点开文件，你正看着的那一列当场变窄，预览还只剩两百出头，读不了代码。

改成**两层折叠**：

```
只弹文件夹层        →  面板 = 文件夹层
点开文件再叠一层预览 →  面板 = 预览层 + 5 + 文件夹层   ← 是加上去，不是切开
收起预览            →  退回文件夹层
```

列表钉在右缘不动，文件内容从它左边长出来 —— 新出现的东西占新地方，正在看的那列不动。

## 每层各自能拖，各自记宽度

两根把手各管紧挨着自己的那一层：

- **里把手**（两层之间）贴着文件夹层 → 拖它改文件夹宽，面板外缘跟着让；
- **外把手**（面板左缘）贴着最左那层 → 预览开着改预览宽，没开改文件夹宽。

## 三处配套（都是踩出来的）

- `INSPECTOR_MAX` 880 → 1200：两层加起来能到一千出头，880 会把预览截短。真正的上界仍由 `inspectorBounds` 按剩余空间给，这只是"最多能拖多宽"。
- 面板报的宽度**只在它变化的那一刻应用一次**。盯着 `inspectorWidth` 反复施加的话，用户拖外把手拖出来的宽度会被立刻弹回去 —— 那根把手就等于拖不动了。
- 回填（把外把手拖出来的宽度收进对应那一层）要**等面板不动了再收**。面板宽度带过渡，松手后那几帧量到的是中间态：实测松手明明到了 985，0.4 秒后自己缩回 872。

顺带修了同一处的落盘时序：最后一次 `pointermove` 与 `pointerup` 落在同一帧时，`onEnd` 读到的 `treeWRef` 还是上一次渲染的值，存进 localStorage 的是旧宽度。

## 验收（headless CDP，第 ④ 步是真实鼠标事件）

```
① 只弹文件夹层   面板 360
② 点开文件       面板 925 = 360 + 5 + 560，文件夹层原地不动
③ 里把手右拖 60  列表 360→300，面板 924→864，预览不变，落盘 300
④ 外把手左拖 120 预览 559→678，面板 864→983，列表不变，落盘 679
⑤ 关掉预览       退回文件夹层（面板下限 360）
```

单测：两栏左右次序（改回旧顺序即变红）、叠一层加一层的宽、报过的值不再反复施加（外把手才拖得动）。
`check.sh full` 通过，232 条前端测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
