### PR TITLE
fix(web): 「需要你」不再漏掉第 4 个以后的等待会话

### DIFF
--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -56,6 +56,12 @@ type projectSummary struct {
 	LastActivity int64            `json:"lastActivity"`
 	FirstSeen    int64            `json:"firstSeen"`
 	Top          []projectSession `json:"top"` // 活跃会话前 3（列表卡「进行中」三行）
+
+	// Top 是**给卡片画三行用的**，被截断过，所以它算不出总数——前端拿它数 waiting/running
+	// 会漏掉第 4 个以后的会话。下面这三样在截断**之前**统计，是完整的：
+	Running int              `json:"running"` // 跑着 agent 的会话数（全量）
+	Waiting int              `json:"waiting"` // 等待输入的会话数（全量）
+	Needs   []projectSession `json:"needs"`   // 全部等待输入的会话——「需要你」队列要的是它，不是 Top
 }
 
 // sessListItem 兼容解析 ttmux ls --json（数值字段 CLI 可能给字符串）。
@@ -154,16 +160,7 @@ func (a *API) ProjectsList(c *gin.Context) {
 		*top = append(*top, ps)
 	}
 	finish := func(p *projectSummary, top []projectSession) {
-		sort.Slice(top, func(i, j int) bool {
-			if top[i].Attached != top[j].Attached {
-				return top[i].Attached
-			}
-			return top[i].LastActivity > top[j].LastActivity
-		})
-		if len(top) > 3 { // 卡片画三行；截到 2 就逼得前端自己再拉一遍会话列表拼
-			top = top[:3]
-		}
-		p.Top = top
+		summarizeSessions(p, top)
 		list = append(list, *p)
 	}
 
@@ -440,4 +437,38 @@ func (a *API) ProjectPrefs(c *gin.Context) {
 	projResp = nil // 偏好变更立即反映到下一次列表
 	projRespMu.Unlock()
 	c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}})
+}
+
+// summarizeSessions 把一个项目的会话汇总进 summary：**先在全量上统计，再截断给卡片**。
+//
+// 反过来做会漏。Top 只留三行给卡片画，而前端一度拿它数 waiting/running、挑「需要你」——
+// 于是一个有 4 个以上活跃会话的项目里，排第 4 的那个「等待输入」会从行动队列和页头计数里
+// 凭空消失，默认排序也跟着失真。计数走 Running/Waiting，队列走 Needs，Top 只管画。
+func summarizeSessions(p *projectSummary, top []projectSession) {
+	p.Running, p.Waiting, p.Needs = 0, 0, nil
+	for _, s := range top {
+		if s.Running {
+			p.Running++
+		}
+		if s.Waiting {
+			p.Waiting++
+			p.Needs = append(p.Needs, s)
+		}
+	}
+	sort.Slice(p.Needs, func(i, j int) bool { return p.Needs[i].LastActivity > p.Needs[j].LastActivity })
+
+	sort.Slice(top, func(i, j int) bool {
+		// 等待输入的排最前：卡片只画三行，而「有人在等你」是这三行里最该被看见的一行
+		if top[i].Waiting != top[j].Waiting {
+			return top[i].Waiting
+		}
+		if top[i].Attached != top[j].Attached {
+			return top[i].Attached
+		}
+		return top[i].LastActivity > top[j].LastActivity
+	})
+	if len(top) > 3 { // 卡片画三行；截到 2 就逼得前端自己再拉一遍会话列表拼
+		top = top[:3]
+	}
+	p.Top = top
 }

