### PR TITLE
fix(web): URL 没写标签时靠本机记录还原，别把上次开的一笔勾销

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -311,13 +311,21 @@ export default function App() {
     return () => { stop = true; clearInterval(t) }
   }, [authed])
 
-  // 从 URL 还原标签：拿到 id 表后做一次。老链接里存的是名字，id 表里查不到就按名字用。
+  // 还原标签：拿到 id 表后做一次。老链接里存的是名字，id 表里查不到就按名字用。
+  //
+  // **URL 没写标签时回落到本机记的那份**（term-tabs-store）。少了这一步，从书签里打开裸域名
+  // 就是「没有标签」，紧接着这个空集会被写回 store，把上次开着的一笔勾销——等于这台浏览器
+  // 只要从裸域名进过一次，跨机保留就永远失效。URL 是显式的、可分享的句柄，它没说话时
+  // 才轮到本机记忆说话。
   useEffect(() => {
     if (!sessIds || restored.current) return
     restored.current = true
     const toName = (tok: string) => sessIds.byId[tok] || tok
-    // 查无此会话的 id 直接丢：切机器、或会话在别处被关掉，都会在这里长出打不开的空标签
-    const names = Array.from(new Set(dropDeadTokens(urlTerms.current, sessIds.byId).map(toName)))
+    const fromUrl = urlTerms.current
+    const saved = fromUrl.length ? null : loadTabs(curNodeId)
+    if (saved && !urlActive.current) urlActive.current = saved.active
+    // 查无此会话的 id 直接丢：切机器、会话在别处被关掉，都会在这里长出打不开的空标签
+    const names = Array.from(new Set(dropDeadTokens(saved ? saved.terms : fromUrl, sessIds.byId).map(toName)))
     if (!names.length) return
     // 用户在 id 表回来之前就点开了标签 → 以他的操作为准，别被 URL 还原顶掉
     setTerms((cur) => (cur.length ? cur : names))
@@ -326,7 +334,7 @@ export default function App() {
       const a = urlActive.current ? toName(urlActive.current) : ''
       return a && names.includes(a) ? a : names[names.length - 1]
     })
-  }, [sessIds])
+  }, [sessIds, curNodeId])
 
   // 终端状态同步到 URL，刷新后可恢复。写 id；还没有 id 的（刚建、列表未刷新）先退回写名字。
   useEffect(() => {

--- a/frontend/src/components/terminal/term-tabs-store.test.ts
+++ b/frontend/src/components/terminal/term-tabs-store.test.ts
@@ -44,6 +44,28 @@ describe('按机器记终端标签', () => {
   })
 })
 
+// 这条是真机上撞出来的：从书签打开裸域名（URL 上没有 terms=）时，如果不回落到本机记的
+// 那份，还原就是空的，紧接着这个空集会被写回 store，把上次开着的一笔勾销——跨机保留于是
+// 「只在带参数的链接里有效」，等于没有。App.tsx 的还原副作用负责回落，这里钉住 store 侧的契约：
+// 存过就必须读得回来，读回来的顺序也不能乱。
+describe('URL 没写标签时靠 store 兜底', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('存过的原样读回来，顺序不乱', () => {
+    const terms = ['2026-0101-1200-aaaa', '2026-0101-1200-bbbb', '2026-0101-1200-cccc']
+    saveTabs('node-a', terms, '2026-0101-1200-bbbb')
+    const back = loadTabs('node-a')
+    expect(back.terms).toEqual(terms)
+    expect(back.active).toBe('2026-0101-1200-bbbb')
+  })
+
+  it('用户关光了标签就是空——不该被「兜底」复活', () => {
+    saveTabs('node-a', ['2026-0101-1200-aaaa'], '2026-0101-1200-aaaa')
+    saveTabs('node-a', [], '')
+    expect(loadTabs('node-a').terms).toEqual([])
+  })
+})
+
 describe('还原前滤掉死 token', () => {
   const known = { '2026-0808-0859-002v': 'roam-sh' }
 


### PR DESCRIPTION
#192 刚部署到中心就撞出来了 —— 这条只在真的多机环境里才看得见，本地单机永远复现不了。

## 现象

从中心切一次机器，**另一台的标签记录变空**。

## 原因

那份记录是跟着 URL 状态写的：还原只看 URL 上的 `terms=`，而从**书签或裸域名**进来时 URL 上什么都没有 → 还原出空 → 紧接着这个空集被写回 store，把上次开着的一笔勾销。

于是「切回来还在」只在带参数的链接里成立 —— 也就是基本不成立：谁都是从书签打开的。

## 改法

URL 没写标签时回落到本机给这台机器记的那份。URL 是显式的、可分享的句柄，它没说话时才轮到本机记忆说话；用户真把标签关光了，写回的空集仍然是空，不会被「兜底」复活。

## 验收

**在中心上真跑的**（本地直连节点口看不到集群列表，验不了这条）：

1. Jetson 上开一个终端 → store 记在 `n_992b46…` 下
2. 切到开发机 → Jetson 那份**保住了**（改之前这里被清空）
3. 开发机上开一个 → 记在 `n_c2dcd2…` 下
4. 切回 Jetson → **它的终端自己回来了**，xterm 挂上、tmux 输出是活的（画面里是 jetson 的 jtop 和 tegra 内核线程）

另加两条单测钉住 store 侧契约：存过的原样读回来（顺序不乱）、关光了就是空。

🤖 Generated with [Claude Code](https://claude.com/claude-code)