### PR TITLE
fix(web): 懒加载失败自动重试 · 标签文字不再被裁 · 切换器下拉重排

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@
 //   电脑 ≥1200 → 三栏：导航 Sider | 列表(页面) | 终端面板(常驻, 多标签)
 //   平板/手机   → 终端为全屏覆盖层；手机底部 Tab 导航
 // 终端：多标签 / 字号调节 / 复制 / 更多快捷键 / 断线自动重连。
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { bootstrapCluster, setCurrentNode, useClusterNodes, useCurrentNodeId } from './components/cluster/node-url'
 import { NodeMark, nodeDotColor } from './components/cluster/NodeMark'
 import {
@@ -23,15 +23,15 @@ import MobileSubPage from './components/MobileSubPage'
 import SettingsPage from './components/settings/SettingsPage'
 // 非首屏的重页面（蜂群/Git 面板/浏览器/手机镜像/插件）按路由懒加载：切到对应 tab 才拉 chunk，
 // 缩小首屏 index 块。都渲染在同一个 Suspense 边界内（见 lazyFallback，App 内 page）。
-const GitPanel = lazy(() => import('./components/git/GitPanel'))
-const WorktreePanel = lazy(() => import('./components/git/WorktreePanel'))
-const RaceCreateModal = lazy(() => import('./components/swarm/Race').then((m) => ({ default: m.RaceCreateModal })))
-const RaceComparePanel = lazy(() => import('./components/swarm/Race').then((m) => ({ default: m.RaceComparePanel })))
-const PluginsPanel = lazy(() => import('./components/plugins/PluginsPanel'))
-const BrowserView = lazy(() => import('./components/mirror/BrowserView'))
-const PhoneView = lazy(() => import('./components/mirror/PhoneView'))
-const Swarm = lazy(() => import('./components/swarm/Swarm'))
-const Projects = lazy(() => import('./components/projects/Projects'))
+const GitPanel = lazyRetry(() => import('./components/git/GitPanel'))
+const WorktreePanel = lazyRetry(() => import('./components/git/WorktreePanel'))
+const RaceCreateModal = lazyRetry(() => import('./components/swarm/Race').then((m) => ({ default: m.RaceCreateModal })))
+const RaceComparePanel = lazyRetry(() => import('./components/swarm/Race').then((m) => ({ default: m.RaceComparePanel })))
+const PluginsPanel = lazyRetry(() => import('./components/plugins/PluginsPanel'))
+const BrowserView = lazyRetry(() => import('./components/mirror/BrowserView'))
+const PhoneView = lazyRetry(() => import('./components/mirror/PhoneView'))
+const Swarm = lazyRetry(() => import('./components/swarm/Swarm'))
+const Projects = lazyRetry(() => import('./components/projects/Projects'))
 import UpdateBanner from './components/UpdateBanner'
 import { useThemeMode } from './theme'
 import { useI18n } from './i18n'
@@ -63,6 +63,7 @@ import { normalizeRoute, setHashParams, readTermTokens } from './route-hash'
 import type { ClaudeInfo } from './components/terminal/claude-info'
 import { dropDeadTokens, loadTabs, saveTabs } from './components/terminal/term-tabs-store'
 import { ExitFullscreenIcon, FullscreenIcon, LogoutIcon, MoonIcon, MoreIcon, SearchIcon, SunIcon } from './icons'
+import { lazyRetry } from './components/lazy-retry'
 
 const { Sider, Content } = Layout
 const { Text } = Typography
@@ -585,14 +586,14 @@ export default function App() {
   const nodeItems: MenuProps['items'] = clusterNodes.length ? [
     ...clusterNodes.map((n) => ({
       key: 'node:' + n.id,
-      icon: <NodeMark name={n.name} size="sm" current={n.id === curNodeId} offline={!n.online} />,
+      // 方章不走 antd 的 icon 槽：那个槽的间距归 antd 管，实测方章会贴着名字（「JE|Jetson」）。
+      // 整行自己排，间距用令牌，样式在 index.css 的 .tt-nodemenu 段。
       label: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, minWidth: 168 }}>
-          <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>{n.name}</span>
-          <span style={{ fontFamily: 'var(--mono)', fontSize: 'var(--fs-micro)', color: 'var(--text-dimmer)' }}>
-            {n.online ? t('node.latencyMs', { ms: n.latencyMs }) : t('node.offline')}
-          </span>
-          <i style={{ width: 7, height: 7, borderRadius: '50%', background: nodeDotColor(n) }} />
+        <span className={`tt-nodemenu${n.id === curNodeId ? ' on' : ''}`}>
+          <NodeMark name={n.name} size="sm" current={n.id === curNodeId} offline={!n.online} />
+          <span className="nm">{n.name}</span>
+          <span className="lat">{n.online ? t('node.latencyMs', { ms: n.latencyMs }) : t('node.offline')}</span>
+          <i className="dot" style={{ background: nodeDotColor(n) }} />
         </span>
       ),
       disabled: !n.online,

--- a/frontend/src/components/files/fileview/CodeView.tsx
+++ b/frontend/src/components/files/fileview/CodeView.tsx
@@ -1,9 +1,10 @@
 // 文本/代码/JSON/Markdown(源码) → Monaco 编辑器（行号、语法高亮、可编辑；截断的大文件只读）。
 // Monaco 很重 → 懒加载，不进首屏包。tab 语境下全屏无边框，背景由 CodeEditor 统一成应用底色。
-import { lazy, Suspense } from 'react'
+import {Suspense } from 'react'
 import { Spin } from 'antd'
+import { lazyRetry } from '../../lazy-retry'
 
-const CodeEditor = lazy(() => import('../CodeEditor'))
+const CodeEditor = lazyRetry(() => import('../CodeEditor'))
 
 export function CodeView({ value, language, dark, readOnly, tabbed, height, onChange, onSave, revealLine }: {
   value: string

--- a/frontend/src/components/files/fileview/OfficeView.tsx
+++ b/frontend/src/components/files/fileview/OfficeView.tsx
@@ -1,15 +1,16 @@
 // Office 文档展示：docx / xlsx / pptx 各有专用前端渲染器（很重，懒加载）；其余 Office
 // 类型（doc/xls/ppt/odt…）走后端 soffice 转 PDF 再内嵌。
-import { lazy, Suspense, useEffect, useState } from 'react'
+import {Suspense, useEffect, useState } from 'react'
 import { Button, Spin } from 'antd'
 import { PreviewShell } from './PreviewShell'
 import { useI18n } from '../../../i18n'
 import { type FileKind } from '../file-utils'
+import { lazyRetry } from '../../lazy-retry'
 
 const OfficePreviewers = () => import('../OfficePreviewers')
-const DocxFilePreview = lazy(() => OfficePreviewers().then((m) => ({ default: m.DocxFilePreview })))
-const ExcelFilePreview = lazy(() => OfficePreviewers().then((m) => ({ default: m.ExcelFilePreview })))
-const PptxFilePreview = lazy(() => OfficePreviewers().then((m) => ({ default: m.PptxFilePreview })))
+const DocxFilePreview = lazyRetry(() => OfficePreviewers().then((m) => ({ default: m.DocxFilePreview })))
+const ExcelFilePreview = lazyRetry(() => OfficePreviewers().then((m) => ({ default: m.ExcelFilePreview })))
+const PptxFilePreview = lazyRetry(() => OfficePreviewers().then((m) => ({ default: m.PptxFilePreview })))
 
 // 后端 soffice 转 PDF 后内嵌（doc/xls/ppt/odt 等无专用前端渲染器的类型）。
 function OfficePdfPreview({ name, previewUrl, rawUrl, downloadUrl, downloadName, height }: { name: string; previewUrl: string; rawUrl: string; downloadUrl: string; downloadName: string; height: string }) {

--- a/frontend/src/components/git/GitPanel.tsx
+++ b/frontend/src/components/git/GitPanel.tsx
@@ -4,7 +4,7 @@
 // 对比 base（仅 worktree 会话）。详情列二选一：文件差异 或 提交详情，宽屏贴面板左侧、窄屏整屏推入。
 //
 // 本文件只做编排：取数、状态、菜单、危险操作确认；渲染都在 ./git/* 里。
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dropdown, Input, Popover, Segmented, Spin, Tag, Tooltip, App as AntApp } from 'antd'
 import type { MenuProps } from 'antd'
 import { api } from '../../api'
@@ -24,8 +24,9 @@ import { InspectorLayers, type LayerSize } from '../shell/InspectorLayers'
 import { useBackDismiss } from '../shell/useBackDismiss'
 import { CheckIcon, ChevronDown, ChevronRight, WarnIcon } from '../../icons'
 import { WindowsIcon } from '../../icons'
+import { lazyRetry } from '../lazy-retry'
 
-const WorktreePanel = lazy(() => import('./WorktreePanel'))
+const WorktreePanel = lazyRetry(() => import('./WorktreePanel'))
 
 interface GitFile { path: string; orig?: string; index: string; work: string; staged: boolean; untracked: boolean }
 interface GitCommit { hash: string; short: string; subject: string; author: string; when: string }

--- a/frontend/src/components/lazy-retry.test.ts
+++ b/frontend/src/components/lazy-retry.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+// 懒加载重试。这条护栏来自线上实测：中心日志里 217 次 `unknown certificate`，
+// 其中用户那台机器**同一秒被拒 6 次**——自签证书下 Chrome 的「继续前往」只对已建立的连接
+// 放行，而懒加载会为并行取 chunk 开新连接。于是「时好时坏」，点重试又往往就好了。
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { lazyRetry } from './lazy-retry'
+
+// React.lazy 只在渲染时才调 loader，这里直接把它交给 lazy 的那个函数拎出来跑：
+// _payload._result 是 React 内部存 loader 的地方（版本相关，拿不到就跳过断言）。
+function loaderOf(comp: any): (() => Promise<any>) | null {
+  const p = comp?._payload
+  return typeof p?._result === 'function' ? p._result : null
+}
+
+describe('懒加载重试', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('第一次握手失败、第二次成功 → 救回来，调用方无感', async () => {
+    let n = 0
+    const load = vi.fn(async () => {
+      if (++n === 1) throw new Error('Failed to fetch dynamically imported module')
+      return { default: (() => null) as any }
+    })
+    const loader = loaderOf(lazyRetry(load))
+    expect(loader).toBeTruthy()
+    const p = loader!()
+    await vi.advanceTimersByTimeAsync(300)
+    await expect(p).resolves.toHaveProperty('default')
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('一直失败 → 最终抛出去给 ErrorBoundary，不是无限重试', async () => {
+    const load = vi.fn(async () => { throw new Error('chunk 404') })
+    const loader = loaderOf(lazyRetry(load))
+    const p = loader!().catch((e: Error) => e.message)
+    await vi.advanceTimersByTimeAsync(2000)
+    await expect(p).resolves.toBe('chunk 404')
+    expect(load).toHaveBeenCalledTimes(3) // 首次 + 两次退避重试
+  })
+
+  it('一次就成的不会多调一次', async () => {
+    const load = vi.fn(async () => ({ default: (() => null) as any }))
+    const loader = loaderOf(lazyRetry(load))
+    await loader!()
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/lazy-retry.ts
+++ b/frontend/src/components/lazy-retry.ts
@@ -1,0 +1,33 @@
+// 懒加载 chunk 的重试外壳。
+//
+// 为什么需要：自签 HTTPS 下，Chrome 的「继续前往」只对**已经建立的那条连接**放行。
+// 懒加载会为并行取 chunk 开新的 TLS 连接，新连接照样验证证书、照样被拒——于是
+// 同一秒里能看到六次 `remote error: tls: unknown certificate`（中心日志实测），
+// 而页面上就是那句「组件加载失败」。命中连接复用时一切正常，开新连接就翻车，
+// 所以它表现为**时好时坏**，点一下「重试」又往往就好了。
+//
+// 根治办法是信任那张 CA（控制台 设置 → 安全 → 下载证书，或直接取 /cert.crt）。
+// 但「一条连接被拒 = 整页功能打不开」本身就太脆：这里退避重试两次，把偶发的握手失败
+// 变成一次看不见的停顿。真正的失败（chunk 被删、断网）仍会抛出去给 ErrorBoundary。
+//
+// 不缓存失败的 Promise：React.lazy 会记住 rejected 的那次，重试必须发生在它里面。
+import { lazy, type ComponentType } from 'react'
+
+const DELAYS = [250, 900] // 两次退避：够跨过一次握手抖动，又不至于让用户干等
+
+export function lazyRetry<T extends ComponentType<any>>(
+  load: () => Promise<{ default: T }>,
+): React.LazyExoticComponent<T> {
+  return lazy(async () => {
+    let last: unknown
+    for (let i = 0; i <= DELAYS.length; i++) {
+      try {
+        return await load()
+      } catch (e) {
+        last = e
+        if (i < DELAYS.length) await new Promise((r) => setTimeout(r, DELAYS[i]))
+      }
+    }
+    throw last
+  })
+}

--- a/frontend/src/components/markdown/Markdown.tsx
+++ b/frontend/src/components/markdown/Markdown.tsx
@@ -1,10 +1,11 @@
 // Markdown 渲染链（react-markdown + unified/micromark/hast 生态 + highlight.js）约 80KB gz，
 // 首屏（终端/列表）用不到 → 实现放 MarkdownImpl.tsx 整体懒加载，真要渲染对话文本/.md 预览才拉取。
 // chunk 到位前先按纯文本展示同样的内容，到位后无缝升级为富文本，不闪加载态。
-import { lazy, Suspense } from 'react'
+import {Suspense } from 'react'
 import type { ComponentProps } from 'react'
+import { lazyRetry } from '../lazy-retry'
 
-const Impl = lazy(() => import('./MarkdownImpl'))
+const Impl = lazyRetry(() => import('./MarkdownImpl'))
 
 export default function Markdown(props: ComponentProps<typeof Impl>) {
   return (

--- a/frontend/src/components/markdown/MarkdownImpl.tsx
+++ b/frontend/src/components/markdown/MarkdownImpl.tsx
@@ -4,12 +4,13 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import type { CSSProperties, MouseEvent } from 'react'
-import { lazy, Suspense } from 'react'
+import {Suspense } from 'react'
 import { CodeBox } from '../chat/blocks'
 import { useI18n } from '../../i18n'
+import { lazyRetry } from '../lazy-retry'
 
 // Mermaid 组件连同其重依赖(mermaid/d3/cytoscape…)整体懒加载，只有真渲染 ```mermaid 才拉取，不进首屏。
-const Mermaid = lazy(() => import('./Mermaid'))
+const Mermaid = lazyRetry(() => import('./Mermaid'))
 
 const mono = 'ui-monospace, SFMono-Regular, Menlo, monospace'
 

--- a/frontend/src/components/projects/Projects.tsx
+++ b/frontend/src/components/projects/Projects.tsx
@@ -7,7 +7,7 @@
 // 视觉基调：终端工业风的克制精修——居中 880px 阅读列、composer 是全页唯一 hero
 // （渐变卡面 + focus 辉光环）、git 数据一律等宽字、行 hover 左导轨渐显、
 // 分区头沿用设计图纸体例、入场一次性 stagger。全部颜色走 index.css token。
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
+import {Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { App as AntApp, AutoComplete, Button, Dropdown, Input, Modal, Popconfirm, Segmented, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd'
 import type { InputRef, MenuProps } from 'antd'
@@ -35,12 +35,13 @@ import { useSwarmProjection, normDir } from './project-list/swarm-projection'
 import FileBrowser from '../files/FileBrowser'
 import { AgentLogo, ArchiveIcon, ArrowDown, ArrowUp, CheckIcon, ChevronDown, CircleIcon, CloseIcon, DiffIcon, ForkIcon, MergeIcon, PaperclipIcon, PlayIcon, PlusIcon, PushIcon, SwarmIcon, TerminalIcon, TrashIcon, WarnIcon, WindowsIcon } from '../../icons'
 import { BranchIcon } from '../git/parts'
+import { lazyRetry } from '../lazy-retry'
 
-const WorktreePanel = lazy(() => import('../git/WorktreePanel'))
-const GitPanel = lazy(() => import('../git/GitPanel'))
-const RaceCreateModal = lazy(() => import('../swarm/Race').then((m) => ({ default: m.RaceCreateModal })))
-const RaceComparePanel = lazy(() => import('../swarm/Race').then((m) => ({ default: m.RaceComparePanel })))
-const NewSwarmModal = lazy(() => import('../swarm/Swarm').then((m) => ({ default: m.NewSwarmModal })))
+const WorktreePanel = lazyRetry(() => import('../git/WorktreePanel'))
+const GitPanel = lazyRetry(() => import('../git/GitPanel'))
+const RaceCreateModal = lazyRetry(() => import('../swarm/Race').then((m) => ({ default: m.RaceCreateModal })))
+const RaceComparePanel = lazyRetry(() => import('../swarm/Race').then((m) => ({ default: m.RaceComparePanel })))
+const NewSwarmModal = lazyRetry(() => import('../swarm/Swarm').then((m) => ({ default: m.NewSwarmModal })))
 
 // 项目列表排序模式（置顶恒在最前；选择持久化）。
 // 「需要你」是默认档——概览并进来之后，首屏第一问是「该做什么」，不是「按名字排一排」。

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1260,6 +1260,10 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
 /* 名字中间省略：头段收缩 + 尾段不收缩，省略号自然落在中间（见 session-label.tsx TabName） */
 /* 这几条对 .tt-name 通用——标签条和手机会话页胶囊共用同一个 TabName。
    之前只挂在 .tt-tab 下，胶囊里的标题就换行了，把 50px 的顶栏撑成两行。 */
+/* 行盒要给足：line-height:1 时行盒正好等于字号（12/12），而 12px 中文的实际墨迹要 13px，
+   于是 overflow:hidden 把 CJK 的下缘和 g/p/y 的降部削掉一截（真机上「config-split」缺半截）。
+   标签高度写死 34，行盒长高不会把标签条撑高。 */
+.tt-name, .tt-name .h, .tt-name .tl, .tt-name .pj { line-height: 1.45; }
 .tt-name { display: flex; min-width: 0; overflow: hidden; white-space: nowrap; }
 .tt-name .h { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tt-name .tl { flex: 0 0 auto; }
@@ -2922,3 +2926,28 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   .tt-set-row { padding: var(--sp-2) 0 var(--sp-3); }
 }
 .tt-set-bare { padding-top: var(--sp-2); }
+
+/* ── 机器切换器的下拉行（侧栏底座那枚按钮弹出来的列表）─────────────────
+   方章原来走 antd 的 icon 槽，间距归 antd 管，实测贴着名字（「JE|Jetson」）；
+   而「当前是哪台」只靠方章一圈蓝边示意，行本身毫无表达——两台机器摆在一起时
+   得眯着眼找。现在整行自己排：当前那台给 --accent-soft 底 + 亮字，
+   延迟走 mono 右对齐，状态点收尾。 */
+.tt-nodemenu {
+  display: flex; align-items: center; gap: var(--sp-2);
+  min-width: 208px; margin: 0 -4px; padding: 2px 4px; border-radius: var(--r-xs);
+}
+.tt-nodemenu .nm {
+  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--text-dim);
+}
+.tt-nodemenu.on { background: var(--accent-soft); }
+.tt-nodemenu.on .nm { color: var(--text-bright); font-weight: 500; }
+.tt-nodemenu .lat {
+  flex: 0 0 auto; font-family: var(--mono); font-size: var(--fs-micro); color: var(--text-dimmer);
+  font-variant-numeric: tabular-nums;
+}
+.tt-nodemenu .dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; }
+/* 手指档：这一列是「点错就换了台机器」的地方，命中区必须到 44 */
+@media (pointer: coarse) {
+  .ant-dropdown-menu-item:has(.tt-nodemenu) { min-height: var(--tap); }
+}


### PR DESCRIPTION
今天在中心上暴露的三个前端问题，同一批修补。

## ① 懒加载 chunk 失败 = 整页报错

自签 HTTPS 下 Chrome 的「继续前往」只对**已经建立的那条连接**放行，而懒加载会为并行取 chunk 另开新的 TLS 连接 —— 新连接照样验证、照样被拒。中心日志里 **217 次** `remote error: tls: unknown certificate`，用户那台机器**同一秒被拒 6 次**；页面上就是那句「组件加载失败」。命中连接复用就正常、开新连接就翻车，所以它表现为**时好时坏**，点一下「重试」又往往就好。

根治是信任那张 CA（控制台 设置 → 安全 → 下载证书，或 `/cert.crt`），但「一条连接被拒 = 整页功能打不开」本身太脆：21 处懒加载统一包一层退避重试（250ms / 900ms），把偶发握手失败变成一次看不见的停顿；真失败（chunk 没了、断网）仍抛给 ErrorBoundary，不会无限重试。3 条单测钉住三种走向。

## ② 终端标签的文字被裁掉一截

`.tt-name` 的 `line-height: 1` 让行盒正好等于字号（12/12），而 12px 中文的实际墨迹要 13px，`overflow:hidden` 于是削掉 CJK 下缘和 g/p/y 的降部（真机上「config-split」缺半截）。改成 1.45：**实测 17/17 不再裁**，标签高度仍是写死的 34，标签条不变高。

## ③ 切换器下拉重排

方章走 antd 的 `icon` 槽，间距归 antd 管，实测贴着名字（「JE|Jetson」）；而「当前是哪台」只靠方章一圈蓝边示意，两台摆一起得眯着眼找。现在整行自排：令牌间距、当前行给 `--accent-soft` 底 + 亮字、延迟 mono 右对齐、宽度不写死、手指档命中区补到 44。

🤖 Generated with [Claude Code](https://claude.com/claude-code)