--- a/backend/api/project_summary_test.go
+++ b/backend/api/project_summary_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+// Top 被截到三行，所以它算不出总数。一个项目有 5 个活跃会话、其中第 4、5 个在等待输入时，
+// 那两条**不能**从计数和「需要你」队列里消失——这是 #186 合并后前端拿 Top 数数留下的账。
+func TestSummarizeSessionsCountsBeyondTop(t *testing.T) {
+	top := []projectSession{
+		{Name: "a", Running: true, Attached: true, LastActivity: 500},
+		{Name: "b", Running: true, LastActivity: 400},
+		{Name: "c", Running: true, LastActivity: 300},
+		{Name: "d", Running: true, Waiting: true, LastActivity: 200, Tail: "proceed? (y/n)"},
+		{Name: "e", Running: true, Waiting: true, LastActivity: 100},
+	}
+	var p projectSummary
+	summarizeSessions(&p, top)
+
+	if p.Running != 5 {
+		t.Errorf("running = %d，期望 5（全量，不是 Top 里的三条）", p.Running)
+	}
+	if p.Waiting != 2 {
+		t.Errorf("waiting = %d，期望 2——第 4/5 个会话的等待被漏掉了", p.Waiting)
+	}
+	if len(p.Needs) != 2 {
+		t.Fatalf("needs = %d 条，期望 2 条（行动队列要的是全部等待会话）", len(p.Needs))
+	}
+	if p.Needs[0].Name != "d" || p.Needs[0].Tail == "" {
+		t.Errorf("needs 应按活跃度倒序且带摘要，实际 %+v", p.Needs[0])
+	}
+	if len(p.Top) != 3 {
+		t.Fatalf("top 应仍是三行，实际 %d", len(p.Top))
+	}
+	// 卡片只画三行，「有人在等你」是这三行里最该被看见的
+	if !p.Top[0].Waiting || !p.Top[1].Waiting {
+		t.Errorf("等待输入的会话应排在 Top 最前，实际 %v/%v", p.Top[0].Name, p.Top[1].Name)
+	}
+}
+
+// 会话不足三条时不该凭空造出东西，计数也要对得上。
+func TestSummarizeSessionsSmall(t *testing.T) {
+	var p projectSummary
+	summarizeSessions(&p, []projectSession{{Name: "a", Attached: true, LastActivity: 9}})
+	if p.Running != 0 || p.Waiting != 0 || len(p.Needs) != 0 || len(p.Top) != 1 {
+		t.Errorf("单会话汇总不对: running=%d waiting=%d needs=%d top=%d", p.Running, p.Waiting, len(p.Needs), len(p.Top))
+	}
+}

--- a/frontend/src/Projects.tsx
+++ b/frontend/src/Projects.tsx
@@ -22,7 +22,7 @@ import AdaptivePanel from './shell/AdaptivePanel'
 import { useLayout } from './layout'
 import { detectPrompt } from './prompt'
 import { relTime, taskNameFromPrompt, shq, NewSessionModal, DirPicker, recentDirs, pushRecentDir, CloseWorktreeModal } from './App'
-import { projNeeds } from './project-list/project-model'
+import { projNeeds, runningCount, waitingCount } from './project-list/project-model'
 import type { Proj, ProjSession } from './project-list/project-model'
 import { NeedsQueue, WorkbenchHead, buildNeedCards, NEEDS_CSS } from './project-list/needs-queue'
 import { ActivityRail, useRecentActivity, RAIL_CSS } from './project-list/activity-rail'
@@ -422,10 +422,10 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
   const cards = useMemo(
     () => buildNeedCards(data.projects, swarms, t, { openTerm, goProject, goSwarm }),
     [data.projects, swarms, t])
-  const allTop = useMemo(() => data.projects.flatMap((p) => p.top || []), [data.projects])
+  // 计数走后端的全量字段：top 只有三行，拿它数会漏掉第 4 个以后的会话（#186 的账）
   const stats = {
-    running: allTop.filter((s) => s.running).length,
-    waiting: allTop.filter((s) => s.waiting).length,
+    running: data.projects.reduce((n, p) => n + runningCount(p), 0),
+    waiting: data.projects.reduce((n, p) => n + waitingCount(p), 0),
     unfinished: data.projects.reduce((n, p) => n + (p.unfinished || 0), 0),
     swarms: swarms.length,
   }

