### PR TITLE
feat(backend): 加只绑回环的诊断口（ROAM_PPROF），默认关

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -126,6 +126,11 @@ func main() {
 		TLSEnabled:    tlsOn,
 	}
 
+	// 诊断口：默认不开，ROAM_PPROF=127.0.0.1:6060 才起（只绑回环，见 pprof.go）
+	if a := os.Getenv("ROAM_PPROF"); a != "" {
+		startPprof(a)
+	}
+
 	// 横向扩展模式分流（见 docs/design/cluster/architecture.html §1/§3）：
 	//   - cloud：中心，只做路由 + 注册表 + 控制台，不构造业务 runtime；
 	//   - standard（默认）：现在的单机 Roam；若配了 cluster.broker，则额外出站注册进云端。

--- a/backend/cmd/pprof.go
+++ b/backend/cmd/pprof.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"strings"
+	"time"
+)
+
+// startPprof 按需开一个**只绑回环**的诊断口：ROAM_PPROF=127.0.0.1:6060。
+//
+// 为什么要有这个：2026-08-10 中心在一台 1.6G 内存的机器上涨到 511MB RSS、106% CPU
+// 把自己压死——端口能连、HTTP 不响应、accept 队列积到 586。当时手上只有 ps 和日志，
+// 而 RSS 与线程数说明不了是谁在堆：Go 的 goroutine 复用少量线程，12 个线程照样挂得住
+// 上万个 goroutine。于是只能重启了事，根因带不走。有这个口就能当场取证：
+//
+//	curl -s localhost:6060/debug/pprof/heap > heap.out
+//	curl -s 'localhost:6060/debug/pprof/goroutine?debug=1' | head -60
+//	go tool pprof -top heap.out
+//
+// 默认关闭，且**拒绝非回环地址**：pprof 挂到公网既是信息泄露（源码路径、内存里的内容），
+// 也是现成的打垮入口（一个 profile 请求就能占满 CPU）。要远程看就 ssh 端口转发。
+func startPprof(addr string) {
+	if !loopbackOnly(addr) {
+		log.Printf("ROAM_PPROF=%s 被拒：诊断口只允许绑回环（127.0.0.1 / [::1]），远程请用 ssh -L 转发", addr)
+		return
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+		// profile / trace 本来就要跑满 30 秒，读超时得给够，否则抓不完就被掐断
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      2 * time.Minute,
+	}
+	go func() {
+		log.Printf("诊断口（pprof）监听 http://%s/debug/pprof/", addr)
+		if err := srv.ListenAndServe(); err != nil {
+			log.Printf("诊断口退出: %v", err)
+		}
+	}()
+}
+
+// loopbackOnly 判断监听地址是否只对本机可见。
+// 空 host（":6060"）等于 0.0.0.0，一律拒绝——这正是最容易手滑写出来的那种。
+func loopbackOnly(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/backend/cmd/pprof_test.go
+++ b/backend/cmd/pprof_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+// 诊断口只允许绑回环。这条断言存在的意义是防手滑：":6060" 和 "0.0.0.0:6060" 看着
+// 像「本机」，实际是对全世界开——pprof 暴露在公网既泄露内存内容，也是打垮进程的现成入口。
+func TestLoopbackOnly(t *testing.T) {
+	ok := []string{"127.0.0.1:6060", "localhost:6060", "[::1]:6060", "127.9.9.9:1"}
+	bad := []string{":6060", "0.0.0.0:6060", "[::]:6060", "192.168.1.5:6060", "47.94.183.77:6060", "6060", ""}
+	for _, a := range ok {
+		if !loopbackOnly(a) {
+			t.Errorf("%q 应被允许", a)
+		}
+	}
+	for _, a := range bad {
+		if loopbackOnly(a) {
+			t.Errorf("%q 应被拒绝", a)
+		}
+	}
+}


### PR DESCRIPTION
## 起因

今天中心在一台 1.6G 内存的机器上涨到 **511MB RSS、106% CPU** 把自己压死：端口能连、HTTP 不响应、accept 队列积到 586。而且是我碰巧部署时撞见才发现的 —— 它已经这样卡了不知道多久。

查的时候手上只有 `ps` 和日志。RSS 和线程数说明不了是谁在堆内存：**Go 的 goroutine 复用少量线程，12 个线程照样挂得住上万个 goroutine**（我一开始按线程数推断「不是泄漏」，那个推断是错的）。结果只能重启了事，根因没带走。

## 改动

`ROAM_PPROF=127.0.0.1:6060` 时起一个独立的 pprof 口，下次当场取证：

```
curl -s localhost:6060/debug/pprof/heap > heap.out
curl -s 'localhost:6060/debug/pprof/goroutine?debug=1' | head -60
go tool pprof -top heap.out
```

**默认关闭，且拒绝非回环地址。** pprof 挂公网既泄露内存内容与源码路径，也是现成的打垮入口（一个 profile 请求就占满 CPU）。要远程看用 `ssh -L` 转发。单测钉住这条守卫 —— `":6060"` 和 `"0.0.0.0:6060"` 看着像本机、实际对全世界开，正是最容易手滑写出来的那种。

## 线上已同步做的运维动作（不在代码里）

- 中心从裸 `nohup` 换成 **systemd 单元**：`Restart=always` + `MemoryHigh=300M/MemoryMax=600M`。它正常态 ~20MB，涨到 600M 一定是出问题了 —— 与其把整台机器拖进换页颠簸，不如让内核杀掉、立刻拉起，节点会自动重连。
- 装了 5 分钟一次的健康采样（rss / goroutines / heap / accept 队列 → `health.log`）。**下次要的是增长曲线**：能看出是稳步爬还是某个事件后突然跳，那才是定位泄漏的关键。
- 基线（重启后、两节点在线）：**6→18 goroutine、2.5MB heap、20MB RSS、队列 0**。

根因仍未定位，等曲线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)