### PR TITLE
fix(files): HTML「新标签打开」改走 /file/serve，页面不再裸奔

### DIFF
--- a/frontend/src/components/files/fileview/FileView.tsx
+++ b/frontend/src/components/files/fileview/FileView.tsx
@@ -172,8 +172,10 @@ export function FileView({
       {(isMd || isHtml) && data && !data.binary && (
         <Button size="small" onClick={() => setSource((s) => !s)}>{source ? t('file.rendered') : t('file.source')}</Button>
       )}
+      {/* 新标签同样走 serveUrl：/file/raw?path= 下，页面里的 shared.css 会被浏览器解析成
+          /api/file/shared.css 而 404，整页裸奔（设计稿只剩黑三角）。见 HtmlView 的同款理由。 */}
       {isHtml && (
-        <Button size="small" href={rawUrl} target="_blank" rel="noreferrer">{t('file.openInNewTab')}</Button>
+        <Button size="small" href={serveUrl} target="_blank" rel="noreferrer">{t('file.openInNewTab')}</Button>
       )}
       {onOpenAgent && (
         <Button size="small" onClick={() => setAgentPick(true)}>{t('file.openInAgent')}</Button>
@@ -250,7 +252,7 @@ export function FileView({
               )}
               {isHtml && (
                 <Tooltip title={t('file.openInNewTab')} placement="bottom">
-                  <Button type="text" size="small" href={rawUrl} target="_blank" rel="noreferrer" style={{ color: 'var(--text-dim)', width: 28, height: 28, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><ExternalLinkIcon /></Button>
+                  <Button type="text" size="small" href={serveUrl} target="_blank" rel="noreferrer" style={{ color: 'var(--text-dim)', width: 28, height: 28, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}><ExternalLinkIcon /></Button>
                 </Tooltip>
               )}
             </div>


### PR DESCRIPTION
## 现象

文件面板里预览设计稿好好的，点「新标签打开」就只剩一个黑三角 —— 整页没有样式。

## 原因

同一份文件，两个入口用了**两种地址**：

| 入口 | 地址 | 页面里的 `href="shared.css"` 解析成 |
|---|---|---|
| 面板 iframe（`HtmlView`） | `/api/file/serve/<绝对路径>` | `…/docs/design/tv/shared.css` ✅ |
| 新标签打开（两处） | `/api/file/raw?path=<路径>` | `/api/file/shared.css` ❌ 404 |

`?path=` 这种查询参数形式，浏览器解析相对引用时只会拿掉最后一段路径，跟文件真实所在目录没有关系。后端本来就为这件事写了 `/file/serve/*path`（把绝对路径编进 URL 路径），只是新标签这两个入口漏了。

## 改动

`FileView.tsx` 两处 `href={rawUrl}` → `href={serveUrl}`：工具栏的「新标签打开」按钮，以及 tab 右上角那个外链图标钮。

## 验证

实测 `1-home.html`（引用 `href="shared.css"`）：

```
/api/file/shared.css               404   ← 旧地址会去要的
/api/file/serve/<dir>/shared.css   200   ← 新地址会去要的
```

改后用真浏览器打开新标签地址：`styleSheets=2`、`cssRules=108`、title 正常，渲染结果与面板内预览一致。

`vitest 279 passed` / typecheck / i18n / hover / build 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)