### PR TITLE
feat(web): 终端标签按机器各记各的，切回来还在

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,7 @@ import SoloTerminal from './components/terminal/SoloTerminal'
 import { ICONS } from './components/nav-icons'
 import { normalizeRoute, setHashParams, readTermTokens } from './route-hash'
 import type { ClaudeInfo } from './components/terminal/claude-info'
+import { dropDeadTokens, loadTabs, saveTabs } from './components/terminal/term-tabs-store'
 import { ExitFullscreenIcon, FullscreenIcon, LogoutIcon, MoonIcon, MoreIcon, SearchIcon, SunIcon } from './icons'
 
 const { Sider, Content } = Layout
@@ -315,7 +316,8 @@ export default function App() {
     if (!sessIds || restored.current) return
     restored.current = true
     const toName = (tok: string) => sessIds.byId[tok] || tok
-    const names = Array.from(new Set(urlTerms.current.map(toName)))
+    // 查无此会话的 id 直接丢：切机器、或会话在别处被关掉，都会在这里长出打不开的空标签
+    const names = Array.from(new Set(dropDeadTokens(urlTerms.current, sessIds.byId).map(toName)))
     if (!names.length) return
     // 用户在 id 表回来之前就点开了标签 → 以他的操作为准，别被 URL 还原顶掉
     setTerms((cur) => (cur.length ? cur : names))
@@ -330,11 +332,15 @@ export default function App() {
   useEffect(() => {
     if (!restored.current) return
     const toTok = (n: string) => sessIds?.byName[n] || n
+    const toks = terms.map(toTok)
+    const activeTok = active ? toTok(active) : ''
     setHashParams({
-      terms: terms.map((n) => encodeURIComponent(toTok(n))).join(','),
-      active: active ? encodeURIComponent(toTok(active)) : '',
+      terms: toks.map(encodeURIComponent).join(','),
+      active: activeTok ? encodeURIComponent(activeTok) : '',
     })
-  }, [terms, active, sessIds])
+    // 同一份东西再按机器存一份：切走了还能切回来（见 term-tabs-store）
+    saveTabs(curNodeId, toks, activeTok)
+  }, [terms, active, sessIds, curNodeId])
 
   // hash 路由：URL #/xxx 与当前页同步（支持前进/后退、刷新保持、收藏分享）
   useEffect(() => {
@@ -566,13 +572,17 @@ export default function App() {
       // 切机器 = 换「浏览 / 新开操作落到哪台」。整页重载是这一版的取舍：页面各自缓存着
       // 上一台的数据，逐个清远比重来一次更容易漏。
       //
-      // **必须先把 terms/active 从 URL 里摘掉**：它们是上一台机器的会话 id，原样带过去
-      // 就会在新机器上还原一批根本不存在的标签——界面上表现为「一堆打不开的窗口」，
-      // 而且同名会话还可能连到错的那台。终端真正的跨机保留要等会话键改成 (nodeId, name)，
-      // 见设计稿；在那之前，切机器就是换一台机器的终端，不留残影。
+      // 切机器 = 换终端。URL 上的 terms/active 是**上一台**的会话 id，原样带过去会在新机器上
+      // 还原一批根本不存在的标签（一堆打不开的窗口，同名会话还可能连错机器）。
+      // 所以这里换成那台机器**自己上次**开着的标签——各记各的，切回来还在（term-tabs-store）。
+      // 兜底还有一层：还原时会把查无此会话的 id 丢掉，关掉的会话不会变成空标签。
       onClick: () => {
+        const back = loadTabs(n.id)
         setCurrentNode(n.id)
-        setHashParams({ terms: '', active: '' })
+        setHashParams({
+          terms: back.terms.map(encodeURIComponent).join(','),
+          active: back.active ? encodeURIComponent(back.active) : '',
+        })
         location.reload()
       },
     })),

