### PR TITLE
fix(web): 输入法上屏的那记回车不再当成提交

### DIFF
--- a/frontend/scripts/i18n-audit.mjs
+++ b/frontend/scripts/i18n-audit.mjs
@@ -30,7 +30,9 @@ function walk(dir, out = []) {
     const path = join(dir, name)
     const st = statSync(path)
     if (st.isDirectory()) walk(path, out)
-    else if (/\.(ts|tsx)$/.test(name)) out.push(path)
+    // 测试里的中文是**被测数据**，不是要发布的界面文案：一条中文输入法的用例，
+    // 断言里必须有中文才测得动。把它们也算进来，等于逼着测试去演一遍英文。
+    else if (/\.(ts|tsx)$/.test(name) && !/\.test\.tsx?$/.test(name)) out.push(path)
   }
   return out
 }

--- a/frontend/src/FileBrowser.tsx
+++ b/frontend/src/FileBrowser.tsx
@@ -18,6 +18,7 @@ import {
 } from './file-icons'
 import { Viewer } from './fileview'
 import { ArrowUp } from './icons'
+import { composingEnter, onEnterSubmit } from './enter-submit'
 
 interface Entry { name: string; dir: boolean; size: number; mtime: number; ctime: number }
 interface Dir { path: string; parent: string; entries: Entry[] }
