### PR TITLE
fix(swarm): swarm sql 找回 members/cards · e2e 基线首次全绿

### DIFF
--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -55,7 +55,8 @@ type projectSummary struct {
 	Races        int              `json:"races"`      // running 状态的竞赛数
 	LastActivity int64            `json:"lastActivity"`
 	FirstSeen    int64            `json:"firstSeen"`
-	Top          []projectSession `json:"top"` // 活跃会话前 3（列表卡「进行中」三行）
+	Archived     bool             `json:"archived,omitempty"` // 干过活但此刻空着：收进「不活跃」分组
+	Top          []projectSession `json:"top"`                // 活跃会话前 3（列表卡「进行中」三行）
 
 	// Top 是**给卡片画三行用的**，被截断过，所以它算不出总数——前端拿它数 waiting/running
 	// 会漏掉第 4 个以后的会话。下面这三样在截断**之前**统计，是完整的：
@@ -89,6 +90,22 @@ var (
 )
 
 // ProjectsList GET /projects
+// noteArchived 判定并回写归档态，返回这个项目此刻算不算「不活跃」。
+//
+// 归档不是删除，也不是用户动作：它是读时收敛的判定结果——「干过活，但此刻既没有
+// 会话、也没有 roam worktree」。置顶的永远算活跃（用户明说要盯着它）。
+// 一旦又开了会话就自动回到活跃，不需要谁去「取消归档」。
+func (a *API) noteArchived(key string, e project.Entry, roamWts, sessions int) bool {
+	idle := roamWts == 0 && sessions == 0 && !e.Pinned
+	switch {
+	case idle && e.ArchivedAt == 0:
+		a.Projects.SetArchived(key, time.Now().Unix())
+	case !idle && e.ArchivedAt != 0:
+		a.Projects.SetArchived(key, 0)
+	}
+	return idle
+}
+
 func (a *API) ProjectsList(c *gin.Context) {
 	projRespMu.Lock()
 	if projResp != nil && time.Since(projRespAt) < 5*time.Second {
@@ -248,6 +265,7 @@ func (a *API) ProjectsList(c *gin.Context) {
 			a.Projects.Remove(key)
 			continue
 		}
+		p.Archived = a.noteArchived(key, e, roamWts, p.Sessions)
 		finish(&p, top)
 	}
 

--- a/backend/project/service.go
+++ b/backend/project/service.go
@@ -50,6 +50,10 @@ type Entry struct {
 	// 有几个会话」：机器一重启 tmux 全清零，按当下会话数收敛会把所有发现型项目
 	// 一次性删光（会话是运行时，项目是台账，不能让前者的生死决定后者的存亡）。
 	LastSessionAt int64 `json:"lastSessionAt,omitempty"`
+	// ArchivedAt 归档时刻（0 = 在册）。「干过活但此刻空着」的项目转到这里，
+	// 而不是继续和活跃项目挤在同一份列表里——它们只是没开会话，不是没了。
+	// 一旦又开了会话就自动回到活跃。
+	ArchivedAt int64 `json:"archivedAt,omitempty"`
 }
 
 type fileShape struct {
@@ -96,7 +100,8 @@ func NewStore(dataDir string, db *metadb.DB) *Store {
 func (s *Store) loadDB() {
 	rows, err := s.db.Query(`SELECT id, dir, IFNULL(origin,''), IFNULL(display_name,''),
 		IFNULL(pinned,0), IFNULL(default_agent,''), IFNULL(default_base,''),
-		IFNULL(first_seen,0), IFNULL(last_seen,0), IFNULL(last_session_at,0) FROM projects`)
+		IFNULL(first_seen,0), IFNULL(last_seen,0), IFNULL(last_session_at,0),
+		IFNULL(archived_at,0) FROM projects`)
 	if err != nil {
 		return
 	}
@@ -104,7 +109,7 @@ func (s *Store) loadDB() {
 		var e Entry
 		var pinned int
 		if rows.Scan(&e.ID, &e.Dir, &e.Origin, &e.DisplayName, &pinned, &e.DefaultAgent,
-			&e.DefaultBase, &e.FirstSeen, &e.LastSeen, &e.LastSessionAt) != nil {
+			&e.DefaultBase, &e.FirstSeen, &e.LastSeen, &e.LastSessionAt, &e.ArchivedAt) != nil {
 			continue
 		}
 		e.Pinned = pinned != 0
@@ -136,15 +141,15 @@ func (s *Store) saveDB() {
 		for id, e := range s.repos {
 			if _, err := tx.Exec(`INSERT INTO projects
 				(id,dir,origin,display_name,pinned,default_agent,default_base,
-				 first_seen,last_seen,last_session_at)
-				VALUES(?,?,?,?,?,?,?,?,?,?)
+				 first_seen,last_seen,last_session_at,archived_at)
+				VALUES(?,?,?,?,?,?,?,?,?,?,?)
 				ON CONFLICT(id) DO UPDATE SET dir=excluded.dir, origin=excluded.origin,
 					display_name=excluded.display_name, pinned=excluded.pinned,
 					default_agent=excluded.default_agent, default_base=excluded.default_base,
 					first_seen=excluded.first_seen, last_seen=excluded.last_seen,
-					last_session_at=excluded.last_session_at`,
+					last_session_at=excluded.last_session_at, archived_at=excluded.archived_at`,
 				e.ID, e.Dir, e.Origin, e.DisplayName, boolInt(e.Pinned), e.DefaultAgent,
-				e.DefaultBase, e.FirstSeen, e.LastSeen, e.LastSessionAt); err != nil {
+				e.DefaultBase, e.FirstSeen, e.LastSeen, e.LastSessionAt, e.ArchivedAt); err != nil {
 				return err
 			}
 			keep = append(keep, id)
@@ -344,6 +349,19 @@ func (s *Store) NoteSessions(key string) {
 		s.repos[k].LastSessionAt = now
 		s.save()
 	}
+}
+
+// SetArchived 置/清归档。归档是**读时收敛的判定结果**，不是用户动作：
+// 聚合层每轮算完就把它写回来，所以只在真的变了的时候落盘。
+func (s *Store) SetArchived(key string, at int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := s.resolve(key)
+	if k == "" || s.repos[k].ArchivedAt == at {
+		return
+	}
+	s.repos[k].ArchivedAt = at
+	s.save()
 }
 
 // Entries 返回台账快照（copy，key = 项目 id，供只读聚合遍历）。

--- a/cli/ttmux-cli-go/e2e/e2e.sh
+++ b/cli/ttmux-cli-go/e2e/e2e.sh
@@ -82,45 +82,14 @@ eq "info --json sessions=0 (no server)" "0" "$($GO info --json | jget 'd["sessio
 eq "ls --json empty (no server)" "0" "$($GO ls --json | jget 'len(d)')"
 
 # ════════════════════════════════════════════
-sec "tasks: spawn / status / collect / group"
-$GO spawn build "lint" "echo LINT_OK; sleep 300" "test" "echo TEST_OK; sleep 300" >/dev/null
-eq "spawn created group file" "2" "$(wc -l < "$TTMUX_DATA/groups/build.group" | tr -d ' ')"
-rc0 "session build-lint exists" tmux -L "$SOCKET" has-session -t build-lint
-eq "status --json task count" "2" "$($GO status build --json | jget 'len(d["tasks"])')"
-eq "status --json running" "running" "$($GO status build --json | jget 'd["tasks"][0]["status"]')"
-has "status pretty" "$($GO status build)" "运行中"
-eq "group ls --json" "build" "$($GO group ls --json | jget 'd[0]["group"]')"
-has "group ls pretty" "$($GO group ls)" "build"
-eq "collect --json prompt" "echo LINT_OK; sleep 300" "$($GO collect build --json | jget 'd["results"][0]["prompt"].strip()')"
-has "collect text" "$($GO collect build)" "build-lint"
-eq "task meta type=cmd" "cmd" "$(cat "$TTMUX_DATA/meta/build-lint/type.txt")"
+sec "sessions: send / capture / windows"
+# 自己建一个会话：这几条以前搭 `spawn` 建出来的任务会话的便车，而 spawn 作为
+# 用户级命令在迁到 Go 时就有意去掉了（内部仍被蜂群/插件用着）。
+SESS=$($GO new --json probe --dir "$SANDBOX" | jget 'd["session"]')
+$GO send "$SESS" "echo INJECTED_CMD" >/dev/null; sleep 1
+has "capture shows injected" "$($GO capture "$SESS" --lines 50)" "INJECTED_CMD"
+has "lw lists window on session" "$($GO lw -t "$SESS")" "◻"
 
-sec "tasks: send / capture"
-$GO send build-lint "echo INJECTED_CMD" >/dev/null; sleep 1
-has "capture shows injected" "$($GO capture build-lint --lines 50)" "INJECTED_CMD"
-
-sec "windows: list"
-has "lw lists window on session" "$($GO lw -t build-lint)" "◻"
-
-sec "tasks: spawn --file + --agent"
-printf 'a echo A; sleep 300\nb echo B; sleep 300\n' > "$SANDBOX/tasks.txt"
-$GO spawn --file fromfile "$SANDBOX/tasks.txt" >/dev/null
-eq "spawn --file 2 tasks" "2" "$(wc -l < "$TTMUX_DATA/groups/fromfile.group" | tr -d ' ')"
-$GO spawn --agent ai "api" "实现登录" --dir /tmp --perm auto >/dev/null; sleep 1
-eq "agent meta type=agent" "agent" "$(cat "$TTMUX_DATA/meta/ai-api/type.txt")"
-has "agent pane runs fake claude" "$(tmux -L "$SOCKET" capture-pane -t ai-api -p)" "[fake claude]"
-
-sec "tasks: wait (task that exits) + group kill"
-$GO spawn quick "q1" "echo QUICKDONE; exit" >/dev/null
-$GO wait quick --timeout 10 >/tmp/e2e-wait 2>&1
-has "wait completes" "$(cat /tmp/e2e-wait)" "全部完成"
-$GO group kill build >/dev/null
-rc0 "group kill removed file" bash -c "[ ! -f '$TTMUX_DATA/groups/build.group' ]"
-rc0 "group kill removed session" bash -c "! tmux -L '$SOCKET' has-session -t build-lint 2>/dev/null"
-
-# ════════════════════════════════════════════
-# 会话身份：tmux 会话名 = 会话 id（2026-0728-1808-0000），用户起的名字降级为
-# 展示名，存 tmux 用户选项 @roam_name。ttmux 一律显示「名字(id)」。
 sec "session identity: id as tmux name, label for display"
 $GO new "我的 会话" --detach >/dev/null
 SID="$($GO resolve "我的 会话")"
@@ -157,8 +126,11 @@ $GO swarm add feat api --type task "echo API; sleep 300" >/dev/null
 $GO swarm add feat web --type task "echo WEB; sleep 300" >/dev/null
 $GO swarm add feat qa --type task --depends-on api "echo QA; sleep 300" >/dev/null
 sleep 1
-eq "members launched" "2" "$($GO swarm status feat --json | jget 'len(d["members"])')"
-eq "qa pending on api" "qa" "$($GO swarm status feat --json | jget 'd["pending"][0]["name"]')"
+# 依赖是**软**的：记录关系供拓扑连线与 prompt 协调，但不挂起——成员一建出来就
+# 起会话开工，缺上游产出时自己去广场等/问（见 cmdAdd 的注释与 worker.md.tmpl）。
+# 这里断言的正是「三个都起来了、没有谁被扣住」。
+eq "members launched" "3" "$($GO swarm status feat --json | jget 'len(d["members"])')"
+eq "soft deps recorded" "api" "$($GO swarm sql feat --json "SELECT deps FROM members WHERE name='qa'" | jget 'd[0]["deps"]')"
 eq "goal stored" "登录功能" "$($GO swarm status feat --json | jget 'd["goal"]')"
 has "swarm ls --json" "$($GO swarm ls --json | jget '[s["name"] for s in d]')" "feat"
 has "swarm ls pretty" "$($GO swarm ls)" "feat"

--- a/cli/ttmux-cli-go/internal/swarm/write.go
+++ b/cli/ttmux-cli-go/internal/swarm/write.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -430,11 +431,34 @@ func readFirst(path string) string {
 // ReadQuery runs a read-only query against a swarm's db and returns the column
 // names and string rows (backs `swarm sql`).
 func (s *Store) ReadQuery(swarm, query string) ([]string, [][]string, error) {
-	db, err := s.openSwarmDB(swarm)
+	id := s.ResolveID(swarm)
+	if id == "" {
+		return nil, nil, fmt.Errorf("swarm not found: %s", swarm)
+	}
+	// 专用只读连接，不走共享池：下面要建临时视图，而临时对象是**按连接**的，
+	// 落在池里会随机漏给别的调用方。这条命令是人手敲的，不在热路径上，多开一条不心疼。
+	db, err := sql.Open("sqlite", "file:"+s.metaPath()+"?_pragma=busy_timeout(5000)&mode=ro")
 	if err != nil {
 		return nil, nil, err
 	}
+	db.SetMaxOpenConns(1)
 	defer db.Close()
+
+	// members / cards 现在住在主库、靠 swarm_id 分群。用按群限定的临时视图把老名字
+	// 还回去：`SELECT ... FROM members` 这类既有查询照常能用，而且看不到别的群。
+	// posts 仍在每群自己的库里，attach 进来。
+	for _, q := range []string{
+		`CREATE TEMP VIEW members AS SELECT * FROM swarm_members WHERE swarm_id=` + sqlLiteral(id),
+		`CREATE TEMP VIEW cards AS SELECT * FROM swarm_cards WHERE swarm_id=` + sqlLiteral(id),
+		`ATTACH DATABASE ` + sqlLiteral(s.swarmDBPath(id)) + ` AS perswarm`,
+	} {
+		if _, err := db.Exec(q); err != nil && !strings.Contains(err.Error(), "unable to open") {
+			return nil, nil, err
+		}
+	}
+	// posts 视图单独建：库不存在时（从没发过帖）上面的 ATTACH 会失败，那就跳过。
+	_, _ = db.Exec(`CREATE TEMP VIEW posts AS SELECT * FROM perswarm.posts`)
+
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, nil, err
@@ -490,3 +514,7 @@ func (s *Store) Remove(swarm string) error {
 	}
 	return os.RemoveAll(s.swarmHome(id))
 }
+
+// sqlLiteral 把字符串包成 SQL 字面量（临时视图的定义不能用占位符）。
+// 输入是我们自己解析出来的蜂群 id 与库路径，不是用户串；转义单引号只为稳妥。
+func sqlLiteral(v string) string { return "'" + strings.ReplaceAll(v, "'", "''") + "'" }

--- a/frontend/src/components/projects/Projects.tsx
+++ b/frontend/src/components/projects/Projects.tsx
@@ -177,6 +177,8 @@ html[data-size="compact"] .prj-subbar.searching .prj-iconbtn.find{display:none}
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 html[data-size="compact"] .prj-quiet{grid-template-columns:minmax(0,1fr) auto;min-height:44px}
 html[data-size="compact"] .prj-quiet .p{display:none}
+/* 右列：可清理标签或「空闲多久」。两者互斥——有活要干时不必再说它闲着。 */
+.prj-quiet .qt{font-size:var(--fs-micro);color:var(--text-dimmer);white-space:nowrap}
 
 .prj-panel{background:var(--bg-container);border:1px solid var(--border-subtle);border-radius:12px;margin-top:8px}
 .prj-wtrow{padding:13px 16px}
@@ -419,7 +421,10 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
   // 两个任务」的项目占同样大的卡，还被同一行最高的卡撑高，页面下三分之一因此全是空卡。
   const isQuiet = (p: Proj) => p.sessions <= 0 && p.unfinished <= 0 && p.races <= 0
   const rest = visible.filter((p) => !p.pinned && !isQuiet(p))
+  // 不活跃那节按「什么时候空下来的」排：刚空的在前，久无人问津的沉底。
+  // 跟着上面的通用排序走的话，这一节读起来没有次序感。
   const quiet = visible.filter((p) => !p.pinned && isQuiet(p))
+    .sort((a, b) => (b.archivedAt || b.lastActivity || 0) - (a.archivedAt || a.lastActivity || 0))
 
   // 行动队列与状态条：跨项目，不吃搜索/筛选（它们只作用于下面的栅格）
   const goProject = (key: string) => { location.hash = '#/projects/' + encodeURIComponent(key) }
@@ -551,7 +556,11 @@ function ProjectList({ data, loaded, openTerm, refresh }: {
                     role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); goProject(p.key) } }}>
                     <span className="nm">{p.name}</span>
                     <span className="p" title={p.dir}>{p.dir}</span>
-                    <span>{p.cleanable > 0 && <Tag color="success" style={{ margin: 0 }}>{t('project.cleanableCount', { count: p.cleanable })}</Tag>}</span>
+                    <span className="qt">
+                      {p.cleanable > 0
+                        ? <Tag color="success" style={{ margin: 0 }}>{t('project.cleanableCount', { count: p.cleanable })}</Tag>
+                        : (p.archivedAt ? t('project.quietSince', { when: relTime(p.archivedAt, t) }) : null)}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/projects/project-list/project-model.ts
+++ b/frontend/src/components/projects/project-list/project-model.ts
@@ -14,6 +14,9 @@ export type Proj = {
   key: string; name: string; dir: string; git: boolean; pinned: boolean
   sessions: number; attached: number; worktrees: number; unfinished: number; cleanable: number; races: number
   lastActivity: number; firstSeen: number
+  /** 归档时刻（秒，0/缺省 = 在册）。「不活跃」那节靠它排序并显示空了多久——
+      少了它，5 分钟前空下来的和三个月没动的长得一模一样。 */
+  archivedAt?: number
   /** 卡片「进行中」三行——**被后端截断过，不能拿它数数**。计数用 running/waiting，队列用 needs。 */
   top: ProjSession[] | null
   running?: number

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1598,6 +1598,7 @@ const enUS = {
   'project.looseHint': 'Not in any project',
   'project.remove': 'Remove project',
   'project.quietSection': 'Other projects',
+  'project.quietSince': 'idle {when}',
   'project.quietHint': 'no sessions running',
   'project.enter': 'Enter',
   'project.forkTask': 'Fork',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1603,6 +1603,7 @@ const zhCN = {
   'project.looseHint': '不属于任何项目',
   'project.remove': '移除项目',
   'project.quietSection': '其他项目',
+  'project.quietSince': '空闲 {when}',
   'project.quietHint': '没有会话在跑',
   'project.enter': '进入',
   'project.forkTask': '派生',


### PR DESCRIPTION
两件独立的事，各一个提交。

## 一、`swarm sql` 找回 members/cards（修 M2 引入的回退）

members/cards 并进主库后，`swarm sql <群> "… FROM members"` 就查不到东西了 —— 而那正是这个命令最常见的用法（`ttmux help` 里写着「只读查每群 swarm.db」）。

改成给它一条**专用只读连接**，用**按群限定的临时视图**把 `members` / `cards` 的老名字还回去，`posts` 仍 attach 每群自己的库。既有查询照常能用，也看不到别的群的行。

临时视图是**按连接**的，所以不能走共享池 —— 落在池里会随机漏给别的调用方。这条命令是人手敲的、不在热路径上，多开一条连接不心疼。

## 二、e2e 基线首次全绿

`e2e/e2e.sh` 此前**一直是红的**（CI 不跑它，所以没人发现）：

- `$GO spawn|wait|collect|group` 那几段删掉 —— `spawn` 作为**用户级命令**在迁到 Go 时就有意去掉了（`internal/command/spawn` 包仍被蜂群/插件用着，只是没注册成子命令），测试是 bash 时代的遗留
- `send` / `capture` / `lw` 三条以前搭 spawn 建的会话的便车，现在自己 `ttmux new` 一个
- 「qa pending on api」是**硬**依赖门禁的旧预期；依赖早就改成**软**的了（记录关系供拓扑连线与 prompt 协调，但不挂起 —— 见 `cmdAdd` 里的注释与 `worker.md.tmpl`）。断言改成「三个都起来了」+「deps 确实记下了」

结果：**65 passed / 0 failed**。

## 三、不活跃的项目显示空闲了多久

项目页的「不活跃」分组本来就有，但每行只有名字和目录 —— 5 分钟前空下来的和三个月没动的长得一模一样，那一节读起来没有次序感。

补上 `archived_at`（M2 建表时就留了这一列，一直没人读写）：聚合时判定并回写，置顶的永远算活跃，一旦又开了会话就自动回到活跃，不需要谁去「取消归档」。前端按它排序（刚空的在前、久无人问津的沉底）并显示「空闲 N 天」；有可清理 worktree 时仍优先显示那个标签 —— 有活要干时不必再说它闲着。

## 验证

`check.sh full` 通过；`e2e/e2e.sh` 65/65。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
