### PR TITLE
fix(cluster): 中心反代不再每请求新建 Transport —— 修 goroutine 泄漏

### DIFF
--- a/backend/cluster/hub/hub.go
+++ b/backend/cluster/hub/hub.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"github.com/hashicorp/yamux"
 	"ttmux-web/cluster/tunnel"
 )
 
@@ -25,6 +26,16 @@ type Hub struct {
 
 	publicURL string        // 中心的对外地址（config: cluster.public_url）；空 = 按请求 Host 推
 	enrollTTL time.Duration // 接入令牌有效期（config: cluster.enroll_ttl_min）
+
+	mu      sync.Mutex
+	proxies map[string]*nodeTransport // 每台节点一个复用的 Transport，见 transportFor
+}
+
+// nodeTransport 绑在**某一条隧道会话**上：节点重连会换 session，那时旧的必须整个丢掉，
+// 否则新请求会打进一条已经死掉的隧道。
+type nodeTransport struct {
+	sess *yamux.Session
+	tr   *http.Transport
 }
 
 // SetPublicURL / SetEnrollTTL 由装配处注入，免得 hub 包反过来依赖 config。
@@ -91,6 +102,7 @@ func (b *Hub) HandleTunnel(c *gin.Context) {
 	b.reg.Attach(id, sess, meta)
 	defer func() {
 		b.reg.Detach(id, sess)
+		b.dropTransport(id)
 		_ = sess.Close()
 	}()
 
@@ -242,6 +254,55 @@ func isPrivateURL(raw string) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
 }
 
+// transportFor 返回该节点**复用**的 Transport。
+//
+// 这里曾经是每个请求 new 一个 http.Transport——一个真实的 goroutine 泄漏，2026-08-11
+// 把中心压死过一次（19185 个 goroutine，其中 9572 对 readLoop/writeLoop 卡在
+// yamux.Stream.Read 上，最久的一个挂了 661 分钟；RSS 从 20MB 涨到 300MB，
+// 端口能连但不再 accept）。
+//
+// 机理：Transport 自带空闲连接池。请求结束后那条 yamux 流被放回池里，
+// readLoop/writeLoop 继续挂着等数据；手写的 Transport 的 IdleConnTimeout 默认是 0
+// （永不超时），而这个 Transport 本身又随请求结束被丢掉，没人再调 CloseIdleConnections()。
+// 于是每个经中心代理的请求都留下两个永不退出的 goroutine 和一条永不关闭的流——
+// 控制台每 5 秒轮询一次，一夜就是几千个。
+//
+// 现在按节点缓存并加上超时与上限：空闲流会自己过期回收，池子也不会无限长。
+func (b *Hub) transportFor(id string, sess *yamux.Session) *http.Transport {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.proxies == nil {
+		b.proxies = map[string]*nodeTransport{}
+	}
+	if cur := b.proxies[id]; cur != nil {
+		if cur.sess == sess {
+			return cur.tr
+		}
+		cur.tr.CloseIdleConnections() // 节点重连了：旧隧道上的流全作废
+	}
+	tr := &http.Transport{
+		DialContext:           func(context.Context, string, string) (net.Conn, error) { return sess.Open() },
+		ResponseHeaderTimeout: 30 * time.Second,
+		// 空闲的隧道流最多留 90 秒。yamux 流很便宜，宁可多开也不要攒着——
+		// 攒着的每一条都是一对活 goroutine。
+		IdleConnTimeout:     90 * time.Second,
+		MaxIdleConnsPerHost: 8,
+	}
+	b.proxies[id] = &nodeTransport{sess: sess, tr: tr}
+	return tr
+}
+
+// dropTransport 在隧道断开时清掉该节点的 Transport 与它池里的流。
+func (b *Hub) dropTransport(id string) {
+	b.mu.Lock()
+	cur := b.proxies[id]
+	delete(b.proxies, id)
+	b.mu.Unlock()
+	if cur != nil {
+		cur.tr.CloseIdleConnections()
+	}
+}
+
 // ProxyNode 把 /n/:nodeId/*path 反代进目标节点的隧道流（REST + WebSocket 升级）。
 // 转发本体是 httputil.ReverseProxy（同 backend/browser/devtools.go），只是把底层连接
 // 换成该节点隧道上 Open() 出来的 yamux 流。见架构文档 §7.2。
@@ -254,10 +315,7 @@ func (b *Hub) ProxyNode(c *gin.Context) {
 	}
 	target := &url.URL{Scheme: "http", Host: "node"}
 	rp := httputil.NewSingleHostReverseProxy(target)
-	rp.Transport = &http.Transport{
-		DialContext:           func(context.Context, string, string) (net.Conn, error) { return sess.Open() },
-		ResponseHeaderTimeout: 30 * time.Second,
-	}
+	rp.Transport = b.transportFor(id, sess)
 	rp.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, _ error) {
 		w.WriteHeader(http.StatusBadGateway)
 	}