--- a/frontend/src/project-list/activity-rail.tsx
+++ b/frontend/src/project-list/activity-rail.tsx
@@ -12,7 +12,15 @@ type Act = { oid?: string; subject?: string; branch?: string; base?: string; str
 
 export function useRecentActivity(projects: Proj[]): Act[] {
   const [acts, setActs] = useState<Act[]>([])
-  const keys = projects.filter((p) => p.git).slice(0, 3).map((p) => p.key)
+  // 「最近活动」得挑**最近在动的**三个 git 项目。原来取的是数组里的前 3 个——
+  // 那个顺序来自列表的排序（置顶/名字/需要你…），于是活动轨会长期盯着几个冷仓库，
+  // 真正刚提交过的那个反而不出现。
+  const keys = projects
+    .filter((p) => p.git)
+    .slice()
+    .sort((a, b) => (b.lastActivity || 0) - (a.lastActivity || 0))
+    .slice(0, 3)
+    .map((p) => p.key)
   const dep = keys.join(',')
   useEffect(() => {
     if (!keys.length) { setActs([]); return }

--- a/frontend/src/project-list/needs-queue.tsx
+++ b/frontend/src/project-list/needs-queue.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react'
 import { useI18n } from '../i18n'
 import { relTime } from '../App'
 import { ChevronDown, ChevronRight, ChevronUp, FlagIcon, PlusIcon, SwarmIcon } from '../icons'
-import type { Proj, ProjSession, ProjSwarm } from './project-model'
+import { waitingSessions, type Proj, type ProjSwarm } from './project-model'
 
 export type NeedCard = {
   key: string; kind: 'waiting' | 'unfinished' | 'swarm'
@@ -24,8 +24,7 @@ export function buildNeedCards(
 ): NeedCard[] {
   const items: NeedCard[] = []
   for (const p of projects) {
-    for (const s of (p.top || []) as ProjSession[]) {
-      if (!s.waiting) continue
+    for (const s of waitingSessions(p)) {
       items.push({
         key: 'w' + s.name, kind: 'waiting', proj: p.name,
         title: s.label || s.name,

--- a/frontend/src/project-list/project-card.tsx
+++ b/frontend/src/project-list/project-card.tsx
@@ -57,7 +57,14 @@ export function ProjectCard({ p, swarms, index, openTerm, refresh }: {
     <div className="prj-card prj-in" data-prj-card role="button" tabIndex={0}
       aria-label={p.name} title={t('overview.enterProject')}
       onClick={open}
-      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); open() } }}
+      // role="button" 就得按按钮的键盘语义来：Enter **和** Space 都要能打开。
+      // 只认 Enter 是半套——原生 <button> 两个都响应，用户的手指记的是这个。
+      onKeyDown={(e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        if (e.target !== e.currentTarget) return // 卡片里的按钮自己处理，别被外层抢走
+        e.preventDefault()
+        open()
+      }}
       style={{ animationDelay: `${Math.min(index, 8) * 45}ms` }}>
       <div className="hd">
         <span className="prj-cico" style={{ color: fg, background: bg }} aria-hidden>{(p.name[0] || '?').toUpperCase()}</span>

--- a/frontend/src/project-list/project-model.test.ts
+++ b/frontend/src/project-list/project-model.test.ts
@@ -1,0 +1,48 @@
+// 「需要你」的计数与队列**不能**从 top 里数：后端把 top 截到三行给卡片画，
+// 第 4 个以后的等待输入会凭空消失（#186 合并后留下的账）。
+import { describe, expect, it } from 'vitest'
+import { projNeeds, runningCount, waitingCount, waitingSessions, type Proj } from './project-model'
+
+const sess = (name: string, o: Partial<{ waiting: boolean; running: boolean }> = {}) =>
+  ({ name, attached: false, lastActivity: 1, ...o })
+
+const proj = (o: Partial<Proj>): Proj => ({
+  key: 'k', name: 'p', dir: '/d', git: true, pinned: false,
+  sessions: 0, attached: 0, worktrees: 0, unfinished: 0, cleanable: 0, races: 0,
+  lastActivity: 0, firstSeen: 0, top: null, ...o,
+})
+
+describe('项目的等待/运行计数', () => {
+  it('用后端的全量字段，而不是被截断的 top', () => {
+    // 卡片那三行里只看得见一个等待，实际有三个
+    const p = proj({
+      top: [sess('a', { waiting: true, running: true }), sess('b', { running: true }), sess('c', { running: true })],
+      waiting: 3, running: 5,
+      needs: [sess('a', { waiting: true }), sess('d', { waiting: true }), sess('e', { waiting: true })] as any,
+    })
+    expect(waitingCount(p)).toBe(3)
+    expect(runningCount(p)).toBe(5)
+    expect(waitingSessions(p).map((s) => s.name)).toEqual(['a', 'd', 'e'])
+    expect(projNeeds(p, [])).toBe(3)
+  })
+
+  it('老后端没有这些字段时回落到 top，不至于变成 0', () => {
+    const p = proj({ top: [sess('a', { waiting: true }), sess('b', { running: true })] })
+    expect(waitingCount(p)).toBe(1)
+    expect(runningCount(p)).toBe(1)
+    expect(waitingSessions(p).map((s) => s.name)).toEqual(['a'])
+  })
+
+  it('needs 为空数组时是「真的没有」，不要回落到 top', () => {
+    // 后端明确说了没有等待，就别再去 top 里翻出一个来
+    const p = proj({ top: [sess('a', { waiting: true })], waiting: 0, needs: [] })
+    expect(waitingCount(p)).toBe(0)
+    expect(waitingSessions(p)).toEqual([])
+  })
+
+  it('待收尾与蜂群待解锁一并算进「需要你」', () => {
+    const p = proj({ key: 'k', waiting: 1, unfinished: 2 })
+    const swarms = [{ name: 's', projKey: 'k', projName: 'p', total: 3, inProj: 3, pending: 1 }]
+    expect(projNeeds(p, swarms)).toBe(4)
+  })
+})

--- a/frontend/src/project-list/project-model.ts
+++ b/frontend/src/project-list/project-model.ts
@@ -13,7 +13,13 @@ export type ProjSession = {
 export type Proj = {
   key: string; name: string; dir: string; git: boolean; pinned: boolean
   sessions: number; attached: number; worktrees: number; unfinished: number; cleanable: number; races: number
-  lastActivity: number; firstSeen: number; top: ProjSession[] | null
+  lastActivity: number; firstSeen: number
+  /** 卡片「进行中」三行——**被后端截断过，不能拿它数数**。计数用 running/waiting，队列用 needs。 */
+  top: ProjSession[] | null
+  running?: number
+  waiting?: number
+  /** 全部等待输入的会话（不截断）。「需要你」队列要的是它——第 4 个以后的等待不能凭空消失。 */
+  needs?: ProjSession[] | null
 }
 
 // 蜂群在项目上的投影（/swarms + 逐群详情，10s）
@@ -24,9 +30,24 @@ export type ProjSwarm = {
 
 /** 一个项目「需要你」的件数：等待输入 + 待收尾 + 蜂群待解锁。排序与筛选都用它。 */
 export function projNeeds(p: Proj, swarms: ProjSwarm[]): number {
-  return (p.top || []).filter((s) => s.waiting).length
+  return waitingCount(p)
     + (p.unfinished || 0)
     + swarms.filter((sw) => sw.projKey === p.key && sw.pending > 0).length
+}
+
+/** 等待输入的会话数。**别从 top 数**——它只有三行，第 4 个以后的等待会被漏掉，
+ *  「需要你」的计数和默认排序都会跟着失真。老后端没有这个字段时才回落到 top。 */
+export function waitingCount(p: Proj): number {
+  return p.waiting ?? (p.top || []).filter((s) => s.waiting).length
+}
+
+export function runningCount(p: Proj): number {
+  return p.running ?? (p.top || []).filter((s) => s.running).length
+}
+
+/** 「需要你」队列要的全部等待会话；老后端回落到 top 里的那几个。 */
+export function waitingSessions(p: Proj): ProjSession[] {
+  return p.needs || (p.top || []).filter((s) => s.waiting)
 }
 
 // 项目图标底色：按 key 取一个稳定色，卡片多了才能一眼分辨是哪个项目


### PR DESCRIPTION
三条都是 #186 把概览并进项目页时留下的账。

## ① 高 · 等待输入会凭空消失

后端把 `top` 截到三行给卡片画（`backend/api/project.go`），而前端拿这三行去数 `waiting`/`running`、挑「需要你」、算默认排序（`project-model.ts` / `Projects.tsx`）。于是**一个项目里有 4 个以上活跃会话时，排第 4 的那个「等待输入」不进行动队列、不进页头计数**，默认排序也跟着失真——而「有人在等你」恰恰是这一页最不能漏的一类。

改法是把统计放到截断**之前**：

| 字段 | 语义 |
|---|---|
| `running` / `waiting` | 全量计数，前端计数只认它 |
| `needs` | **全部**等待会话（不截断），行动队列只认它 |
| `top` | 仍是三行，**只管画卡片** |

顺带让等待输入的会话在 `top` 里排最前——卡片只有三行，「有人在等你」是最该被看见的一行。老后端没有这些字段时回落到 `top`，不至于变成 0；`needs: []` 表示「真的没有」，此时不回落。

## ② 中 · 活动轨盯着冷项目

`activity-rail.tsx` 取的是数组里的前 3 个 git 项目，而那个顺序来自列表排序（置顶 / 名字 / 需要你…），于是右侧活动流会长期盯着几个冷仓库，真正刚提交过的那个反而不出现。改成按 `lastActivity` 倒序挑前三。

## ③ 低 · 卡片 Space 打不开

`role="button"` 就得按按钮的键盘语义来，Enter **和** Space 都要响应——原生 `<button>` 两个都认，用户的手指记的是这个。顺带只在事件确实来自卡片本身时才接管，别把卡片内那些按钮的按键抢走。

## 测试

- 后端：`finish` 里那段抽成包级 `summarizeSessions` 才测得到，补两条——5 个会话里第 4、5 个等待时计数与 `needs` 都要对、等待要排进 `top` 最前；单会话时不许凭空造数。
- 前端：补 4 条——用全量字段、老后端回落、`needs: []` 是「真的没有」不许回落、待收尾与蜂群一并计入。
- `typecheck / i18n:check / hover:check / vitest / go test ./...` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)