--- a/frontend/src/components/terminal/term-tabs-store.test.ts
+++ b/frontend/src/components/terminal/term-tabs-store.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+// 按机器记标签 + 还原时滤掉死 token。
+//
+// 后者是 #190 那个 bug 的护栏：URL 里带着上一台机器的会话 id 切过去，会在新机器上
+// 还原出一堆打不开的空标签。那次是靠「切之前清空」躲掉的，代价是切回来也没了；
+// 现在按机器各记各的，就必须在还原这一步真的把查无此会话的 id 拦下来。
+import { describe, it, expect, beforeEach } from 'vitest'
+import { saveTabs, loadTabs, dropDeadTokens } from './term-tabs-store'
+
+describe('按机器记终端标签', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('两台机器各记各的，互不覆盖', () => {
+    saveTabs('node-a', ['2026-0808-0859-002v'], '2026-0808-0859-002v')
+    saveTabs('node-b', ['2026-0101-1200-aaaa', '2026-0101-1200-bbbb'], '2026-0101-1200-bbbb')
+    expect(loadTabs('node-a').terms).toEqual(['2026-0808-0859-002v'])
+    expect(loadTabs('node-b').terms).toHaveLength(2)
+    expect(loadTabs('node-b').active).toBe('2026-0101-1200-bbbb')
+  })
+
+  it('单机（没有 nodeId）也占一格，不和别人串', () => {
+    saveTabs(null, ['x'], 'x')
+    saveTabs('node-a', ['y'], 'y')
+    expect(loadTabs(null).terms).toEqual(['x'])
+    expect(loadTabs('node-a').terms).toEqual(['y'])
+  })
+
+  it('没记过的机器返回空，不返回别人的', () => {
+    saveTabs('node-a', ['x'], 'x')
+    expect(loadTabs('node-zzz')).toEqual({ terms: [], active: '' })
+  })
+
+  it('最多记 8 台，按最后使用淘汰', () => {
+    for (let i = 0; i < 12; i++) saveTabs('node-' + i, ['t' + i], 't' + i)
+    const kept = Array.from({ length: 12 }, (_, i) => loadTabs('node-' + i).terms.length).filter(Boolean).length
+    expect(kept).toBe(8)
+    expect(loadTabs('node-11').terms).toEqual(['t11']) // 最近的一定在
+    expect(loadTabs('node-0').terms).toEqual([])       // 最早的被挤掉
+  })
+
+  it('localStorage 里是垃圾时按空处理，不抛', () => {
+    localStorage.setItem('roam.terms', '{{{')
+    expect(loadTabs('node-a')).toEqual({ terms: [], active: '' })
+  })
+})
+
+describe('还原前滤掉死 token', () => {
+  const known = { '2026-0808-0859-002v': 'roam-sh' }
+
+  it('这台机器上查无此会话的 id 丢掉', () => {
+    expect(dropDeadTokens(['2026-0808-0859-002v', '2026-0101-1200-dead'], known))
+      .toEqual(['2026-0808-0859-002v'])
+  })
+
+  it('不像 id 的 token 是老链接里的会话名，照旧放行', () => {
+    // 那时 URL 里写的是名字；名字查不到可能只是列表还没刷到，不能当死标签丢
+    expect(dropDeadTokens(['roam-sh', 'dev'], known)).toEqual(['roam-sh', 'dev'])
+  })
+
+  it('全都查无此会话时还原出空，而不是一排空标签', () => {
+    expect(dropDeadTokens(['2026-0101-1200-dead', '2026-0101-1200-gone'], known)).toEqual([])
+  })
+})

--- a/frontend/src/components/terminal/term-tabs-store.ts
+++ b/frontend/src/components/terminal/term-tabs-store.ts
@@ -1,0 +1,76 @@
+// 每台机器各记一份自己开着的终端标签。
+//
+// 切机器是整页重载，而 URL 里的 `terms=` 是**上一台**机器的会话 id：原样带过去会在新机器上
+// 还原一批根本不存在的标签（#190 修的就是这个，办法是切之前清空）。清空的代价是切回来时
+// 上一台开着的终端也没了——人在两台机器之间来回，等于每次都要重开一遍。
+//
+// 这里把「清空」换成「按机器各记各的」：切走前这台的标签已经存下（URL 同步那一步顺手存），
+// 切过去时把那台上次的标签填回 URL，由现有的还原逻辑接手。**同一时刻 dock 里只有当前机器的
+// 标签**——这与「机器切换器是全局唯一的一个」这条 UI 决定一致（见 docs/design/cluster/ui.html）：
+// 页面从不混着画两台机器的东西，终端也不该例外。
+//
+// 存 localStorage 而不是服务端偏好：① 切机器要整页重载，异步偏好回来得太晚
+// （AGENTS.md「Preferences Arrive Late」）；② 这本来就是「这台浏览器上开着哪些窗口」，
+// 跟设备走，不跟账号走。
+
+const KEY = 'roam.terms'
+/** 最多记几台机器的标签——超了按最后使用时间淘汰，别让它无限长 */
+const MAX_NODES = 8
+
+export type TabSet = { terms: string[]; active: string }
+type Entry = TabSet & { at: number }
+
+/** 单机（没有 nodeId）也占一格，键是空串——单机与多机走同一条路径，不写分支 */
+function slot(nodeId: string | null): string {
+  return nodeId || ''
+}
+
+function readAll(): Record<string, Entry> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    const v = raw ? JSON.parse(raw) : null
+    return v && typeof v === 'object' && !Array.isArray(v) ? v : {}
+  } catch { return {} }
+}
+
+function writeAll(all: Record<string, Entry>) {
+  try { localStorage.setItem(KEY, JSON.stringify(all)) } catch { /* 隐私模式/配额满：记不住而已，不该崩 */ }
+}
+
+/** 存一台机器当前开着的标签。terms 是**写进 URL 的那种 token**（会话 id），不是显示名。 */
+export function saveTabs(nodeId: string | null, terms: string[], active: string) {
+  const all = readAll()
+  const cur = slot(nodeId)
+  // at 严格递增，不直接用 Date.now()：切标签是连着来的，同一毫秒内存好几次很正常，
+  // 时间戳一撞，下面的淘汰就只能按 key 顺序瞎猜，可能把刚用过的那台挤掉。
+  const maxAt = Object.values(all).reduce((m, e) => Math.max(m, e?.at || 0), 0)
+  all[cur] = { terms, active, at: Math.max(Date.now(), maxAt + 1) }
+  // 刚写的这台永远留着，只在**其余**里淘汰——否则「存一次就把自己挤掉」是可能的
+  const others = Object.keys(all).filter((k) => k !== cur)
+  if (others.length > MAX_NODES - 1) {
+    others.sort((a, b) => (all[b].at || 0) - (all[a].at || 0))
+    for (const k of others.slice(MAX_NODES - 1)) delete all[k]
+  }
+  writeAll(all)
+}
+
+/** 取一台机器上次开着的标签；没记过就是空。 */
+export function loadTabs(nodeId: string | null): TabSet {
+  const e = readAll()[slot(nodeId)]
+  if (!e || !Array.isArray(e.terms)) return { terms: [], active: '' }
+  return { terms: e.terms.filter((x) => typeof x === 'string' && x), active: typeof e.active === 'string' ? e.active : '' }
+}
+
+/** 会话 id 的形状（后端 internal/id：YYYY-MMDD-HHMM-rand4）。 */
+const ID_RE = /^\d{4}-\d{4}-\d{4}-[a-z0-9]{4}$/
+
+/**
+ * 还原前先滤一遍：**长得像 id 但在这台机器上查无此会话**的一律丢掉。
+ *
+ * 不丢就会长出打不开的空标签——切机器、或者会话在别处被关掉，都会走到这。
+ * 不像 id 的 token 是老链接里存的会话名（那时 URL 写的是名字），照旧放行：
+ * 名字查不到可能只是列表还没刷到。
+ */
+export function dropDeadTokens(tokens: string[], knownIds: Record<string, string>): string[] {
+  return tokens.filter((tok) => !ID_RE.test(tok) || !!knownIds[tok])
+}