--- a/backend/cluster/hub/integration_test.go
+++ b/backend/cluster/hub/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -324,5 +325,65 @@ func TestEnrollFlagsPrivateFallback(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&out)
 	if !out.Data.Private {
 		t.Error("127.0.0.1 应被标成内网地址，好提醒「别处的机器接不进来」")
+	}
+}
+
+// TestProxyDoesNotLeakGoroutines 盯的是一个把中心压死过的真事（2026-08-11）：
+// ProxyNode 曾经**每个请求 new 一个 http.Transport**。Transport 自带空闲连接池，请求结束后
+// 那条 yamux 流被放回池里、readLoop/writeLoop 继续挂着等数据；手写 Transport 的
+// IdleConnTimeout 默认是 0（永不超时），而 Transport 本身随请求结束被丢掉，再没人调
+// CloseIdleConnections()。于是每个经中心代理的请求都留下两个永不退出的 goroutine。
+//
+// 线上表现：19185 个 goroutine（9572 对卡在 yamux.Stream.Read，最久的挂了 661 分钟），
+// RSS 从 20MB 涨到 300MB，端口能连但不再 accept——控制台每 5 秒轮询一次，一夜就是几千个。
+//
+// 这里连打 40 个请求，断言 goroutine 增量远小于「每请求 2 个」。不卡死值：并发与运行时
+// 自己的 goroutine 都会浮动，只要不是线性增长就行（泄漏时这里会 +80 以上）。
+func TestProxyDoesNotLeakGoroutines(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	brk := hub.New(t.TempDir())
+
+	r := gin.New()
+	r.GET("/cluster/tunnel", brk.HandleTunnel)
+	r.POST("/api/hub/enroll", brk.Enroll)
+	r.GET("/api/hub/nodes", brk.Nodes)
+	r.Any("/n/:nodeId/*path", brk.ProxyNode)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := enroll(t, srv.URL)
+	biz := http.NewServeMux()
+	biz.HandleFunc("/api/ping", func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, "pong") })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cl := &node.Client{
+		Hub: srv.URL, Token: token, Name: "leak-node", Version: "test",
+		CredPath: filepath.Join(t.TempDir(), "node.json"), Handler: biz,
+	}
+	go cl.Run(ctx)
+	id := waitOnline(t, srv.URL)
+
+	get := func() {
+		resp, err := http.Get(srv.URL + "/n/" + id + "/api/ping")
+		if err != nil {
+			t.Fatalf("反代请求失败: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	get() // 预热：第一次会建隧道流、起 readLoop，那一份不算泄漏
+	time.Sleep(200 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	const n = 40
+	for i := 0; i < n; i++ {
+		get()
+	}
+	time.Sleep(500 * time.Millisecond) // 给收尾的 goroutine 一点退出时间
+	grew := runtime.NumGoroutine() - before
+
+	if grew > n { // 泄漏时是 2n（80）；复用时基本是 0，留足并发抖动的余量
+		t.Fatalf("%d 个反代请求后 goroutine 增长 %d，疑似每请求泄漏（复用 Transport 时应接近 0）", n, grew)
 	}
 }


### PR DESCRIPTION
中心今天第二次卡死：端口能连、HTTP 不响应、accept 队列积压。昨天补的诊断口（#194）这次抓到了现场。

## 根因

`ProxyNode` **每个请求 new 一个 `http.Transport`**。

Transport 自带空闲连接池：请求结束后那条 yamux 流被放回池里，`readLoop`/`writeLoop` 继续挂着等数据。而手写 Transport 的 `IdleConnTimeout` 默认是 **0（永不超时）**，Transport 本身又随请求结束被丢掉，再没人调 `CloseIdleConnections()`。于是**每个经中心代理的请求 = 2 个永不退出的 goroutine + 1 条永不关闭的流**。控制台每 5 秒轮询一次，一夜攒几千个。

## 现场

SIGQUIT 全量栈：**19185 个 goroutine**，其中 **9572 对**卡在

```
yamux.(*Stream).Read  ←  net/http.(*persistConn).readLoop
created by net/http.(*Transport).dialConn
```

最久的一个挂了 **661 分钟**。健康采样把曲线拍得很清楚：

```
09:50  rss  38MB  goroutine  1518
09:55  rss  64MB  goroutine  2667
10:00  rss 148MB  goroutine  7126
10:20  rss 294MB  goroutine 18298
10:25  rss 299MB  goroutine   ?     acceptq  73   ← 采样自己都取不到了
```

## 改法

按节点缓存 Transport，绑在**隧道会话**上（节点重连即换掉旧的并 `CloseIdleConnections`），并加 `IdleConnTimeout=90s` + `MaxIdleConnsPerHost=8` —— 空闲的隧道流会自己过期，池子不会无限长。隧道断开时 `dropTransport` 清干净。

## 回归测试

连打 40 个反代请求，断言 goroutine 不线性增长。**验证过它抓得住**：退回旧写法跑这条用例增长 **120**（=2×40+抖动），装上修复接近 **0**。

线上同样实测：登录后连打 80 个真反代请求（均 200），goroutine **20 → 20**。

## 一条运维教训（已在线上纠正）

昨天设的 `MemoryHigh=300M` 反而让事情更糟：内核把进程压在 300M 反复回收，它爬得动却**永远够不到 `MemoryMax=600M`**，`Restart=always` 一次都没触发 —— 从「撑爆重启」变成「慢性绞死」，连 SIGQUIT 打栈都写不完（8 秒 8 行）。已解除 `MemoryHigh`，只留 `MemoryMax` 兜底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)