### PR TITLE
feat(web): 侧栏去掉标语，导航默认收成轨

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1,5 +1,4 @@
 const enUS = {
-  'app.tagline': 'ANYWHERE · ANYTIME',
   'p2p.connectedVia': 'Direct connection ({path})',
   'p2p.fellBackToHttp': 'Direct connection failed, fell back to HTTP download',
   'p2p.downloadDone': '{name} downloaded',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1,5 +1,4 @@
 const zhCN = {
-  'app.tagline': 'ANYWHERE · ANYTIME',
   'p2p.connectedVia': '已直连（{path}）',
   'p2p.fellBackToHttp': '直连失败，已回退到 HTTP 下载',
   'p2p.downloadDone': '{name} 下载完成',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -275,13 +275,18 @@ body {
 .tt-nav.rail .tt-nav-brand { justify-content: center; padding: 18px 0 14px; }
 /* 标是透明底的，别再给它圆角和投影——那是当年方形底板留下的两笔 */
 .tt-nav-brand img { flex: 0 0 auto; }
-.tt-nav-brand .wd { min-width: 0; line-height: 1.15; }
-.tt-nav-brand .wd strong {
-  display: block; font-size: 19px; font-weight: 800; letter-spacing: .5px;
+/* 只有标 + 名，没有标语。
+   标语（ANYWHERE · ANYTIME）是 10px——比 --fs-micro 还小一档，掉在字号阶梯外面；
+   它也不承载信息：这一栏是导航，用户已经在应用里了，不需要再被介绍一遍产品。
+   名字随之从 19 提到 --fs-title：一行名压不住 34 的标，提一档才配得上；块高仍由标
+   决定（34 > 22×1.15），删掉一行不会让下面整列往上跳。 */
+.tt-nav-brand .wd {
+  min-width: 0; line-height: 1.15;
+  font-size: var(--fs-title); font-weight: 800; letter-spacing: .5px;
   background: var(--brand-grad); -webkit-background-clip: text; background-clip: text;
   -webkit-text-fill-color: transparent;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.tt-nav-brand .wd span { display: block; font-size: 10px; letter-spacing: 1.5px; color: var(--text-dimmer); }
 
 
 .tt-nav-list { flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; }

--- a/frontend/src/preferences.ts
+++ b/frontend/src/preferences.ts
@@ -41,7 +41,12 @@ export interface WorkspacePreference {
 }
 
 const WORKSPACE_DEFAULTS: WorkspacePreference = {
-  navCollapsed: false,
+  // 默认成轨（VSCode 的活动栏本来就不带文字标签，名字在 tooltip 里）。
+  // 两个实在理由：① 展开态只在 large(≥1280) 存在，1280 以下强制成轨——默认展开的结果是
+  // 拖窗口跨过 1280 导航自己换一副样子；默认成轨，桌面各档同一个形状。
+  // ② 那 160px 在 1280 上是决定性的：展开时终端最宽 488，比它的下限 480 只多 8，等于顶死；
+  // 收成轨是 648。已经存过偏好的浏览器不受影响，这只是没拖过时给什么。
+  navCollapsed: true,
   dockOpen: true,
   dockWidth: 0, // 0 = 还没拖过，用该档默认（clamp(480, 42vw, 880)）
   inspectorWidth: 0, // 0 = 还没拖过，用 INSPECTOR_DEFAULT

--- a/frontend/src/shell/Navigation.tsx
+++ b/frontend/src/shell/Navigation.tsx
@@ -59,13 +59,9 @@ export function Navigation({
   return (
     <div className={`tt-nav${rail ? ' rail' : ''}`}>
       <div className="tt-nav-brand">
-        <img src="/logo-mark.svg" width={34} height={34} alt="Roam" />
-        {!rail && (
-          <div className="wd">
-            <strong>Roam</strong>
-            <span>{t('app.tagline')}</span>
-          </div>
-        )}
+        {/* 轨态下标是唯一的品牌元素，得由它报名字；展开时旁边就写着 Roam，再念一遍是重复 */}
+        <img src="/logo-mark.svg" width={34} height={34} alt={rail ? 'Roam' : ''} aria-hidden={rail ? undefined : true} />
+        {!rail && <strong className="wd">Roam</strong>}
       </div>
 
       {/* 这里原来还有一枚搜索入口。去掉了：顶栏 Command Center 的搜索横跨整个工作区、


### PR DESCRIPTION
侧栏两件事，都是"默认少点装饰"：**去掉标语**、**默认收成轨**。

## 一、品牌区只留标 + 名

`ANYWHERE · ANYTIME` 是 **10px** —— 比 `--fs-micro`（11）还小一档，掉在字号阶梯外面，设计系统明写「除眉标/角标外不许低于 12px」。

更根本的是它不承载信息：这一栏是**导航**，用户已经在应用里了，不需要每屏被介绍一遍产品。产品介绍该待的地方是登录页（`auth.tagline`，未动）和「关于」。

名字随之从 19 提到 `--fs-title`(22)：标语在时它俩合起来正好 34 高、和标齐平，删掉一行只剩 22，重量一下子空了。提一档既配得上 34 的标，也顺带清掉 19 这个阶梯外的值。**块高仍由标决定**（34 > 22×1.15），所以删掉一行不会让下面整列往上跳 —— 实测前后都是 66 高。

轨态下标是唯一的品牌元素，`alt` 仍报 `Roam`；展开时旁边就写着 Roam，标改 `aria-hidden`，读屏不再念两遍。`app.tagline` 两份 locale 一并删掉（无其他引用）。

## 二、导航默认收成轨

VSCode 的活动栏本来就不带文字标签，名字活在 tooltip 里；我们这栏在代码和设计稿里也叫 Activity Bar（14 §4.4），却默认撑成 224 的带标签侧边栏。

1. **展开态只在 `large`(≥1280) 存在**，1280 以下强制成轨 —— 默认展开的结果是拖窗口跨过 1280，导航自己换一副样子。默认成轨，桌面各档同一个形状，展开变成显式选择。
2. **那 160px 在 1280 上是决定性的**：

| 视口 | 导航 | 工作区 | 终端最宽 |
|---:|---|---:|---:|
| 1280 | 展开 224 | 1056 | **488**（下限 480，等于顶死） |
| 1280 | 轨 64 | 1216 | 648 |
| 1366 | 展开 224 | 1142 | 574 |
| 1366 | 轨 64 | 1302 | 734 |
| 1440 | 展开 224 | 1216 | 648 |
| 1440 | 轨 64 | 1376 | 808 |

**已经存过偏好的浏览器不受影响** —— 这只是「没拖过时给什么」。轨底那枚展开钮是回去的路。

## 验收

headless CDP 干净环境：

- 品牌块 `207×66 · name "Roam" · font-size 22px · imgAlt "" · aria-hidden true · tagline false`
- 1280 视口：导航 `63` 宽、`rail` 态、无文字标签，档位仍是 `large`

`check.sh full` 通过，234 条前端测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