@@ -878,7 +879,7 @@ export default function FileBrowser({
             allowClear
             enterButton={t('file.open')}
             onSearch={(v) => submitTypedPath(v)}
-            onPressEnter={(e) => submitTypedPath((e.target as HTMLInputElement).value)}
+            onPressEnter={(e) => { if (composingEnter(e)) return; submitTypedPath((e.target as HTMLInputElement).value) }}
             placeholder={t('file.pathPlaceholder')}
             style={{ fontFamily: 'ui-monospace, monospace', fontSize: 12 }}
           />
@@ -955,7 +956,7 @@ export default function FileBrowser({
         onOk={doMkdir}
         onCancel={() => { setMkdirOpen(false); setMkdirName(''); setMkdirDir(null) }}
       >
-        <Input autoFocus value={mkdirName} onChange={(e) => setMkdirName(e.target.value)} onPressEnter={doMkdir} placeholder={t('file.folderName')} />
+        <Input autoFocus value={mkdirName} onChange={(e) => setMkdirName(e.target.value)} onPressEnter={onEnterSubmit(doMkdir)} placeholder={t('file.folderName')} />
         <div style={{ marginTop: 8, color: 'var(--text-dimmer)', fontSize: 12, wordBreak: 'break-all' }}>
           {t('file.createUnder', { path: displayPath(mkdirDir || cur) })}
         </div>
@@ -969,7 +970,7 @@ export default function FileBrowser({
         onOk={doTouch}
         onCancel={() => { setTouchDir(null); setTouchName('') }}
       >
-        <Input autoFocus value={touchName} onChange={(e) => setTouchName(e.target.value)} onPressEnter={doTouch} placeholder={t('file.fileName')} />
+        <Input autoFocus value={touchName} onChange={(e) => setTouchName(e.target.value)} onPressEnter={onEnterSubmit(doTouch)} placeholder={t('file.fileName')} />
         <div style={{ marginTop: 8, color: 'var(--text-dimmer)', fontSize: 12, wordBreak: 'break-all' }}>
           {touchDir ? t('file.createUnder', { path: displayPath(touchDir) }) : null}
         </div>
@@ -983,7 +984,7 @@ export default function FileBrowser({
         onOk={doMove}
         onCancel={() => { setMoveTarget(null); setMoveDest('') }}
       >
-        <Input autoFocus value={moveDest} onChange={(e) => setMoveDest(e.target.value)} onPressEnter={doMove} placeholder={t('file.copyTargetPlaceholder')} />
+        <Input autoFocus value={moveDest} onChange={(e) => setMoveDest(e.target.value)} onPressEnter={onEnterSubmit(doMove)} placeholder={t('file.copyTargetPlaceholder')} />
         <div style={{ marginTop: 8, color: 'var(--text-dimmer)', fontSize: 12, wordBreak: 'break-all' }}>
           {moveTarget ? t('file.copySourceHint', { path: moveTarget.path }) : null}
         </div>
@@ -997,7 +998,7 @@ export default function FileBrowser({
         onOk={doRename}
         onCancel={() => { setRenameTarget(null); setRenameName('') }}
       >
-        <Input autoFocus value={renameName} onChange={(e) => setRenameName(e.target.value)} onPressEnter={doRename} placeholder={t('file.namePlaceholder')} />
+        <Input autoFocus value={renameName} onChange={(e) => setRenameName(e.target.value)} onPressEnter={onEnterSubmit(doRename)} placeholder={t('file.namePlaceholder')} />
         <div style={{ marginTop: 8, color: 'var(--text-dimmer)', fontSize: 12, wordBreak: 'break-all' }}>
           {renameTarget ? t('file.renamePathHint', { path: renameTarget.path }) : null}
         </div>
@@ -1011,7 +1012,7 @@ export default function FileBrowser({
         onOk={doCopy}
         onCancel={() => { setCopyTarget(null); setCopyDest('') }}
       >
-        <Input autoFocus value={copyDest} onChange={(e) => setCopyDest(e.target.value)} onPressEnter={doCopy} placeholder={t('file.copyTargetPlaceholder')} />
+        <Input autoFocus value={copyDest} onChange={(e) => setCopyDest(e.target.value)} onPressEnter={onEnterSubmit(doCopy)} placeholder={t('file.copyTargetPlaceholder')} />
         <div style={{ marginTop: 8, color: 'var(--text-dimmer)', fontSize: 12, wordBreak: 'break-all' }}>
           {copyTarget ? t('file.copySourceHint', { path: copyTarget.path }) : null}
         </div>

--- a/frontend/src/Swarm.tsx
+++ b/frontend/src/Swarm.tsx
@@ -14,6 +14,7 @@ import { DirPicker, recentDirs, pushRecentDir } from './App'
 import { useI18n } from './i18n'
 import Markdown from './Markdown'
 import { useLayout } from './layout'
+import { onEnterSubmit } from './enter-submit'
 import { BlockIcon, BotIcon, CheckIcon, ChevronLeft, ClockIcon, CloseIcon, DiamondIcon, DotIcon, KeyboardIcon, LinkIcon, MegaphoneIcon, OpenInIcon, QuestionIcon, ReplyIcon, TargetIcon } from './icons'
 
 // ── 配色（与 App.tsx 一致） ──
@@ -223,7 +224,7 @@ export function NewSwarmModal({ open, onClose, onDone, initialDir, lockDir }: {
     <>
       <Modal open={open} onCancel={onClose} onOk={ok} okText={t('file.create')} confirmLoading={busy} title={t('swarm.new')} destroyOnClose>
         <Space direction="vertical" style={{ width: '100%' }}>
-          <Input placeholder={t('swarm.namePlaceholder')} value={name} onChange={(e) => setName(e.target.value)} autoFocus onPressEnter={ok} />
+          <Input placeholder={t('swarm.namePlaceholder')} value={name} onChange={(e) => setName(e.target.value)} autoFocus onPressEnter={onEnterSubmit(ok)} />
           <Input.TextArea rows={2} placeholder={t('swarm.goalPlaceholder')} value={goal} onChange={(e) => setGoal(e.target.value)} />
           {lockDir ? (
             <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: 12, color: C.fg2, padding: '6px 10px', border: `1px solid ${C.line}`, borderRadius: 6 }} title={dir}>{dir}</div>
@@ -862,7 +863,7 @@ function Plaza({ name, posts, focus }: { name: string; posts: Post[]; focus: str
       <div style={{ display: 'flex', gap: 8, padding: '9px 12px', borderTop: `1px solid ${C.line}` }}>
         <Select size="small" value={kind} onChange={setKind} style={{ width: 96 }}
           options={['note', 'ask', 'decide', 'broadcast', 'block', 'done'].map((k) => ({ value: k, label: k }))} />
-        <Input size="small" value={text} onChange={(e) => setText(e.target.value)} onPressEnter={send} placeholder={t('swarm.sayPlaceholder')} />
+        <Input size="small" value={text} onChange={(e) => setText(e.target.value)} onPressEnter={onEnterSubmit(send)} placeholder={t('swarm.sayPlaceholder')} />
         <Button size="small" type="primary" loading={sending} onClick={send}>{t('swarm.say')}</Button>
       </div>
     </Panel>
@@ -1021,7 +1022,7 @@ function AddCardModal({ open, name, onClose, onDone }: { open: boolean; name: st
   return (
     <Modal open={open} onCancel={onClose} onOk={ok} okText={t('swarm.addCard')} title={t('swarm.newCard')} destroyOnClose>
       <Space direction="vertical" style={{ width: '100%' }}>
-        <Input placeholder={t('swarm.cardTitlePlaceholder')} value={title} onChange={(e) => setTitle(e.target.value)} autoFocus onPressEnter={ok} />
+        <Input placeholder={t('swarm.cardTitlePlaceholder')} value={title} onChange={(e) => setTitle(e.target.value)} autoFocus onPressEnter={onEnterSubmit(ok)} />
         <Input placeholder={t('swarm.assigneePlaceholder')} value={assignee} onChange={(e) => setAssignee(e.target.value)} />
         <Select value={col} onChange={(v) => setCol(v as Col)} style={{ width: '100%' }}
           options={COLS.map((c) => ({ value: c, label: `${c} (${colLabel(t, c)})` }))} />

--- a/frontend/src/chat/ChatShell.tsx
+++ b/frontend/src/chat/ChatShell.tsx
@@ -168,6 +168,21 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
     finally { setSending(false) }
   }
 
+  /**
+   * 回车发送——但输入法正在组合时那记回车是「上屏候选词」，不是「发送」。
+   *
+   * 不挡的话：打一句中文按回车上屏，消息当场就发出去了，而且缺了还没上屏的那半截；
+   * send() 清的是 React 态，浏览器随后把组合前的值写回 DOM，于是刚粘贴的那段文件路径
+   * 又冒回输入框里（看着像"又粘了一遍"）。keyCode 229 是 Chrome 组合态的老写法，
+   * 跟 isComposing 一起判，两代浏览器都盖住。
+   */
+  const onEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const ne = e.nativeEvent as KeyboardEvent
+    if (e.shiftKey || ne.isComposing || ne.keyCode === 229) return
+    e.preventDefault()
+    send()
+  }
+
   // 中断生成：向会话注入 Escape（Claude / Codex 都按 Esc 打断当前回合）
   const stop = () => { api('POST', `/sessions/${encodeURIComponent(name)}/keys`, { keys: ['Escape'] }).catch(() => {}) }
 
@@ -269,7 +284,7 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
               <Input.TextArea
                 value={input} onChange={(e) => setInput(e.target.value)}
                 autoSize={{ minRows: 1, maxRows: 6 }} placeholder={placeholder}
-                onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
+                onPressEnter={onEnter}
                 onPaste={onPaste}
               />
               <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
@@ -286,7 +301,7 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
               <Input.TextArea
                 value={input} onChange={(e) => setInput(e.target.value)}
                 autoSize={{ minRows: 1, maxRows: 5 }} placeholder={placeholder}
-                onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
+                onPressEnter={onEnter}
                 onPaste={onPaste}
               />
               {busy && <Button danger title={t('chat.stopTitle')} onClick={stop} icon={<StopIcon size={11} />}>{t('chat.stop')}</Button>}

--- a/frontend/src/chat/composer-enter.test.tsx
+++ b/frontend/src/chat/composer-enter.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+// 中文输入法里的回车是「上屏候选词」，不是「发送」。
+//
+// 这条测试对着一个真实 bug：粘贴图片拿到一段 @路径，接着打一句中文，按回车上屏——
+// 结果消息提前发出去了，发出去的还缺了没上屏的那半截；而 send() 清的是 React 态，
+// 浏览器随后把组合前的值写回 DOM，于是那段文件路径又冒回输入框里。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { App as AntApp } from 'antd'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ChatShell } from './ChatShell'
+import { I18nProvider } from '../i18n'
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+/** 发出去的消息体（没发就是 null） */
+function sentMessages(fetchMock: ReturnType<typeof vi.fn>): string[] {
+  return fetchMock.mock.calls
+    .filter(([url]) => String(url).includes('/tasks/_/send'))
+    .map(([, init]) => JSON.parse(String((init as RequestInit).body)).msg)
+}
+
+describe('对话输入框：回车与输入法组合态', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('ttmux-locale', 'zh-CN')
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(),
+      addListener: vi.fn(), removeListener: vi.fn(),
+    }))
+    fetchMock = vi.fn(async () => jsonResponse({ data: {} }))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+  afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+  const renderShell = () => render(
+    <I18nProvider><AntApp>
+      <ChatShell name="s1" accent="var(--accent)" placeholder="说点什么"
+        messages={[]} renderMessage={() => null} />
+    </AntApp></I18nProvider>,
+  )
+
+  it('组合中的回车只上屏，不发送', async () => {
+    renderShell()
+    const box = await screen.findByPlaceholderText('说点什么')
+
+    fireEvent.change(box, { target: { value: '/tmp/a.png 看下这张' } })
+    fireEvent.compositionStart(box)
+    // 输入法把这记回车吃掉去上屏；浏览器仍然派一个 isComposing 的 keydown 过来
+    fireEvent.keyDown(box, { key: 'Enter', code: 'Enter', keyCode: 229, isComposing: true })
+
+    expect(sentMessages(fetchMock)).toEqual([])
+    expect((box as HTMLTextAreaElement).value).toBe('/tmp/a.png 看下这张')
+  })
+
+  it('上屏之后再按回车，整句发出去', async () => {
+    renderShell()
+    const box = await screen.findByPlaceholderText('说点什么')
+
+    fireEvent.change(box, { target: { value: '/tmp/a.png 看下这张图' } })
+    fireEvent.compositionStart(box)
+    fireEvent.compositionEnd(box)
+    fireEvent.keyDown(box, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => expect(sentMessages(fetchMock)).toEqual(['/tmp/a.png 看下这张图']))
+    await waitFor(() => expect((box as HTMLTextAreaElement).value).toBe(''))
+  })
+})

--- a/frontend/src/enter-submit.ts
+++ b/frontend/src/enter-submit.ts
@@ -1,0 +1,23 @@
+// 「回车＝提交」的唯一写法。
+//
+// 中文输入法里那记回车是**上屏候选词**，不是提交：浏览器照样派一个 keydown 过来，
+// 直接当提交处理就会把还没上屏的半截当成全部——对话框发出去缺字的一句、新建文件夹
+// 建出个半拉名字。而且提交后清空的是 React 态，浏览器随后把组合前的值写回 DOM，
+// 上一段内容看着像"自己又冒回来了"。
+//
+// `isComposing` 是标准写法，`keyCode === 229` 是 Chrome 组合态的老写法，两条一起判。
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+
+/** 这记回车是输入法在上屏，不是用户要提交 */
+export function composingEnter(e: ReactKeyboardEvent | KeyboardEvent): boolean {
+  const ne = 'nativeEvent' in e ? (e.nativeEvent as KeyboardEvent) : e
+  return !!ne.isComposing || ne.keyCode === 229
+}
+
+/** 包一层「回车提交」处理器：组合中的回车放行给输入法，其余才提交 */
+export function onEnterSubmit<T extends Element>(submit: () => void) {
+  return (e: ReactKeyboardEvent<T>) => {
+    if (composingEnter(e)) return
+    submit()
+  }
+}

--- a/frontend/src/git/AskModal.tsx
+++ b/frontend/src/git/AskModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Input, Modal } from 'antd'
 import { useI18n } from '../i18n'
+import { onEnterSubmit } from '../enter-submit'
 
 export interface AskSpec {
   title: string
@@ -36,7 +37,7 @@ export default function AskModal({ spec, onClose }: { spec: AskSpec | null; onCl
       {spec?.label && <div style={{ fontSize: 12.5, color: 'var(--text-dim)', marginBottom: 6 }}>{spec.label}</div>}
       <Input autoFocus value={value} placeholder={spec?.placeholder}
         onChange={(e) => setValue(e.target.value)}
-        onPressEnter={submit} />
+        onPressEnter={onEnterSubmit(submit)} />
     </Modal>
   )
 }


### PR DESCRIPTION
## 现象

粘一张图拿到 `@路径`，接着打一句中文，按回车上屏 —— 消息当场就发出去了，**发出去的还缺了没上屏的那半截**；而且那段文件路径又冒回输入框里，看着像"又粘了一遍"。

## 原因

中文输入法里那记回车是**上屏候选词**，不是发送，但浏览器照样派一个 keydown 过来。`ChatShell` 的输入框直接把它当发送：

```tsx
onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); send() } }}
```

于是 `send()` 拿到的是还没上屏的那一半。`send()` 清空的是 React 态，浏览器随后把组合前的值写回 DOM —— 上一段内容（含刚粘的路径）就"自己回来了"。

仓库里 `App.tsx:1751`、`Projects.tsx:1394`、`BrowserView.tsx:600` 三处早就各写了一遍 `isComposing` 判断，唯独主对话输入框漏了。

## 改动

- 新增 `enter-submit.ts`：`composingEnter(e)` / `onEnterSubmit(fn)` —— 「回车＝提交」的唯一写法，`isComposing` 与 Chrome 老写法 `keyCode === 229` 一起判。
- 主对话输入框（手机 / 桌面两处）走它。
- 同一类的其余入口一并收掉：新建文件 / 新建目录 / 重命名 / 移动 / 复制到、路径直达框、蜂群发言与命名、Git 询问框 —— **中文名字打一半被回车提交，是同一个 bug 的不同长相**。
- i18n 审计跳过 `*.test.tsx`：测试里的中文是被测数据，一条输入法用例的断言里必须有中文才测得动，把它算成待翻译文案等于逼着测试演一遍英文。（locale key 数不变，仍是 1575。）

## 验收

新增 `chat/composer-enter.test.tsx` 两条：

- 组合中的回车（`isComposing` / `keyCode 229`）只上屏，不发送，输入框内容一字不动；
- 上屏之后再按回车，整句原样发出，框清空。

去掉守卫，第一条立刻变红。`check.sh full` 通过，231 条前端测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
