### PR TITLE
fix(web): 切机器不留残影 · 机器切换器进底座第一位 · 终端开关从侧栏去掉

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -753,8 +753,9 @@ export default function App() {
 
   // 多机：机器列表接在账户菜单最上面（切机器是「换浏览范围」，不是页面）。
   // 单机时 nodes 为空，这一段整个不出现，菜单与今天逐项一致。
+  // 顶部切换器的下拉：就是机器列表本身，不再套一层分组标题——它已经有自己的按钮当标题了
   const nodeItems: MenuProps['items'] = clusterNodes.length ? [
-    { key: 'nodes-title', type: 'group', label: t('node.switch'), children: clusterNodes.map((n) => ({
+    ...clusterNodes.map((n) => ({
       key: 'node:' + n.id,
       icon: <NodeMark name={n.name} size="sm" current={n.id === curNodeId} offline={!n.online} />,
       label: (
@@ -779,13 +780,11 @@ export default function App() {
         setHashParams({ terms: '', active: '' })
         location.reload()
       },
-    })) },
-    { type: 'divider' },
+    })),
   ] : []
 
   // 设置不在这里：它在侧栏底部有自己的入口，菜单里再放一条就是同一页两个门
   const accountMenu: MenuProps['items'] = [
-    ...nodeItems,
     { key: 'about', icon: ICONS.github, label: t('nav.about'), onClick: () => go('about') },
     { type: 'divider' },
     { key: 'theme', icon: themeIcon, label: mode === 'dark' ? t('common.lightTheme') : t('common.darkTheme'), onClick: () => toggleTheme() },
@@ -817,18 +816,14 @@ export default function App() {
             rail={navRail} active={tab} groups={navGroups} onGo={go}
             settings={{ key: 'settings', label: t('nav.env'), icon: ICONS.settings }}
             linkStatus={<LinkStatus collapsed={navRail} />}
-            dock={terms.length > 0 ? {
-              count: terms.length, open: space.dockVisible,
-              onToggle: () => { space.setFocus('none'); space.toggleDock() },
-              title: `${space.dockVisible ? t('terminal.collapseRightTitle') : t('terminal.expandTitle')} (${modKeyLabel}J)`,
-            } : null}
             accountName={t('nav.thisDevice')}
             account={accountMenu}
+            nodeMenu={nodeItems}
             node={curNode ? {
               name: curNode.name,
-              // 底座这枚**不涂蓝**：它永远是当前机器，`current` 那层高亮不传递任何信息，
-              // 只会和上面终端开关的蓝撞成两块「选中」，让人以为选了两样东西。
-              // 蓝留给弹层列表里区分「哪台是当前」，那里才有对比对象。
+              // 切换器那枚**不涂蓝**：它永远是当前机器，`current` 那层高亮不传递任何信息，
+              // 只会和别处的蓝撞成两块「选中」。蓝留给下拉列表里区分「哪台是当前」，
+              // 那里才有对比对象。
               mark: <NodeMark name={curNode.name} size="sm" />,
               dot: nodeDotColor(curNode),
               latency: curNode.online ? t('node.latencyMs', { ms: curNode.latencyMs }) : t('node.offline'),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -768,8 +768,17 @@ export default function App() {
       ),
       disabled: !n.online,
       // 切机器 = 换「浏览 / 新开操作落到哪台」。整页重载是这一版的取舍：页面各自缓存着
-      // 上一台的数据，逐个清远比重来一次更容易漏（终端跨机保留要等会话键改造，见设计稿 §7）。
-      onClick: () => { setCurrentNode(n.id); location.reload() },
+      // 上一台的数据，逐个清远比重来一次更容易漏。
+      //
+      // **必须先把 terms/active 从 URL 里摘掉**：它们是上一台机器的会话 id，原样带过去
+      // 就会在新机器上还原一批根本不存在的标签——界面上表现为「一堆打不开的窗口」，
+      // 而且同名会话还可能连到错的那台。终端真正的跨机保留要等会话键改成 (nodeId, name)，
+      // 见设计稿；在那之前，切机器就是换一台机器的终端，不留残影。
+      onClick: () => {
+        setCurrentNode(n.id)
+        setHashParams({ terms: '', active: '' })
+        location.reload()
+      },
     })) },
     { type: 'divider' },
   ] : []
@@ -817,7 +826,10 @@ export default function App() {
             account={accountMenu}
             node={curNode ? {
               name: curNode.name,
-              mark: <NodeMark name={curNode.name} size="sm" current />,
+              // 底座这枚**不涂蓝**：它永远是当前机器，`current` 那层高亮不传递任何信息，
+              // 只会和上面终端开关的蓝撞成两块「选中」，让人以为选了两样东西。
+              // 蓝留给弹层列表里区分「哪台是当前」，那里才有对比对象。
+              mark: <NodeMark name={curNode.name} size="sm" />,
               dot: nodeDotColor(curNode),
               latency: curNode.online ? t('node.latencyMs', { ms: curNode.latencyMs }) : t('node.offline'),
             } : null}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -430,13 +430,25 @@ html[data-pointer="coarse"] .tt-rail-btn::after {
 .tt-nodemark.lg[data-cjk] { font-size: 17px; }
 .tt-nodemark.cur { color: var(--accent); border-color: var(--accent-border); background: var(--accent-soft); }
 .tt-nodemark.off { color: var(--text-dimmer); border-style: dashed; background: transparent; }
-/* 底座那枚：展开态名字后面缀状态点；轨态只剩方章，点叠在右下角（外描底色免得糊在边上） */
-.tt-nav-account .nd { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; }
-.tt-nav-account .nd.rail {
-  position: absolute; right: 6px; bottom: 6px;
-  box-shadow: 0 0 0 2px var(--bg-base);
+/* 机器切换器：摆在底部这一组的第一位。底下几样都是「上下文与账户」，
+   而它是其中作用域最大的一个——切它，上面整列页面看的都换一台机器。 */
+.tt-nav-node {
+  position: relative; display: flex; align-items: center; gap: 8px; width: 100%;
+  height: 34px; padding: 0 8px; margin-bottom: 4px;
+  border: 0; border-radius: var(--r-sm); background: var(--bg-elevated); color: var(--text-dim);
+  font-size: var(--fs-meta); text-align: left;
 }
-.tt-nav.rail .tt-nav-account.node { position: relative; }
+.tt-nav-node .av { flex: 0 0 auto; display: grid; place-items: center; }
+.tt-nav-node .nm { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
+.tt-nav-node .nd { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; }
+.tt-nav-node .dots { flex: 0 0 auto; display: grid; place-items: center; color: var(--text-dimmer); }
+:where(html[data-pointer="fine"]) .tt-nav-node:hover { background: var(--list-hover); color: var(--text-bright); }
+/* 轨态：只剩方章，状态点叠在右下角（外描底色免得糊在方章边上） */
+.tt-nav.rail .tt-nav-node { width: 34px; justify-content: center; padding: 0; margin: 0 auto 4px; }
+.tt-nav.rail .tt-nav-node .nd { position: absolute; right: 1px; bottom: 1px; box-shadow: 0 0 0 2px var(--bg-base); }
+/* 它和下面的设置/账户是一组，但作用域不同：给一条分隔线把它单独拎出来 */
+.tt-nav-node { margin-bottom: 6px; padding-bottom: 6px; }
+.tt-nav-foot .tt-nav-node { border-bottom: 1px solid var(--border-subtle); border-radius: var(--r-sm); }
 
 /* 选中态：3px 左强调线 + 低饱和蓝底。整块高亮会把注意力从内容上夺走（14 §4.4） */
 .tt-nav-item.on { background: var(--accent-soft); color: var(--text-bright); }

--- a/frontend/src/shell/Navigation.tsx
+++ b/frontend/src/shell/Navigation.tsx
@@ -27,7 +27,7 @@ export type NavGroup = { label: string; items: NavEntry[] }
 
 export function Navigation({
   rail, active, groups, onGo, settings,
-  linkStatus, dock, account, accountName, node, onToggleRail,
+  linkStatus, account, accountName, node, nodeMenu, onToggleRail,
 }: {
   /** 48px 轨态：用户收起 / Focus / 非 large 档 */
   rail: boolean
@@ -37,12 +37,12 @@ export function Navigation({
   /** 设置：是页面，但摆在底部——它跟「概览/项目」不是一类事（14 §4.4） */
   settings: NavEntry
   linkStatus: ReactNode
-  /** 终端开合入口；没有已打开的终端时传 null */
-  dock: { count: number; open: boolean; onToggle: () => void; title: string } | null
   account: MenuProps['items']
   accountName: string
-  /** 多机（连了中心）时给：底座那枚按钮变成机器切换器；单机传 null */
+  /** 多机（连了中心）时给：顶部出现机器切换器；单机传 null，那一块整个不渲染 */
   node: { name: string; mark: ReactNode; dot: string; latency: string } | null
+  /** 切换器下拉里的机器列表（含中心）；单机时不会用到 */
+  nodeMenu: MenuProps['items']
   onToggleRail: () => void
 }) {
   const { t } = useI18n()
@@ -71,6 +71,7 @@ export function Navigation({
       {/* 这里原来还有一枚搜索入口。去掉了：顶栏 Command Center 的搜索横跨整个工作区、
           轨态下也在，侧栏这枚是同一个动作的第二个入口，只是把导航第一屏又占掉一行。 */}
 
+
       <div className="tt-nav-list">
         {groups.map((g) => (
           <div key={g.label} className="tt-nav-group">
@@ -81,35 +82,40 @@ export function Navigation({
       </div>
 
       <div className="tt-nav-foot">
-        {linkStatus}
-        {/* 终端是开关不是页面，所以只给底色不给 3px 强调线——那条线是"当前在哪一页"的语言 */}
-        {dock && (
-          <button type="button" className={`tt-nav-item toggle${dock.open ? ' on' : ''}`} onClick={dock.onToggle} title={dock.title}>
-            <span className="ic">{termIcon}</span>
-            {!rail && <span className="nm">{t('nav.terminal')}</span>}
-            <span className="bd blue">{dock.count}</span>
-          </button>
+        {/* 机器切换器摆在这一组的第一位：底下这几样都是「上下文与账户」，
+            而它是其中作用域最大的一个——切它，上面整列页面看的都换一台机器。
+            单机（没连中心）时整块不渲染，侧栏与今天逐像素一致。 */}
+        {node && (
+          <Dropdown menu={{ items: nodeMenu }} trigger={['click']} placement={rail ? 'topLeft' : 'top'}>
+            <button type="button" className="tt-nav-node"
+              title={`${node.name} · ${node.latency}`}
+              aria-label={t('node.aria.switcher', { name: node.name })}>
+              <span className="av">{node.mark}</span>
+              {!rail && <span className="nm">{node.name}</span>}
+              <i className={`nd${rail ? ' rail' : ''}`} style={{ background: node.dot }} />
+              {!rail && <span className="dots">{chevronDown}</span>}
+            </button>
+          </Dropdown>
         )}
+        {linkStatus}
+        {/* 终端开关不在这儿了：顶栏 Command Center 已经有一枚（还带数量），
+            外加 ⌘J。侧栏这枚是同一个动作的第三个入口，占的还是最贵的那一格。 */}
         {/* 设置摆在这儿而不是账户菜单里：它是一整页，且是这列里唯一天天要开的一页——
             藏在下拉里等于每次进设置都多点一下。菜单里那条随之删掉，一个入口就够。 */}
         {item(settings)}
         {/* 关于 / 主题 / 全屏 / 退出 留在账户菜单：它们是操作不是导航，
             和「概览/项目」并排时，退出登录和切主题的误触代价差了几个数量级 */}
+        {/* 账户按钮回到它本来的样子：这台设备 + 关于/主题/全屏/退出。
+            机器切换已经搬到最上面，这里不再兼两份职。 */}
         <Dropdown menu={{ items: account }} trigger={['click']} placement={rail ? 'topLeft' : 'top'}>
-          {/* 多机时这枚按钮就是机器切换器——它本来说的就是「你连着的这台机器」，
-              多机后终于有了名字。单机时原样保留今天的长相（主机图标 + 「当前设备」）。 */}
-          <button type="button" className={`tt-nav-account${node ? ' node' : ''}`}
-            title={node ? `${node.name} · ${node.latency}` : accountName}
-            aria-label={node ? t('node.aria.switcher', { name: node.name }) : accountName}>
-            <span className="av">{node ? node.mark : hostIcon}</span>
+          <button type="button" className="tt-nav-account" title={accountName} aria-label={accountName}>
+            <span className="av">{hostIcon}</span>
             {!rail && (
               <>
-                <span className="nm">{node ? node.name : accountName}</span>
-                {node && <i className="nd" style={{ background: node.dot }} />}
+                <span className="nm">{accountName}</span>
                 <span className="dots">{moreIcon}</span>
               </>
             )}
-            {node && rail && <i className="nd rail" style={{ background: node.dot }} />}
           </button>
         </Dropdown>
         <button type="button" className="tt-nav-collapse" onClick={onToggleRail}
@@ -124,10 +130,10 @@ export function Navigation({
 
 const stroke = { fill: 'none', stroke: 'currentColor', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }
 const svg = (children: ReactNode) => <svg viewBox="0 0 24 24" width={18} height={18} {...stroke}>{children}</svg>
-const termIcon = svg(<><rect x="3" y="4" width="18" height="16" rx="2" /><line x1="14" y1="4" x2="14" y2="20" /></>)
 // 主机图标而不是姓名首字母：这里代表的是"你连着的这台机器"，不是一个人。
 // 尺寸跟导航项同为 18：整列图标要落在同一条竖线、同一个视觉重量上。
 const hostIcon = svg(<><rect x="3" y="4" width="18" height="12" rx="2" /><path d="M8 20h8" /><path d="M12 16v4" /></>)
+const chevronDown = <svg viewBox="0 0 24 24" width={14} height={14} {...stroke}><polyline points="6 9 12 15 18 9" /></svg>
 const chevronLeft = svg(<polyline points="15 6 9 12 15 18" />)
 const chevronRight = svg(<polyline points="9 6 15 12 9 18" />)
 // 「•••」是三个句点，不是图标：字号下和标点混作一团，也跟不上这一列的线性图标语言


### PR DESCRIPTION
三条都是切到多机之后冒出来的界面问题。

## ① 切过去之后一堆窗口打不开

切机器是整页 `reload()`，而 URL 里的 `?terms=` / `?active=` **原样带了过去**——它们是**上一台机器**的会话 id，于是在新机器上去还原一批根本不存在的标签。同名会话（两台都有 `build` 是常态）还可能连到错的那台。切换前先把这两个参数摘掉。

> 终端**真正的**跨机保留（A 的标签切到 B 仍然留着、各连各的）要等会话键从 `name` 改成 `(nodeId, name)`，那是另一件事。在那之前，切机器就是换一台机器的终端，**但不留残影**。tmux 会话本身一直都在，切回去还能接上。

## ② 底座两块蓝撞在一起

终端开关是蓝的（坞开着），机器方章也是蓝的（`current` 高亮）——两块「选中」上下叠着，像是选了两样东西。而底座那枚方章**永远是当前机器**，`current` 高亮不传递任何信息。改成中性色；蓝留给下拉列表里区分「哪台是当前」，那里才有对比对象。

## ③ 切换器换位置 + 终端开关从侧栏去掉

- **切换器**从账户按钮里拆出来，独立成一枚，摆在底座这一组的**第一位**（设置之上）。底下几样都是「上下文与账户」，而它是其中**作用域最大**的一个——切它，上面整列页面看的都换一台机器，所以和设置/当前设备之间给了条分隔线。
- 顺带解决一个兼职问题：账户按钮原来同时是「当前设备 + 机器切换」，菜单里既有机器列表又有退出登录。现在各归各的，下拉也不用再套「切换机器」分组标题（按钮本身就是标题）。
- **终端开关**从侧栏去掉：顶栏 Command Center 已经有一枚（还带数量），加上 ⌘J，侧栏这枚是同一个动作的**第三个**入口，占的还是最贵的那一格。

单机（没连中心）时切换器整块不渲染，侧栏与今天逐像素一致。

## 验证

真机（公网中心 + 两台节点）上逐条走过：带着 `?terms=aaa,bbb&active=aaa` 切换 → 切完 hash 只剩 `#/projects`、标签数 0；侧栏已无终端开关；切换器下拉列出两台带延迟与状态点；方章是中性灰 + 绿点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)