### PR DESCRIPTION
> **叠在 #191 上**（它把终端代码搬进了 `components/terminal/`，这一刀改的正是那些文件）。#191 合入后本 PR 的 base 会自动指回 main。

## 问题

#190 修过一个 bug：切机器时 URL 上的 `terms=` 是**上一台**机器的会话 id，原样带过去会在新机器上还原一批根本不存在的标签——界面上就是一堆打不开的窗口，同名会话还可能连错机器。当时的办法是**切之前清空**，代价是切回来时上一台开着的终端也没了：人在两台机器之间来回，每次都得重开一遍。

## 改法

按机器各记各的（`components/terminal/term-tabs-store.ts`）：

- URL 同步那一步顺手把这台机器的标签存进 localStorage，键是 nodeId（单机是空串——**单机与多机同一条路径，不写分支**，和 `nodePath()` 一个原则）
- 切过去时把那台机器**上次**开着的标签填回 URL，交给现有的还原逻辑接手
- 还原前滤一遍 token：长得像会话 id 但这台机器上查无此会话的一律丢掉。这层兜底比切换逻辑本身更靠谱——会话在别处被关掉、链接是别人发的，都会走到这。不像 id 的 token 是老链接里存的会话名，照旧放行（查不到可能只是列表还没刷到）

存 localStorage 而不是服务端偏好：① 切机器要整页重载，异步偏好回来得太晚（AGENTS.md「Preferences Arrive Late」）；② 这本来就是「这台浏览器上开着哪些窗口」，跟设备走不跟账号走。

## 边界：这一刀不做什么

**同一时刻 dock 里只有当前机器的标签**，不混着画两台。这与「机器切换器是全局唯一的一个、页面不各自标机器」那条已定的 UI 决定一致（`docs/design/cluster/ui.html`）。真正的跨机并排（一个 dock 里 A 机器和 B 机器的终端并存）要把会话键一路改成 `(nodeId, name)`、每个标签的 WS/API 各走各的机器，那是另一件事。

## 一个自己撞出来的坑

LRU 淘汰用严格递增的 `at` 而不是裸 `Date.now()`：切标签是连着来的，同一毫秒存好几次很正常，时间戳一撞，淘汰就只能按 key 顺序瞎猜，可能把刚用过的那台挤掉。写测试时撞出来的。

## 验收

- 8 条单测：分机器互不覆盖、单机独占一格、LRU 淘汰、垃圾数据不抛、死 token 过滤（三种情况）
- 浏览器实测两条：URL 里塞两个不存在的会话 id → 标签数 **0**（旧行为会长出两个空标签，URL 也被清干净）；正常开标签 → `roam.terms` 落盘、刷新还原
- `typecheck / i18n / hover / vitest(265) / build` 全过

**没验到的**：跨机切换本身。本机是直连节点口，看不到集群列表；那条路径要在中心（13570）上过一遍，而中心现在跑的是旧构建。合入后我可以部署上去实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)