### PR TITLE
fix(chrome-cli): chrome CLI 跟着「浏览器」设置走 · 同 profile 只留一台 Chrome

### DIFF
--- a/backend/browser/browser.go
+++ b/backend/browser/browser.go
@@ -48,6 +48,11 @@ var (
 
 func setLastErr(s string) { statusMu.Lock(); lastErr = s; statusMu.Unlock() }
 
+// cdpHTTP 专用于 CDP 的 HTTP 端点（/json*）。必须带超时：默认 http.Get 没有超时，端口上要是
+// 蹲了个「只监听不回话」的进程（占了 9222 的非 Chrome 程序），探活就永久挂住——alive() 在
+// /browser/tabs 轮询和 ensureChrome 的等待循环里都调，一挂就是整条请求链卡死。
+var cdpHTTP = &http.Client{Timeout: 3 * time.Second}
+
 // cdpPort 解析 CDPBase 里的端口；解析失败回落 9222。
 func cdpPort() int {
 	if u, err := url.Parse(CDPBase); err == nil {
@@ -141,7 +146,9 @@ func ensureChrome() error {
 	running := chrome != nil && chrome.Process != nil
 	procMu.Unlock()
 	if running || time.Since(lastLaunch) < 12*time.Second {
-		for i := 0; i < 30; i++ {
+		// 按总时限等而不是按次数：探活自身可能要等满超时（端口被「只监听不回话」的进程占着），
+		// 按次数写就是 30 × 超时，把整条 HTTP 请求拖成分钟级。
+		for deadline := time.Now().Add(3 * time.Second); time.Now().Before(deadline); {
 			if alive() {
 				return nil
 			}
@@ -150,6 +157,20 @@ func ensureChrome() error {
 		err := fmt.Errorf("Chrome 启动中或上次未就绪，调试端口 %s 暂未就绪", CDPBase)
 		setLastErr(err.Error())
 		return err
+	}
+
+	cfg := effectiveConfig() // Settings 里存的值 > env > 默认
+
+	// 单实例优先：同 profile 的 Chrome 已经在跑，只是调试端口不是我们记着的那个 → 附着它。
+	// 同 user-data-dir 的 Chrome 是单例，这时候再拉一个只会把命令行转交给它然后自己退出，
+	// 端口永远不开；与其报「启动后随即退出」，不如认下这台（chrome CLI 读同一份端口记录，
+	// 跟着一起走）。固定端口模式是用户显式钉死的地址，不替他改。
+	if !cdpFixed {
+		if p := profileInstancePort(cfg.Profile); p > 0 && p != cdpPort() && aliveAt(p) {
+			setCDPPort(p)
+			setLastErr("")
+			return nil
+		}
 	}
 
 	// 端口选择：当前端口被别的进程占着（且不是可用 Chrome，否则上面 alive 已 attach）→ 换一个空闲端口，
@@ -162,7 +183,6 @@ func ensureChrome() error {
 		}
 	}
 
-	cfg := effectiveConfig() // Settings 里存的值 > env > 默认
 	args := []string{
 		"--remote-debugging-port=" + strconv.Itoa(port),
 		"--remote-debugging-address=127.0.0.1",
@@ -220,7 +240,7 @@ func ensureChrome() error {
 		}
 		procMu.Unlock()
 	}()
-	for i := 0; i < 50; i++ { // 最多等 5s
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); { // 最多等 5s（含探活自身耗时）
 		if alive() {
 			setLastErr("") // 就绪：清掉上次错误
 			return nil
@@ -258,7 +278,7 @@ func Shutdown() {
 }
 
 func alive() bool {
-	resp, err := http.Get(CDPBase + "/json/version")
+	resp, err := cdpHTTP.Get(CDPBase + "/json/version")
 	if err != nil {
 		return false
 	}
@@ -266,10 +286,57 @@ func alive() bool {
 	return resp.StatusCode == http.StatusOK
 }
 
+// aliveAt 探某个端口上有没有在应答的 CDP（不动 CDPBase）。
+func aliveAt(port int) bool {
+	resp, err := cdpHTTP.Get(fmt.Sprintf("http://127.0.0.1:%d/json/version", port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// profileInstancePort 找「已经在跑、且用同一个 user-data-dir 的 Chrome 浏览器进程」的调试端口，
+// 没有则 0。用 ps 而不是 /proc：macOS 也要能用。
+func profileInstancePort(profile string) int {
+	if profile == "" {
+		return 0
+	}
+	out, err := exec.Command("ps", "-eo", "args=").Output()
+	if err != nil {
+		return 0
+	}
+	return parseProfilePort(string(out), profile)
+}
+
+// parseProfilePort 从 ps 输出里挑出那台浏览器进程的 --remote-debugging-port。
+// 逐 token 精确比对 user-data-dir（子串匹配会让 /tmp/x 命中 /tmp/x-headed），并跳过
+// 带 --type= 的子进程（renderer/gpu 也带着同样的 profile 和端口参数）。
+func parseProfilePort(psOut, profile string) int {
+	want := "--user-data-dir=" + profile
+	for _, line := range strings.Split(psOut, "\n") {
+		port, hasProfile, isChild := 0, false, false
+		for _, f := range strings.Fields(line) {
+			switch {
+			case f == want:
+				hasProfile = true
+			case strings.HasPrefix(f, "--type="):
+				isChild = true
+			case strings.HasPrefix(f, "--remote-debugging-port="):
+				port, _ = strconv.Atoi(strings.TrimPrefix(f, "--remote-debugging-port="))
+			}
+		}
+		if hasProfile && !isChild && port > 0 {
+			return port
+		}
+	}
+	return 0
+}
+
 // browserUA 取这台 Chrome 的原生 User-Agent（/json/version 的 "User-Agent" 字段）。
 // 用于手机模式切回桌面时复位 UA——CDP 没有 clearUserAgentOverride，只能再 set 回默认值。
 func browserUA() string {
-	resp, err := http.Get(CDPBase + "/json/version")
+	resp, err := cdpHTTP.Get(CDPBase + "/json/version")
 	if err != nil {
 		return ""
 	}
@@ -286,7 +353,7 @@ func browserUA() string {
 
 // listPages 返回所有 page 类型的标签页（过滤掉 service worker / iframe 等其它 target）。
 func listPages() []target {
-	resp, err := http.Get(CDPBase + "/json")
+	resp, err := cdpHTTP.Get(CDPBase + "/json")
 	if err != nil {
 		return nil
 	}
@@ -354,7 +421,7 @@ func newTab(rawURL string) (string, error) {
 
 // closeTab 关闭指定标签页。
 func closeTab(id string) error {
-	resp, err := http.Get(CDPBase + "/json/close/" + id)
+	resp, err := cdpHTTP.Get(CDPBase + "/json/close/" + id)
 	if err != nil {
 		return err
 	}
@@ -393,7 +460,7 @@ func frontSnapshot() (string, uint64) {
 
 // activateTab 把指定标签页在 Chrome 里前置（让 agent 的前台焦点与正在镜像的一致）。
 func activateTab(id string) error {
-	resp, err := http.Get(CDPBase + "/json/activate/" + id)
+	resp, err := cdpHTTP.Get(CDPBase + "/json/activate/" + id)
 	if err != nil {
 		return err
 	}

--- a/backend/browser/config.go
+++ b/backend/browser/config.go
@@ -106,6 +106,22 @@ func saveConfig(c Config) error {
 	return os.Rename(tmp, f)
 }
 
+// normalizeHeadless 把模式收敛到 auto/on/off（无法识别返回空 = 未设，交给 pick 回落）。
+// 配置文件是手可以改的，历史上也出现过 "new"（照着 --headless=new 写）这种野值：不收敛的话
+// Settings 的分段控件选不中任何一项，而 ensureChrome 把它当成「非 off」照样按无头跑
+// —— 界面和实际就此对不上，还看不出为什么。
+func normalizeHeadless(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "auto":
+		return "auto"
+	case "on", "new", "true", "1":
+		return "on"
+	case "off", "false", "0":
+		return "off"
+	}
+	return ""
+}
+
 func pick(stored, env, def string) string {
 	if stored != "" {
 		return stored
@@ -126,7 +142,7 @@ func effectiveConfig() Config {
 		fs = false
 	}
 	return Config{
-		Headless:   pick(c.Headless, "", "auto"),
+		Headless:   pick(normalizeHeadless(c.Headless), "", "auto"),
 		WindowSize: pick(c.WindowSize, os.Getenv("TTMUX_CHROME_WINDOW"), "1920,1080"),
 		Fullscreen: &fs,
 		Scale:      pick(c.Scale, os.Getenv("TTMUX_CHROME_SCALE"), "2"),
@@ -159,6 +175,7 @@ func SetConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_REQUEST"}})
 		return
 	}
+	in.Headless = normalizeHeadless(in.Headless) // 落盘的就是干净值，chrome CLI 也读同一份文件
 	if err := saveConfig(in); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "WRITE_ERROR", "message": err.Error()}})
 		return

--- a/backend/browser/config_test.go
+++ b/backend/browser/config_test.go
@@ -1,0 +1,76 @@
+package browser
+
+import "testing"
+
+// 模式值的收敛表。chrome CLI（cli/chrome-cli/launcher.sh 的 _load_browser_cfg）照抄了这张表，
+// 改这里要一起改那边，否则 CLI 和后端会对同一份配置得出不同的无头/有头结论。
+func TestNormalizeHeadless(t *testing.T) {
+	cases := map[string]string{
+		"auto": "auto", "on": "on", "off": "off",
+		"AUTO": "auto", " off ": "off",
+		"new": "on", "true": "on", "1": "on", // 手改/历史野值
+		"false": "off", "0": "off",
+		"":   "", // 未设 → 交给 pick 回落
+		"乱写": "",
+	}
+	for in, want := range cases {
+		if got := normalizeHeadless(in); got != want {
+			t.Errorf("normalizeHeadless(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// 「存的值 > 环境变量 > 默认」这条链 chrome CLI 也照抄了一份（_load_browser_cfg），
+// 两边任一侧改了优先级，同一台机器上两个 launcher 就会起出参数不同的 Chrome。
+func TestEffectiveConfigFallsBackToEnv(t *testing.T) {
+	dir := t.TempDir()
+	InitConfig(dir)
+	t.Cleanup(func() {
+		cfgStore.mu.Lock()
+		cfgStore.file, cfgStore.portFile = "", ""
+		cfgStore.mu.Unlock()
+	})
+	t.Setenv("TTMUX_CHROME_WINDOW", "800,600")
+	t.Setenv("TTMUX_CHROME_SCALE", "1.25")
+	t.Setenv("TTMUX_CHROME_PROFILE", "/tmp/env-profile")
+	t.Setenv("TTMUX_CHROME_FULLSCREEN", "0")
+
+	if err := saveConfig(Config{Scale: "3"}); err != nil { // 只存了 scale：其余走 env
+		t.Fatal(err)
+	}
+	got := effectiveConfig()
+	if got.WindowSize != "800,600" || got.Profile != "/tmp/env-profile" {
+		t.Errorf("env 回落失败: window=%q profile=%q", got.WindowSize, got.Profile)
+	}
+	if got.Scale != "3" { // 存了就赢过 env
+		t.Errorf("Scale = %q, want 3", got.Scale)
+	}
+	if got.Fullscreen == nil || *got.Fullscreen {
+		t.Error("TTMUX_CHROME_FULLSCREEN=0 应关掉全屏")
+	}
+}
+
+// 无法识别的模式必须回显成 auto：分段控件选不中任何一项时，用户看到的是「没选」，
+// 而后端仍会按某个模式跑——界面和实际就此对不上。
+func TestEffectiveConfigHeadlessFallsBackToAuto(t *testing.T) {
+	dir := t.TempDir()
+	InitConfig(dir)
+	t.Cleanup(func() {
+		cfgStore.mu.Lock()
+		cfgStore.file, cfgStore.portFile = "", ""
+		cfgStore.mu.Unlock()
+	})
+
+	if err := saveConfig(Config{Headless: "乱写"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := effectiveConfig().Headless; got != "auto" {
+		t.Errorf("Headless = %q, want auto", got)
+	}
+	if err := saveConfig(Config{Headless: "new"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := effectiveConfig().Headless; got != "on" {
+		t.Errorf("Headless = %q, want on", got)
+	}
+}

--- a/backend/browser/instance_test.go
+++ b/backend/browser/instance_test.go
@@ -1,0 +1,28 @@
+package browser
+
+import "testing"
+
+// 单实例判定的核心是这段 ps 解析。chrome CLI 的 _running_profile_port 是同一套规则的 awk 版本。
+func TestParseProfilePort(t *testing.T) {
+	ps := `/usr/lib/systemd/systemd --user
+/opt/google/chrome/chrome --remote-debugging-port=9333 --user-data-dir=/tmp/other --headless=new about:blank
+/opt/google/chrome/chrome --type=renderer --user-data-dir=/tmp/mine --remote-debugging-port=9222 --lang=en-US
+/opt/google/chrome/chrome --remote-debugging-port=9351 --remote-allow-origins=* --user-data-dir=/tmp/mine about:blank
+`
+	if got := parseProfilePort(ps, "/tmp/mine"); got != 9351 {
+		t.Errorf("找的是浏览器进程那一行的端口: got %d, want 9351", got)
+	}
+	// 子串不算命中：/tmp/mine 不能匹配到 /tmp/mine-headed 那台
+	headed := "/opt/google/chrome/chrome --remote-debugging-port=9444 --user-data-dir=/tmp/mine-headed about:blank\n"
+	if got := parseProfilePort(headed, "/tmp/mine"); got != 0 {
+		t.Errorf("profile 必须整段相等: got %d, want 0", got)
+	}
+	// 只有 renderer 子进程（浏览器进程已经没了）不算「实例在跑」
+	onlyChild := "/opt/google/chrome/chrome --type=renderer --user-data-dir=/tmp/mine --remote-debugging-port=9222\n"
+	if got := parseProfilePort(onlyChild, "/tmp/mine"); got != 0 {
+		t.Errorf("带 --type= 的子进程不算: got %d, want 0", got)
+	}
+	if got := parseProfilePort(ps, ""); got != 0 {
+		t.Errorf("空 profile 不该匹配任何东西: got %d", got)
+	}
+}

--- a/cli/chrome-cli/README.md
+++ b/cli/chrome-cli/README.md
@@ -1,9 +1,9 @@
 # chrome-cli — `chrome` 的模块化源码
 
 `chrome` 是 ttmux 家族里**独立的浏览器自动化 CLI**：用 [Playwright](https://playwright.dev) 的
-`connectOverCDP` 接 `127.0.0.1:9222` 上的全局 Chrome——与 ttmux Web 镜像**同一台**，所以
-自动化能在控制台「浏览器」标签里实时围观。`connectOverCDP` 复用已开的 Chrome，**不下载
-Playwright 自带浏览器**，依赖只有一个 `playwright-core`。
+`connectOverCDP` 接全局 Chrome 的调试端口（默认 `127.0.0.1:9222`）——与 ttmux Web 镜像
+**同一台**，所以自动化能在控制台「浏览器」标签里实时围观。`connectOverCDP` 复用已开的
+Chrome，**不下载 Playwright 自带浏览器**，依赖只有一个 `playwright-core`。
 
 与根目录的 `ttmux` 一样，分发的是**单文件**（`install.sh` / `curl | bash` 直接装），源码在此拆开维护。
 
@@ -31,6 +31,10 @@ bash install.sh                    # 可选：装到 ~/.local/bin + npm i playwr
 首次使用（或 `chrome setup`）会在 `~/.local/share/ttmux/chrome/`（`$TTMUX_DATA/chrome`）
 写出 `driver.mjs` 并 `npm i playwright-core`。`install.sh` 会在安装时预热这一步。
 
+热路径上有个常驻 daemon（unix socket，空闲自杀）持有 CDP 连接，它把 driver 代码**读进内存**
+长跑：所以内嵌 driver 内容一变，`_write_driver` 会顺手请它退场，下一条命令拉起装着新代码的
+——否则 `build.sh` 之后改动要等它空闲超时才生效，调试时极易误判「改了没用」。
+
 ## 用法
 
 ```bash
@@ -49,4 +53,42 @@ chrome help                        # 全部动词与选项
 批量截图建议使用 `--fresh --goto <url>`：它会临时启动一个干净 Chrome，截图后关闭；
 需要复用已登录状态或在控制台围观自动化时，继续使用默认共享 Chrome 模式。
 
-环境变量：`TTMUX_CHROME_CDP`（默认 `http://127.0.0.1:9222`）、`TTMUX_CHROME_SCALE`（默认 2）。
+## 和「浏览器」设置页共用一套配置
+
+CLI 不自带一套默认值，**跟着后端走**——否则「设置里选了有头、CLI 却又开一台无头的」，
+两台 Chrome 各干各的，Web 镜像里看不见 CLI 的动作：
+
+- **目标端口**：读后端记录的 `<数据目录>/browser-cdp-port`（后端发现 9222 被占会自动换端口
+  并记下来），没有记录才回落 `9222`。数据目录同后端解析：`ROAM_DATA` > `TTMUX_DATA` >
+  `ROAM_HOME` > `TTMUX_HOME` > `~/.roam`。
+- **自己拉起 Chrome 时的参数**：读 `<数据目录>/browser-config.json`（就是设置页「浏览器」
+  存的那份）——模式（`auto`/`on`/`off`）、窗口尺寸、`--force-device-scale-factor`、
+  profile 目录、可执行路径，与后端 `ensureChrome` 取同一份值、同一套判定（`auto` = 没显示器
+  或 WSL 才无头）。语义的权威出处是 `backend/browser/{config,browser}.go`。
+
+## 只有一台
+
+同一个 profile 只该有一台 Chrome，这件事不靠「碰巧」，有三道闸：
+
+1. **端口上有 Chrome 就附着**，不再拉起（后端、CLI 都一样）。
+2. **端口不对也认**：同 `user-data-dir` 的实例已经在别的端口上跑着时，两边都改用它的调试端口
+   （后端还会把端口记进 `browser-cdp-port`，CLI 跟着读）。同 profile 的 Chrome 本来就是单例，
+   这时再拉一个只会把命令行转交给它然后自己退出、端口永远不开——从前的表现是「启动后随即
+   退出」这种没头没尾的报错。
+3. **并发只有一个能拉**：CLI 用 `flock`（`<运行时目录>/launch.lock`）跨进程串行，拿到锁后
+   重新探一遍。agent 一次并发甩十几条 `chrome` 命令是常态，没这道闸就是十几次启动互相打架。
+
+端口上已经有 Chrome 时**只附着，不改参数**——那台是谁按什么参数起的就什么样，改了设置要
+在设置页点「重启 Chrome」才换得上。启动参数与后端 `ensureChrome` **逐字一致**，所以「这台
+Chrome 是谁起的」不影响它的行为。
+
+两处刻意不一致，都是为了「跟着镜像走」：
+
+- **自签证书**由 driver 按 CDP 逐标签放行（`Security.enable` + `setIgnoreCertificateErrors`，
+  见 `allowInsecureTLS`），不加 `--ignore-certificate-errors` 启动开关——开关只在「CLI 抢到
+  启动」时才轮得到，且一加就是整个浏览器全站放行，把镜像里的正常上网也松掉了。
+- **端口被占时不自己换端口**：后端会换（并记下来），CLI 只报错。CLI 换到一个镜像不知道的
+  端口，等于开一台没人看得见的 Chrome。
+
+环境变量：`TTMUX_CHROME_CDP`（固定目标地址，优先于上面的端口记录）、`TTMUX_CHROME_SCALE`
+（默认 2）、`TTMUX_CHROME_WINDOW`（默认 `1920,1080`）——后两个只在设置里没存值时兜底。

--- a/cli/chrome-cli/driver.mjs
+++ b/cli/chrome-cli/driver.mjs
@@ -127,6 +127,7 @@ async function freshScreenshot(flags, pos, timeoutMs, io) {
     fresh = await chromium.launch({ ...launch, headless: true, args: ['--no-sandbox', '--disable-dev-shm-usage'], timeout: to })
     const context = await fresh.newContext({
       viewport: vp,
+      ignoreHTTPSErrors: true, // 同 allowInsecureTLS：自签 HTTPS（含 ttmux 自己）不该停在拦截页
       deviceScaleFactor: num(flags.scale, device ? device.scale : 1),
       ...(device ? { userAgent: device.ua, isMobile: true, hasTouch: true } : {}),
     })
@@ -142,6 +143,18 @@ async function freshScreenshot(flags, pos, timeoutMs, io) {
   }
 }
 
+// 自签证书：ttmux 自己就跑在自签 HTTPS 上，不放过证书错误就会停在「您的连接不是私密连接」
+// 拦截页上，连自己的 Web UI 都驱动不了。按 CDP 逐标签放行（Security 域是会话级的），而不是给
+// Chrome 加启动开关——那台 Chrome 可能是后端起的，启动开关这时根本轮不到我们加，
+// 而且它一加就是整个浏览器全站放行，把镜像里的正常上网也一起松掉了。
+async function allowInsecureTLS(ctx, page) {
+  try {
+    const s = await ctx.newCDPSession(page)
+    await s.send('Security.enable') // 少这一句 setIgnoreCertificateErrors 会静默无效（返回 {} 但照拦）
+    await s.send('Security.setIgnoreCertificateErrors', { ignore: true })
+  } catch {} // 老版本 Chrome 不支持就算了，导航照走（顶多停在拦截页）
+}
+
 // ── 主动词分发：操作一条已连好的 CDP browser。daemon 与一次性冷启动路径共用 ─────────────
 
 async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
@@ -153,7 +166,7 @@ async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
   const pickHere = () => pick(pages, flags, fail)
 
   switch (verb) {
-    case 'goto': { const p = await pickHere(); await p.goto(pos[0], { waitUntil: 'load', timeout: to }); io.log({ url: p.url(), title: await p.title() }); break }
+    case 'goto': { const p = await pickHere(); await allowInsecureTLS(ctx, p); await p.goto(pos[0], { waitUntil: 'load', timeout: to }); io.log({ url: p.url(), title: await p.title() }); break }
     case 'url': io.log((await pickHere()).url()); break
     case 'title': io.log(await (await pickHere()).title()); break
     case 'click': await (await pickHere()).click(pos[0], { timeout: to }); io.log('ok'); break
@@ -230,7 +243,7 @@ async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
     }
     case 'pdf': { const f = pos[0] || 'page.pdf'; await (await pickHere()).pdf({ path: f }); io.log(f); break }
     case 'tabs': io.log(await Promise.all(pages.map(async (pg, i) => ({ i, title: await pg.title().catch(() => ''), url: pg.url() })))); break
-    case 'new': { const np = await ctx.newPage(); if (pos[0]) await np.goto(pos[0], { waitUntil: 'load', timeout: to }); await np.bringToFront().catch(() => {}); io.log({ i: ctx.pages().indexOf(np), url: np.url() }); break }
+    case 'new': { const np = await ctx.newPage(); if (pos[0]) { await allowInsecureTLS(ctx, np); await np.goto(pos[0], { waitUntil: 'load', timeout: to }) } await np.bringToFront().catch(() => {}); io.log({ i: ctx.pages().indexOf(np), url: np.url() }); break }
     case 'close': await (await pickHere()).close(); io.log('ok'); break
     default: fail('未知命令: ' + verb)
   }
@@ -425,13 +438,19 @@ function runFFmpeg(args, fail) {
 // ── Session：daemon 里跨请求复用的 CDP 连接（一次性冷启动路径也走它，只是活不过一条命令） ──
 
 class Session {
-  constructor() { this.browser = null; this.recorder = new Recorder() }
+  constructor() { this.browser = null; this.cdp = ''; this.recorder = new Recorder() }
   async browserFor(cdp) {
-    if (this.browser && !this.browser.isConnected()) this.browser = null
+    // 换了地址就得重连：daemon 常驻、缓存的是「上一条命令那台」的连接，而目标端口是会变的
+    // （后端 9222 被占时会换端口）。不比对就会把命令继续发给旧的那台。
+    if (this.browser && (!this.browser.isConnected() || this.cdp !== cdp)) {
+      try { await this.browser.close() } catch {} // 仅断连接，不杀共享 Chrome
+      this.browser = null
+    }
     if (!this.browser) {
       try {
         const { chromium } = await import('playwright-core')
         this.browser = await chromium.connectOverCDP(cdp, { timeout: 10000 })
+        this.cdp = cdp
       } catch (e) {
         throw new ChromeError('连不上 Chrome (' + cdp + '): ' + e.message)
       }

--- a/cli/chrome-cli/launcher.sh
+++ b/cli/chrome-cli/launcher.sh
@@ -6,15 +6,17 @@
 # ⚠ 本文件由 cli/chrome-cli/build.sh 生成（driver.mjs 内联进下方占位标记处），请勿手改。
 #   改 cli/chrome-cli/{driver.mjs,launcher.sh} 后跑 cli/chrome-cli/build.sh 重新生成。
 #
-# 驱动 127.0.0.1:9222 上的全局 Chrome——与 ttmux Web 镜像同一台，自动化能在
-# 控制台「浏览器」标签里实时围观。引擎 playwright-core 的 connectOverCDP 复用
-# 已开的 Chrome，不下载 Playwright 自带浏览器（依赖很轻）。
+# 驱动全局 Chrome——与 ttmux Web 镜像同一台，自动化能在控制台「浏览器」标签里实时围观。
+# 引擎 playwright-core 的 connectOverCDP 复用已开的 Chrome，不下载 Playwright 自带浏览器
+# （依赖很轻）。调试端口默认 9222，但后端换过端口就跟着它记录的那个走；要自己拉起 Chrome 时
+# 也照 Settings「浏览器」页存的那份配置（无头/有头、窗口、缩放、profile）来，见 _ensure_browser。
 #
 set -euo pipefail
 
 TTMUX_CHROME_VERSION="0.1.0"
-TTMUX_DATA="${TTMUX_DATA:-${HOME}/.local/share/ttmux}"
-CHROME_DIR="${TTMUX_DATA}/chrome"
+# CLI 自己的运行时目录（内嵌 driver + playwright-core）。注意别给 TTMUX_DATA 赋默认值——
+# 它同时是后端数据目录的覆盖变量，赋了默认值 _roam_data() 就再也找不到 ~/.roam。
+CHROME_DIR="${TTMUX_DATA:-${HOME}/.local/share/ttmux}/chrome"
 
 # 颜色/提示
 if [ -t 2 ]; then
@@ -25,7 +27,111 @@ fi
 _info() { echo -e " ${_c_blue}●${_c_reset} $*" >&2; }
 _err()  { echo -e " ${_c_red}✘${_c_reset} $*" >&2; }
 
-_cdp() { echo "${TTMUX_CHROME_CDP:-http://127.0.0.1:9222}"; }
+# ttmux 后端的数据目录（与 backend 的 dataDir() 同解析）。Settings 页存的 Chrome 配置
+# (browser-config.json) 和后端实际在用的 CDP 端口 (browser-cdp-port) 都在这里；不读它，
+# CLI 就会按自己那套默认值另开一台 Chrome，Web「浏览器」标签里看不见 CLI 的动作。
+_roam_data() {
+    local d
+    for d in "${ROAM_DATA:-}" "${TTMUX_DATA:-}" "${ROAM_HOME:-}" "${TTMUX_HOME:-}"; do
+        if [ -n "$d" ]; then echo "$d"; return 0; fi
+    done
+    echo "${HOME}/.roam"
+}
+
+# USER_CDP：命令行上的 --cdp（driver 只认 `--cdp <地址>` 这种分开写的形式）。探活/拉起必须冲着
+# 真正下命令的那个地址：不认它，`chrome --cdp <另一台>` 会去探默认那台、顺手白开一台 Chrome。
+# ADOPTED_CDP：本次运行中改用的地址（见 _adopt_existing）。两者必须分开——用「有没有 --cdp」
+# 决定要不要把地址传给 driver，就不能拿同一个变量兼职存采纳结果，否则采纳成功等于没传。
+USER_CDP=''
+ADOPTED_CDP=''
+_scan_cdp_arg() {
+    local a prev=''
+    for a in "$@"; do
+        if [ "$prev" = "--cdp" ]; then USER_CDP="$a"; return 0; fi
+        prev="$a"
+    done
+}
+
+# 目标 CDP 地址：命令行 --cdp 最高，其次本次采纳到的实例，再是显式 env，再是后端记录的端口
+# （9222 被占时它会自动换端口并记下来），最后才是默认 9222。
+_cdp() {
+    if [ -n "${USER_CDP:-}" ]; then echo "$USER_CDP"; return 0; fi
+    if [ -n "${ADOPTED_CDP:-}" ]; then echo "$ADOPTED_CDP"; return 0; fi
+    if [ -n "${TTMUX_CHROME_CDP:-}" ]; then echo "$TTMUX_CHROME_CDP"; return 0; fi
+    local f port
+    f="$(_roam_data)/browser-cdp-port"
+    if [ -r "$f" ]; then
+        port="$(tr -dc 0-9 < "$f")"
+        if [ -n "$port" ]; then echo "http://127.0.0.1:${port}"; return 0; fi
+    fi
+    echo "http://127.0.0.1:9222"
+}
+
+# 从 CDP 地址里取端口（拉起 Chrome 时要用同一个，写死 9222 会造出「探 A 口、开 B 口」）。
+_cdp_port() {
+    local p="${1##*:}"
+    p="${p%%/*}"
+    p="$(printf '%s' "$p" | tr -dc 0-9)"
+    if [ -n "$p" ]; then echo "$p"; else echo 9222; fi
+}
+
+# 读 Settings 页存的 Chrome 启动配置，按后端同一优先级「存的值 > 环境变量 > 默认」解析成
+# CFG_* 变量。语义的权威出处是 backend/browser/{config,browser}.go，改那边这里要跟。
+_load_browser_cfg() {
+    CFG_HEADLESS=''; CFG_WINDOW=''; CFG_SCALE=''; CFG_PROFILE=''; CFG_BIN=''; CFG_FULLSCREEN=''
+    local raw k v
+    raw="$(node -e '
+const fs = require("fs");
+let c = {};
+try { c = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); } catch (e) {}
+const s = (v) => (typeof v === "string" ? v.trim() : "");
+const pick = (stored, env, def) => s(stored) || s(env) || def;
+const modes = { auto: "auto", on: "on", off: "off", new: "on", true: "on", "1": "on", false: "off", "0": "off" };
+const env = process.env;
+const fs0 = c.fullscreen === undefined || c.fullscreen === null;
+process.stdout.write([
+  "headless=" + (modes[s(c.headless).toLowerCase()] || "auto"),
+  "window=" + pick(c.windowSize, env.TTMUX_CHROME_WINDOW, "1920,1080"),
+  "scale=" + pick(c.scale, env.TTMUX_CHROME_SCALE, "2"),
+  "profile=" + pick(c.profile, env.TTMUX_CHROME_PROFILE, "/tmp/ttmux-chrome"),
+  "bin=" + pick(c.bin, env.CHROME_BIN, ""),
+  "fullscreen=" + ((fs0 ? env.TTMUX_CHROME_FULLSCREEN !== "0" : !!c.fullscreen) ? "1" : "0"),
+].join("\n") + "\n");
+' "$(_roam_data)/browser-config.json" 2>/dev/null)" || raw=''
+    while IFS='=' read -r k v; do
+        case "$k" in
+            headless)   CFG_HEADLESS="$v" ;;
+            window)     CFG_WINDOW="$v" ;;
+            scale)      CFG_SCALE="$v" ;;
+            profile)    CFG_PROFILE="$v" ;;
+            bin)        CFG_BIN="$v" ;;
+            fullscreen) CFG_FULLSCREEN="$v" ;;
+        esac
+    done <<EOF
+$raw
+EOF
+    : "${CFG_HEADLESS:=auto}"
+    : "${CFG_WINDOW:=1920,1080}"
+    : "${CFG_SCALE:=2}"
+    : "${CFG_PROFILE:=/tmp/ttmux-chrome}"
+    : "${CFG_FULLSCREEN:=1}"
+}
+
+_is_wsl() {
+    if [ -n "${WSL_DISTRO_NAME:-}" ] || [ -n "${WSL_INTEROP:-}" ]; then return 0; fi
+    grep -qi microsoft /proc/version 2>/dev/null
+}
+
+# 与后端同一判定：on=强制无头，off=强制有头，auto=没显示器/WSL(WSLg 那个 DISPLAY 不算真显示器)才无头。
+_headless_wanted() {
+    case "$CFG_HEADLESS" in
+        on)  return 0 ;;
+        off) return 1 ;;
+    esac
+    [ "$(uname -s 2>/dev/null || echo unknown)" = "Darwin" ] && return 1
+    _is_wsl && return 0
+    [ -z "${DISPLAY:-}" ]
+}
 
 _chrome_bin() {
     if [ -n "${CHROME_BIN:-}" ] && [ -x "$CHROME_BIN" ]; then
@@ -58,11 +164,21 @@ _daemon_start() {
 }
 
 # 写出内嵌 driver.mjs（构建时由 driver.mjs 内联）。引号 heredoc → JS 原样不展开。
+# 内容变了才落盘，并顺手请常驻 daemon 退场：daemon 是把 driver 代码读进内存长跑的，光换磁盘
+# 上的文件，跑着的还是旧逻辑——「升级后立即生效」会变成一句空话（最坏要等它空闲自杀）。
 _write_driver() {
     mkdir -p "$CHROME_DIR"
-    cat > "${CHROME_DIR}/driver.mjs" <<'TTMUX_CHROME_DRIVER_EOF'
+    local tmp="${CHROME_DIR}/driver.mjs.$$.tmp" # 带 pid：并发的多条命令共用一个临时名会互相抢，
+                                               # 一个 mv 走了、其余全报 cannot stat 然后被 set -e 掀掉
+    cat > "$tmp" <<'TTMUX_CHROME_DRIVER_EOF'
 @@DRIVER@@
 TTMUX_CHROME_DRIVER_EOF
+    if [ -f "${CHROME_DIR}/driver.mjs" ] && cmp -s "$tmp" "${CHROME_DIR}/driver.mjs"; then
+        rm -f "$tmp"
+        return 0
+    fi
+    mv -f "$tmp" "${CHROME_DIR}/driver.mjs"
+    pkill -f "${CHROME_DIR}/driver.mjs _daemon" 2>/dev/null || true
 }
 
 # 安装/校验依赖：node + npm + playwright-core
@@ -80,26 +196,103 @@ _setup() {
     return 0
 }
 
-# 确保 CDP 端口上有 Chrome：探活，否则按与 ttmux 后端一致的 flag 自起（无 DISPLAY 走 headless）。
+_probe() { curl -fsS -m 2 "${1}/json/version" >/dev/null 2>&1; }
+
+# 找「已经在跑、且用同一个 user-data-dir 的 Chrome 浏览器进程」的调试端口。逐 token 精确比对
+# （子串匹配会让 /tmp/x 命中 /tmp/x-headed），并跳过带 --type= 的子进程（renderer 也带着同样的
+# profile 和端口参数）。ps 而不是 /proc：macOS 也要能用。
+_running_profile_port() {
+    ps -eo args= 2>/dev/null | awk -v prof="--user-data-dir=$1" '
+        {
+            port = ""; hasprof = 0; child = 0
+            for (i = 1; i <= NF; i++) {
+                if ($i == prof) hasprof = 1
+                else if ($i ~ /^--type=/) child = 1
+                else if ($i ~ /^--remote-debugging-port=/) { split($i, a, "="); port = a[2] }
+            }
+            if (hasprof && !child && port != "") { print port; exit }
+        }'
+}
+
+# 单实例：同 profile 的 Chrome 已经在跑（只是端口不是我们要的那个）→ 认下它。同 user-data-dir
+# 的 Chrome 是单例，这时候再拉一个只会把命令行转交给它然后自己退出，端口永远不开。
+_adopt_existing() {
+    local p; p="$(_running_profile_port "$CFG_PROFILE")"
+    [ -n "$p" ] || return 1
+    local addr="http://127.0.0.1:${p}"
+    [ "$addr" = "$(_cdp)" ] && return 1
+    _probe "$addr" || return 1
+    _info "已有同 profile 的 Chrome 在 ${p}，用它（不开第二台）"
+    ADOPTED_CDP="$addr" # 后面 exec 时会作为 --cdp 传给 driver
+    return 0
+}
+
+# 确保 CDP 端口上有 Chrome：先探活（后端那台在就直接附着），否则按 Settings 页存的那份
+# 配置自起——模式/窗口/缩放/profile/可执行路径全部与后端 ensureChrome 取同一份值，
+# 免得「设置里选了有头、CLI 却又开一台无头的」。
 _ensure_browser() {
     local base; base="$(_cdp)"
-    curl -fsS "${base}/json/version" >/dev/null 2>&1 && return 0
+    _probe "$base" && return 0
+    _load_browser_cfg
+    _adopt_existing && return 0
+    # 跨进程串行：并发跑的多条 chrome 命令（agent 一次并行开一串很常见）不该各拉一台。
+    # 拿到锁后重新探一遍——等锁期间大概率已经有人拉起来了。拿不到锁就照旧往下走，
+    # 宁可多探一次，也不要在这里把命令卡死。
+    # 注意别写成 `exec 9>file 2>/dev/null`：exec 不带命令时那个 2>/dev/null 会永久按在整个
+    # 脚本的 stderr 上，之后所有报错（含 driver 的）全被吞掉，只剩一个静默的非零退出码。
+    local locked=0
+    if command -v flock >/dev/null 2>&1; then
+        if exec 9>"${CHROME_DIR}/launch.lock"; then
+            flock -w 30 9 || true # 等不到锁就自己去探/去起，别把命令卡死在这儿
+            locked=1
+        fi
+    fi
+    if [ "$locked" = 1 ] && { _probe "$(_cdp)" || _adopt_existing; }; then
+        exec 9>&-
+        return 0
+    fi
+    local rc=0
+    _launch_browser || rc=$? # 不用裸调用：set -e 会让失败直接掀掉整个脚本，跳过下面的解锁
+    [ "$locked" = 1 ] && exec 9>&-
+    return $rc
+}
+
+_launch_browser() {
+    local base; base="$(_cdp)"
     local chrome_bin
-    chrome_bin="$(_chrome_bin)" || { _err "${base} 上无 Chrome，且未找到 Chrome/Chromium"; return 1; }
-    local args=(--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1
-        --remote-allow-origins=* --user-data-dir=/tmp/ttmux-chrome
+    if [ -n "$CFG_BIN" ] && [ -x "$CFG_BIN" ]; then
+        chrome_bin="$CFG_BIN"
+    else
+        chrome_bin="$(_chrome_bin)" || { _err "${base} 上无 Chrome，且未找到 Chrome/Chromium"; return 1; }
+    fi
+    local port; port="$(_cdp_port "$base")"
+    local args=(--remote-debugging-port="$port" --remote-debugging-address=127.0.0.1
+        --remote-allow-origins=* --user-data-dir="$CFG_PROFILE"
         --no-first-run --no-default-browser-check
-        --ignore-certificate-errors
-        --force-device-scale-factor="${TTMUX_CHROME_SCALE:-2}")
-    [ "$(uname -s 2>/dev/null || echo unknown)" != "Darwin" ] && [ -z "${DISPLAY:-}" ] && args+=(--headless=new --window-size=1280,800)
-    _info "拉起 Chrome（调试端口 9222）..."
+        # 参数与后端 ensureChrome 逐字一致：这台 Chrome 可能是后端起的、也可能是这里起的，
+        # 参数不一样就成了「谁抢到启动谁说话」。自签证书的容忍度由 driver 按 CDP 逐标签打开
+        # （见 allowInsecureTLS），不再靠启动开关——那个只在「CLI 抢到启动」时才生效。
+        --disable-blink-features=AutomationControlled
+        --force-device-scale-factor="$CFG_SCALE")
+    local mode=有头
+    if _headless_wanted; then
+        mode=无头
+        args+=(--headless=new --window-size="$CFG_WINDOW")
+    elif [ "$CFG_FULLSCREEN" = "1" ]; then
+        args+=(--start-fullscreen)
+    fi
+    _info "拉起 Chrome（${mode}，调试端口 ${port}）..."
     _daemon_start "$chrome_bin" "${args[@]}" about:blank
-    local i
-    for i in $(seq 1 50); do
-        curl -fsS "${base}/json/version" >/dev/null 2>&1 && return 0
-        sleep 0.1
+    # 按总时限等，不按次数：端口上蹲着「只监听不回话」的进程时每次探活都要等满超时，
+    # 按次数写就是 50 × 超时（分钟级卡住），而 agent 那头只会觉得 chrome 命令死了。
+    local deadline=$((SECONDS + 8))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        curl -fsS -m 1 "${base}/json/version" >/dev/null 2>&1 && return 0
+        sleep 0.2
     done
-    _err "Chrome 调试端口未就绪"
+    # 同一 user-data-dir 的 Chrome 是单例：profile 被别的实例占着时，新起的这个会把 about:blank
+    # 转给它然后自己退出，端口永远不开——错误里点出来，否则只看到「未就绪」无从下手。
+    _err "Chrome 调试端口 ${port} 未就绪（若 profile ${CFG_PROFILE} 已被另一台 Chrome 占用：同一 user-data-dir 只能有一个实例，先关掉那台或在设置里换 profile）"
     return 1
 }
 
@@ -133,7 +326,12 @@ chrome — 浏览器自动化（Playwright over CDP，驱动 ttmux Web 镜像那
             --fresh --goto <url>（临时干净 Chrome 截图）  --quality <1-100>（jpg）
             --mobile（手机视口=iPhone）  --device iphone|iphone-se|pixel|ipad（指定机型）
             默认截图失败时自动降级到 CDP 截图；所有路径受 --timeout 约束
-  环境变量: TTMUX_CHROME_CDP=http://127.0.0.1:9222  TTMUX_CHROME_SCALE=2
+  目标 Chrome: 默认跟着 ttmux 后端那台（读 <数据目录>/browser-cdp-port，缺省 9222）；
+            端口上没有 Chrome 时按 Settings「浏览器」页存的配置自起（无头/有头、窗口、
+            缩放、profile、可执行路径），与后端拉起的那台参数一致。
+  环境变量: TTMUX_CHROME_CDP=http://127.0.0.1:9222（固定目标，优先于上面的记录）
+            TTMUX_CHROME_SCALE=2  TTMUX_CHROME_WINDOW=1920,1080（无设置时的兜底）
+            ROAM_HOME / ROAM_DATA（后端数据目录，默认 ~/.roam）
             TTMUX_CHROME_DAEMON_IDLE=300（常驻 daemon 空闲自杀秒数）
 EOF
 }
@@ -145,6 +343,7 @@ case "$sub" in
     -v|--version)   echo "chrome v${TTMUX_CHROME_VERSION}"; exit 0 ;;
     setup)          _setup; exit $? ;;
 esac
+_scan_cdp_arg "$@"
 fresh_screenshot=0
 if [ "$sub" = "screenshot" ] || [ "$sub" = "shot" ]; then
     for arg in "$@"; do
@@ -162,4 +361,8 @@ fi
 if [ "$fresh_screenshot" -eq 0 ]; then
     _ensure_browser || exit 1
 fi
-exec node "${CHROME_DIR}/driver.mjs" "$@"
+# 目标地址逐条命令显式传下去：常驻 daemon 是先起先得，它进程里的 env 还是当初拉起它那次的，
+# 后端换了端口以后只靠 env 会把命令发到已经不在了的那台上。
+cdp_arg=()
+if [ -z "$USER_CDP" ]; then cdp_arg=(--cdp "$(_cdp)"); fi
+exec node "${CHROME_DIR}/driver.mjs" "$@" ${cdp_arg[@]+"${cdp_arg[@]}"}


### PR DESCRIPTION
## 问题

`chrome` CLI 自己拉起 Chrome 时用的是一套硬编码参数，跟设置页「浏览器」存的那份
(`browser-config.json`) 毫无关系。设置里选了「有头」，CLI 照样开一台**无头**的——
这就是「chrome CLI 默认无头、和浏览器设置没对上」的直接原因。

顺着查出来一串同类的「说的和做的不是一回事」：

| # | 问题 | 后果 |
|---|---|---|
| 1 | 无头/有头按「自己有没有 DISPLAY」硬判，窗口写死 `1280,800`，profile 写死 `/tmp/ttmux-chrome`，缩放只认 env | 设置页形同虚设；profile 写死还必然撞车——同 `user-data-dir` 的 Chrome 是单例，后端那台占着它，CLI 新起的会把 `about:blank` 转交过去然后自己退出，端口永远不开 |
| 2 | 探活用 `_cdp()`，拉起却写死 `--remote-debugging-port=9222` | 后端 9222 被占时会换端口并记进 `browser-cdp-port`，CLI 不读它 → CLI 驱动的是另一台，Web「浏览器」标签里看不见 CLI 的动作 |
| 3 | `--cdp` 只有 driver 认，launcher 不认 | `chrome --cdp <另一台>` 会去探默认那台、顺手白开一台 Chrome |
| 4 | CLI 多塞 `--ignore-certificate-errors`，后端没有 | **能不能驱动 ttmux 自己的 Web UI，取决于那台 Chrome 是谁抢到启动的**：干净 profile 下后端起的那台停在 `Your connection is not private` |
| 5 | 同 profile 的实例跑在别的端口时，两边都只会失败 | 后端报「Chrome 启动后随即退出」这种没头没尾的错，镜像直接不可用 |
| 6 | 并发拉起没有跨进程锁 | agent 一次并发甩十几条 `chrome` 命令是常态，十几次启动互相打架 |
| 7 | 常驻 daemon 把 driver 代码读进内存长跑，换了磁盘上的文件也不生效 | `build.sh` 之后改动要等它空闲超时才生效，调试时极易误判「改了没用」 |
| 8 | 探活没超时（CLI `curl` 无 `-m`、后端裸 `http.Get`） | 端口上蹲着「只监听不回话」的进程时**永久挂住**；后端 `alive()` 在 `/browser/tabs` 轮询里，一挂就是整条请求链卡死 |
| 9 | 配置里手改过 `"headless": "new"` 这类野值 | 分段控件选不中任何一项，后端却按「非 off」照跑无头——界面和实际对不上还看不出为什么 |

## 改动

- **目标地址统一**：`--cdp` > `TTMUX_CHROME_CDP` > 后端记录的端口 > 9222，探活/拉起/下命令都用同一个。
- **启动参数取自设置**：模式（`auto`/`on`/`off`，含 WSL 判定）、窗口、缩放、profile、可执行路径，回落链同为「存的值 > env > 默认」，与后端 `ensureChrome` **逐字一致**。
- **自签证书改由 CDP 逐标签放行**（`Security.enable` + `setIgnoreCertificateErrors`，`--fresh` 用 `ignoreHTTPSErrors`），不再加启动开关：开关只在「CLI 抢到启动」时才轮得到，且一加就是整浏览器全站放行，把镜像里的正常上网也松掉了。
- **单实例三道闸**：端口上有 Chrome 就附着；同 profile 的实例在别的端口跑着就改用它的端口（后端顺手记进 `browser-cdp-port`，CLI 跟着读）；并发用 `flock` 串行，拿到锁后重新探一遍。
- **daemon 代码变更即换人**，探活加超时且等待循环改按总时限（按次数写就是 50 × 超时 ≈ 100s）。
- **模式值归一化**：读和写都收敛到 `auto`/`on`/`off`，`new`/`true`/`1` → `on`，不认识的 → `auto`。

刻意保留的两处不一致（已写进 README）：CLI 端口被占时**不自己换端口**（换到镜像不知道的端口 = 开一台没人看得见的 Chrome）；`--fresh` 截图仍是独立的一次性 Chrome。

## 实测

在真机上跑，用的是这台机器真实在跑的浏览器（有真实桌面 Xwayland `:1`，**没用 Xvfb**）：

| 检查 | 结果 |
|---|---|
| 启动参数 CLI vs 后端（同一份配置，去掉端口/profile） | 逐行 `diff` 一致，8/8 |
| 模式判定：`on` / `off` / `auto`×有无显示器 / 野值 `new` / 乱写 | 六档与后端一致 |
| env 回落链 | CLI 实测 `800,600` / `1.25` / `/tmp/env-profile-cli`；后端侧加了 Go 测试钉住 |
| 自签 HTTPS：`goto` / `new` / `--fresh` | 全部进应用，不再停在拦截页 |
| 端口解析：记录端口 / `--cdp` / 被占端口 | 跟随记录（原先探 A 开 B）；`--cdp` 通吃探活与拉起（死端口上 0 台白开）；被占时 11s 内明确报错、不换端口 |
| 单实例·采纳 | 同 profile 实例在 9399：后端 health 由「启动后随即退出」变为 `cdp=9399, alive:true` 且端口记录同步；CLI 打印「已有同 profile 的 Chrome 在 9399，用它」；全程该 profile 进程数 = 1 |
| 单实例·并发 | 6 条命令同时打向空端口：**6/6 成功，拉起 1 次，进程 1 台** |
| 附着机器上那台有头 Chrome | 列出它的标签、驱动成功、UA 无 `Headless`；它原有的页面没被动 |

并发那组测试还炸出 3 个只在并发下出现的 bug（都已修，串行跑永远看不见）：`_write_driver`
用固定临时名导致多进程抢同一个文件、`exec 9>lock 2>/dev/null` 把**整个脚本的 stderr**
永久重定向掉（所有报错静默消失）、采纳到的地址与「用户是否给了 `--cdp`」共用一个变量导致
采纳成功等于没传。

## 门禁

`scripts/dev/quality/check.sh full` 通过；`go test ./browser/`（4 个测试，含 `parseProfilePort`
的浏览器进程 vs renderer 子进程、`/tmp/mine` 不得命中 `/tmp/mine-headed`）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
