### PR TITLE
fix(project): 收尾留痕进库 · 直连模式下不再被静默丢弃

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@
 /.worktrees/
 
 # 后端构建产物 + 单一二进制内嵌素材（构建期生成，不入库；仓库只留占位）
-/backend/ttmux-web
+# 不加前导 /：曾经在 backend/ 里再编一次，产物落到 backend/backend/ttmux-web，
+# 锚定到根的规则盖不住它，34MB 的二进制就这么混进了一次提交。
+ttmux-web
 /backend/roam
 /backend/internal/webui/site/*
 !/backend/internal/webui/site/.gitkeep

--- a/backend/api/agent-transcript-link.go
+++ b/backend/api/agent-transcript-link.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"ttmux-web/ttmux"
+)
+
+// 把会话和它那段 agent 对话对应起来。
+//
+// ttmux 自己拉起的 agent（spawn / 蜂群成员）走 `claude --session-id`，关联由构造
+// 保证。但日常用法是「`ttmux new` 建个会话，然后自己在里面敲 claude」——那条路
+// 我们插不进参数，只能从外面认。
+//
+// 认法：**会话开始跑 claude 的那一刻，先把它工作目录下已有的对话文件名记下来；
+// 之后哪一份是新冒出来的，哪一份就是它的。**
+//
+// 两个细节是踩出来的：
+//
+//   - 不能只看跃迁后那一轮。Claude Code 要等**第一条消息**才把对话落盘，中间隔多久
+//     取决于人什么时候开口——可能几秒，也可能几分钟。所以要一直等到它出现为止
+//     （或者超时放弃）。
+//   - 不能用 mtime 判「新」。同目录里别的会话继续说话时，它自己那份的 mtime 也会
+//     被刷新，于是看起来像是「新出现的」。比的必须是**文件名集合的差集**。
+//
+// 只在完全无歧义时才认：同一目录里同时有两个会话在等着认，就一个都不认
+// （本机 13 个活会话挤在 7 个目录里，这种情况是常态）。空着顶多是重开时给个空壳，
+// 认错了却是把别人的对话摆到你面前。
+
+// linkWindow 等对话出现的最长时间。超过就放弃——隔了半小时才冒出来的那份，
+// 更可能是这期间用户自己另开的，不该硬认到这个会话头上。
+const linkWindow = 30 * time.Minute
+
+// pendingLink 一个「已经开始跑 claude、还没认到对话」的会话。
+type pendingLink struct {
+	dir   string
+	since time.Time
+	// seen 是跃迁那一刻该目录下已有的对话；之后的新面孔才算候选。
+	seen map[string]bool
+}
+
+// agentLinker 记住上一轮谁在跑 agent，以及还在等着认的那些会话。
+type agentLinker struct {
+	mu      sync.Mutex
+	prev    map[string]string // 会话 → 上一轮在跑的 agent
+	pending map[string]*pendingLink
+	linked  map[string]bool // 本进程内已认过，别反复 exec CLI
+	primed  bool            // 第一轮只建基线
+}
+
+func newAgentLinker() *agentLinker {
+	return &agentLinker{
+		prev:    map[string]string{},
+		pending: map[string]*pendingLink{},
+		linked:  map[string]bool{},
+	}
+}
+
+// projectDirFor 给出某工作目录对应的 Claude Code 对话目录
+// （~/.claude/projects/<cwd 转义>）。做成变量是留给测试注入的。
+var projectDirFor = func(dir string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || dir == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "projects", encodeProject(dir))
+}
+
+var linkNow = time.Now // 测试注入时钟
+
+// note 吃下这一轮的 agent 扫描结果：登记新开始跑 claude 的会话，并给还在等的那些
+// 尝试认领。homeOf 给出会话的归属目录，link 落地关联。
+func (l *agentLinker) note(running map[string]string, homeOf func(string) string, link func(sess, uuid string)) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	prev := l.prev
+	l.prev = map[string]string{}
+	for s, a := range running {
+		l.prev[s] = a
+	}
+	if !l.primed {
+		l.primed = true
+		return // 第一轮只建基线：此刻在跑的会话可能已经跑了几小时，认不得
+	}
+
+	now := linkNow()
+	// 1) 新开始跑 claude 的会话进入等待，并记下此刻该目录已有哪些对话
+	for sess, agent := range running {
+		if agent != "claude" || prev[sess] == "claude" || l.linked[sess] || l.pending[sess] != nil {
+			continue
+		}
+		dir := homeOf(sess)
+		if dir == "" {
+			continue
+		}
+		l.pending[sess] = &pendingLink{dir: dir, since: now, seen: transcriptSet(projectDirFor(dir))}
+	}
+
+	// 2) 会话不跑 claude 了（关了/退出了），或等太久 → 放弃
+	for sess, p := range l.pending {
+		if running[sess] != "claude" || now.Sub(p.since) > linkWindow {
+			delete(l.pending, sess)
+		}
+	}
+
+	// 3) 同一目录有多个在等 → 谁都认不准，这一轮都不认（等到只剩一个再说）
+	perDir := map[string]int{}
+	for _, p := range l.pending {
+		perDir[p.dir]++
+	}
+	for sess, p := range l.pending {
+		if perDir[p.dir] != 1 {
+			continue
+		}
+		fresh := newTranscripts(projectDirFor(p.dir), p.seen)
+		if len(fresh) != 1 {
+			continue // 还没出现，或一次冒出好几份：都不敢认
+		}
+		l.linked[sess] = true
+		delete(l.pending, sess)
+		link(sess, fresh[0])
+	}
+}
+
+// transcriptSet 列出目录下现有的对话 uuid。
+func transcriptSet(dir string) map[string]bool {
+	out := map[string]bool{}
+	if dir == "" {
+		return out
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range ents {
+		if name := e.Name(); !e.IsDir() && filepath.Ext(name) == ".jsonl" {
+			out[name[:len(name)-len(".jsonl")]] = true
+		}
+	}
+	return out
+}
+
+// newTranscripts 返回 seen 之外新出现的对话 uuid。
+// 比的是**文件名集合**而不是 mtime：别的会话继续说话也会刷新它自己那份的 mtime。
+func newTranscripts(dir string, seen map[string]bool) []string {
+	var out []string
+	for uuid := range transcriptSet(dir) {
+		if !seen[uuid] {
+			out = append(out, uuid)
+		}
+	}
+	return out
+}
+
+// linkAgentSession 把关联落进台账。sessions 表归 CLI 写（单写者），所以走子命令。
+// 记不上不是错误：空着顶多重开时给个空壳。
+func (a *API) linkAgentSession(sess, uuid string) {
+	if out, err := a.TT.Run("db", "link-agent", sess, uuid); err != nil {
+		log.Printf("关联会话对话失败 %s → %s: %s", sess, uuid, ttmux.StripANSI(out))
+	}
+}

--- a/backend/api/agent_transcript_link_test.go
+++ b/backend/api/agent_transcript_link_test.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// linkFixture 造一个 transcript 目录，并允许「在某个时刻之后写出一份新对话」。
+type linkFixture struct {
+	t    *testing.T
+	dirs map[string]string // 会话归属目录 → 该目录的 transcript 目录
+	got  map[string]string // 会话 → 认到的 uuid
+}
+
+func newLinkFixture(t *testing.T) *linkFixture {
+	return &linkFixture{t: t, dirs: map[string]string{}, got: map[string]string{}}
+}
+
+// project 注册一个工作目录，返回它的 transcript 目录。
+func (f *linkFixture) project(home string) string {
+	f.t.Helper()
+	dir := f.t.TempDir()
+	f.dirs[home] = dir
+	return dir
+}
+
+func (f *linkFixture) homeOf(sess string) string {
+	for home := range f.dirs {
+		if sess == "" {
+			continue
+		}
+		// 测试里会话名以其归属目录为前缀，简单映射即可
+		if len(sess) > len(home) && sess[:len(home)] == home {
+			return home
+		}
+	}
+	return ""
+}
+
+func (f *linkFixture) link(sess, uuid string) { f.got[sess] = uuid }
+
+// writeTranscript 在某工作目录的 transcript 目录里写一份对话。
+func (f *linkFixture) writeTranscript(home, uuid string) {
+	f.t.Helper()
+	p := filepath.Join(f.dirs[home], uuid+".jsonl")
+	if err := os.WriteFile(p, []byte(`{"sessionId":"`+uuid+`"}`+"\n"), 0o600); err != nil {
+		f.t.Fatal(err)
+	}
+	// 确保 mtime 严格晚于上一轮扫描时刻
+	now := time.Now().Add(time.Second)
+	_ = os.Chtimes(p, now, now)
+}
+
+// linkerWith 把 claudeProjectDir 换成 fixture 的映射（生产里它算的是 ~/.claude/projects）。
+func (f *linkFixture) run(l *agentLinker, running map[string]string) {
+	orig := projectDirFor
+	projectDirFor = func(dir string) string { return f.dirs[dir] }
+	defer func() { projectDirFor = orig }()
+	l.note(running, f.homeOf, f.link)
+}
+
+// 正常路径，且**对话是迟到的**：Claude Code 要等第一条消息才把对话落盘，
+// 中间隔多久取决于人什么时候开口。所以不能只看跃迁后那一轮。
+func TestLinksWhenTranscriptArrivesLate(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+
+	// 第一轮只建基线：此刻在跑的会话可能早就跑着了，认不得
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("第一轮不该认任何东西: %v", f.got)
+	}
+
+	// 第二轮：另一个会话刚起来，但用户还没开口，目录里什么都没多
+	f.run(l, map[string]string{"/repo/a-1": "claude", "/repo/a-2": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("对话还没出现时不该认: %v", f.got)
+	}
+
+	// 又过了几轮，用户开口了，对话这才落盘
+	f.writeTranscript("/repo/a", "uuid-new")
+	f.run(l, map[string]string{"/repo/a-1": "claude", "/repo/a-2": "claude"})
+	if f.got["/repo/a-2"] != "uuid-new" {
+		t.Fatalf("迟到的对话也该认到: %v", f.got)
+	}
+	if _, ok := f.got["/repo/a-1"]; ok {
+		t.Fatal("上一轮就在跑的会话不该被认（它的对话早写完了）")
+	}
+}
+
+// 同目录里**别的会话**继续说话会刷新它自己那份的 mtime——那不算「新出现」。
+// 判据必须是文件名集合的差集，不是 mtime。
+func TestOtherSessionsWritesDoNotCountAsNew(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	// 目录里先有一份别人的对话
+	f.writeTranscript("/repo/a", "uuid-someone-else")
+	f.run(l, map[string]string{})
+
+	// 我们的会话起来了；随后那份**旧**对话被刷新（别人在说话）
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	f.writeTranscript("/repo/a", "uuid-someone-else") // 重写 = mtime 变新
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("别人那份被刷新不该被当成我们的: %v", f.got)
+	}
+
+	// 真正属于我们的那份出现了，才认
+	f.writeTranscript("/repo/a", "uuid-ours")
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if f.got["/repo/a-1"] != "uuid-ours" {
+		t.Fatalf("该认 uuid-ours: %v", f.got)
+	}
+}
+
+// 等太久就放弃：隔了半小时才冒出来的那份更可能是用户自己另开的。
+func TestGivesUpAfterWindow(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	base := time.Now()
+	linkNow = func() time.Time { return base }
+	defer func() { linkNow = time.Now }()
+
+	f.run(l, map[string]string{})
+	f.run(l, map[string]string{"/repo/a-1": "claude"}) // 进入等待
+
+	linkNow = func() time.Time { return base.Add(linkWindow + time.Minute) }
+	f.writeTranscript("/repo/a", "uuid-late")
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("超窗之后不该再认: %v", f.got)
+	}
+}
+
+// 同一目录同时起了两个会话 → 分不清谁是谁，一个都不认。
+func TestSkipsWhenTwoSessionsStartInSameDir(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	f.run(l, map[string]string{})
+
+	f.run(l, map[string]string{"/repo/a-1": "claude", "/repo/a-2": "claude"})
+	f.writeTranscript("/repo/a", "uuid-x")
+	f.run(l, map[string]string{"/repo/a-1": "claude", "/repo/a-2": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("同目录两个会话同时起来时不该认: %v", f.got)
+	}
+}
+
+// 一轮里冒出好几份对话 → 同样不敢认。
+func TestSkipsWhenSeveralTranscriptsAppear(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	f.run(l, map[string]string{})
+
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	f.writeTranscript("/repo/a", "uuid-1")
+	f.writeTranscript("/repo/a", "uuid-2")
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("一次冒出多份对话时不该认: %v", f.got)
+	}
+}
+
+// 没有新对话（会话跑的不是 claude，或对话还没落盘）→ 不认，下一轮再说。
+func TestSkipsWhenNoNewTranscript(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	f.run(l, map[string]string{})
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("没有新对话时不该认: %v", f.got)
+	}
+}
+
+// codex 不走这条路（它没有 --session-id，对话也不在 ~/.claude/projects）。
+func TestIgnoresCodex(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	f.run(l, map[string]string{"/repo/a-1": "codex"})
+	f.writeTranscript("/repo/a", "uuid-1")
+	f.run(l, map[string]string{"/repo/a-1": "codex"})
+	if len(f.got) != 0 {
+		t.Fatalf("codex 不该被认: %v", f.got)
+	}
+}
+
+// 认过一次就不再重复 exec CLI（台账那边也只记一次，这里少走一趟子进程）。
+func TestLinksOnlyOncePerSession(t *testing.T) {
+	f := newLinkFixture(t)
+	f.project("/repo/a")
+	l := newAgentLinker()
+	f.run(l, map[string]string{})
+
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	f.writeTranscript("/repo/a", "uuid-1")
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if f.got["/repo/a-1"] != "uuid-1" {
+		t.Fatalf("首次该认到: %v", f.got)
+	}
+	// 会话停了又起，目录里再冒出一份——已经认过就不再改
+	delete(f.got, "/repo/a-1")
+	f.run(l, map[string]string{})
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	f.writeTranscript("/repo/a", "uuid-2")
+	f.run(l, map[string]string{"/repo/a-1": "claude"})
+	if len(f.got) != 0 {
+		t.Fatalf("同一会话不该认第二次: %v", f.got)
+	}
+}

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -39,6 +39,7 @@ type API struct {
 	Projects    *project.Store    // 项目（08）：knownRepos 弱台账 + UI 偏好
 	FileIndex   *search.FileIndex // 全局搜索（⌘K）的项目文件名索引，见 search.go
 	Meta        *metadb.DB        // 台账库直连；降级时各 store 自动退回 JSON
+	agentLink   *agentLinker      // 把手敲起来的 claude 会话认到它那段对话上
 }
 
 // New 组装 API。台账库的握手在这里做一次：库的位置由 ttmux 报，不是后端自己拼
@@ -56,7 +57,8 @@ func New(tt *ttmux.Client, browserHome, dataDir, fallbackBin string) *API {
 	return &API{TT: tt, WT: worktree.New(dataDir, meta), BrowserHome: browserHome,
 		Football: NewFootballStore(), Speech: NewSpeechStore(dataDir),
 		Prefs: NewPreferencesStore(dataDir), Races: race.NewStore(dataDir, meta),
-		Projects: project.NewStore(dataDir, meta), FileIndex: search.NewFileIndex(), Meta: meta}
+		Projects: project.NewStore(dataDir, meta), FileIndex: search.NewFileIndex(), Meta: meta,
+		agentLink: newAgentLinker()}
 }
 
 // json 透传 ttmux 的 --json 输出

--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -150,6 +150,9 @@ func (a *API) ProjectsList(c *gin.Context) {
 	var cwds map[string][]string // 懒取：有非 git 项目才拉
 
 	agentRunning := runningAgentSessions() // 一次进程树扫描，供绿点判活跃（设计 W2）
+	// 顺带认一次「刚开始跑 claude 的会话 ↔ 它那段对话」。挂在这里是因为进程树
+	// 已经扫过了，不额外付代价；只在完全无歧义时才记（见 agent-transcript-link.go）。
+	a.agentLink.note(agentRunning, a.WT.SessionHome, a.linkAgentSession)
 
 	addSession := func(p *projectSummary, top *[]projectSession, name, label string, attached bool, last int64, branch string, linked bool) {
 		claimed[name] = true

--- a/backend/internal/metadb/handshake_test.go
+++ b/backend/internal/metadb/handshake_test.go
@@ -31,7 +31,7 @@ func makeSchema(t *testing.T, path string) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if _, err := db.Exec(testSchema); err != nil {
+	if _, err := db.Exec(TestSchema); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/backend/internal/metadb/legacyfiles.go
+++ b/backend/internal/metadb/legacyfiles.go
@@ -17,19 +17,32 @@ import (
 
 const legacyMark = "metadb-v3.done"
 
+// traceMark 单独一个标记：留痕（activity.log）是后来才收编的，那时 v3 的标记
+// 在老机器上早就落下了。共用一个标记等于「这台机器永远轮不到退休 activity.log」。
+const traceMark = "metadb-traces.done"
+
 var legacyFiles = []string{"projects.json", "races.json", "session-homes.json"}
 
+// traceFiles 是两代留痕（当代 + 轮转出去的那一代）。
+var traceFiles = []string{"activity.log", "activity.log.1"}
+
 // RetireLegacyFiles 把已收编的旧台账改名 <文件>.bak-<时间>，并落一个幂等标记。
+func RetireLegacyFiles(dataDir string) {
+	retire(dataDir, legacyMark, legacyFiles)
+	retire(dataDir, traceMark, traceFiles)
+}
+
+// retire 退休一组已收编的源文件。
 //
 // **标记在 + 文件又出现 → 不重导也不再改名**，只告警：用户可能是从备份恢复了旧文件，
 // 重来一遍会把已经删掉的项目、已经清理的竞赛统统复活。想强来设 ROAM_METADB_REIMPORT=1。
-func RetireLegacyFiles(dataDir string) {
+func retire(dataDir, markName string, files []string) {
 	if dataDir == "" {
 		return
 	}
-	mark := filepath.Join(dataDir, "migrations", legacyMark)
+	mark := filepath.Join(dataDir, "migrations", markName)
 	_, marked := os.Stat(mark)
-	present := existing(dataDir)
+	present := existing(dataDir, files)
 
 	if marked == nil { // 标记已在
 		if len(present) > 0 && !Reimport() {
@@ -51,12 +64,12 @@ func RetireLegacyFiles(dataDir string) {
 	if err := os.MkdirAll(filepath.Dir(mark), 0o755); err != nil {
 		return
 	}
-	_ = os.WriteFile(mark, []byte(fmt.Sprintf("v3 %s\n", stamp)), 0o644)
+	_ = os.WriteFile(mark, []byte(fmt.Sprintf("%s %s\n", markName, stamp)), 0o644)
 }
 
-func existing(dataDir string) []string {
+func existing(dataDir string, files []string) []string {
 	var out []string
-	for _, name := range legacyFiles {
+	for _, name := range files {
 		if _, err := os.Stat(filepath.Join(dataDir, name)); err == nil {
 			out = append(out, name)
 		}

--- a/backend/internal/metadb/legacyfiles_test.go
+++ b/backend/internal/metadb/legacyfiles_test.go
@@ -1,0 +1,62 @@
+package metadb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func gone(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}
+
+// 留痕的退休不能挂在 v3 那个标记上。
+//
+// activity.log 是后来才收编的，而 v3 的标记在老机器上早就落下了——共用一个标记
+// 等于「这台机器永远轮不到退休 activity.log」，源文件就一直躺在那儿，
+// 下次谁再打开它就会看到一份与库分叉的旧数据。
+func TestTracesRetireOnTheirOwnMark(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "migrations"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 老机器的现场：v3 早已盖章，留痕文件还在
+	touch(t, filepath.Join(dir, "migrations", legacyMark))
+	touch(t, filepath.Join(dir, "activity.log"))
+	touch(t, filepath.Join(dir, "activity.log.1"))
+
+	RetireLegacyFiles(dir)
+
+	for _, name := range traceFiles {
+		if !gone(t, filepath.Join(dir, name)) {
+			t.Fatalf("%s 应当已改名退休", name)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "migrations", traceMark)); err != nil {
+		t.Fatal("应当落下留痕自己的标记")
+	}
+}
+
+// 标记在 + 文件又出现（用户从备份恢复了）→ 不再改名，也不重导。
+func TestRetireIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	touch(t, filepath.Join(dir, "projects.json"))
+	RetireLegacyFiles(dir)
+	if !gone(t, filepath.Join(dir, "projects.json")) {
+		t.Fatal("第一次应当改名")
+	}
+	touch(t, filepath.Join(dir, "projects.json")) // 从备份恢复回来
+	RetireLegacyFiles(dir)
+	if gone(t, filepath.Join(dir, "projects.json")) {
+		t.Fatal("已收编过就不该再动它（重来会把已删的项目复活）")
+	}
+}

--- a/backend/internal/metadb/schema_testdata.go
+++ b/backend/internal/metadb/schema_testdata.go
@@ -1,11 +1,12 @@
 package metadb
 
-// testSchema 是一份**够测试用**的表骨架。
+// TestSchema 是一份**够测试用**的表骨架。
 //
 // schema 的真相源是 ttmux CLI 的 internal/metadb —— 两个 Go module 不能互相 import
 // （见 backend/internal/id 的包注释），所以只能各留一份。生产代码一行 DDL 都不跑，
 // 这份常量只被测试引用；真结构漂了靠 TestSchemaMatchesRealCLI 用真 CLI 对拍抓出来。
-const testSchema = `
+// 导出是为了让别的包（project 等）在测试里摆**同一份**骨架：多摆一份就是第三个会漂开的定义。
+const TestSchema = `
 CREATE TABLE IF NOT EXISTS projects(
 	id TEXT PRIMARY KEY, dir TEXT NOT NULL UNIQUE, origin TEXT NOT NULL DEFAULT '',
 	display_name TEXT, pinned INTEGER NOT NULL DEFAULT 0,
@@ -22,6 +23,11 @@ CREATE TABLE IF NOT EXISTS races(
 CREATE TABLE IF NOT EXISTS session_homes(
 	tmux_id TEXT PRIMARY KEY, epoch TEXT, name TEXT, home TEXT NOT NULL,
 	pinned_at INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE IF NOT EXISTS project_traces(
+	id TEXT PRIMARY KEY, repo TEXT NOT NULL DEFAULT '', branch TEXT, head_oid TEXT,
+	base TEXT, action TEXT, strategy TEXT, at INTEGER NOT NULL DEFAULT 0,
+	merged_into TEXT, merged_kind TEXT);
+CREATE INDEX IF NOT EXISTS project_traces_repo ON project_traces(repo, at DESC);
 CREATE TABLE IF NOT EXISTS sessions(
 	id TEXT PRIMARY KEY, parent_id TEXT, created_by TEXT, created_at TEXT,
 	initial_cwd TEXT, status TEXT NOT NULL DEFAULT 'live', died_at TEXT,

--- a/backend/project/service.go
+++ b/backend/project/service.go
@@ -10,6 +10,7 @@
 package project
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"log"
@@ -470,33 +471,75 @@ func (s *Store) Trace(e TraceEntry) {
 }
 
 // ReadTrace 读某仓库的留痕（两代合并、新在前、上限 limit）。
+// ReadTrace 读某仓库最近的留痕（新在前，最多 limit 条）。
+//
+// **从文件尾部往回读**：留痕是只追加的 JSONL，要的永远是最新那几条，而文件会长到
+// 5MB 才轮转一代。原先每次都把两代整个读进来解析（最多 10MB），只为挑出 50 条——
+// 项目活动页每打开一次就付一遍这个代价。现在按块回读，凑够就停。
 func (s *Store) ReadTrace(repoDir string, limit int) []TraceEntry {
 	p := s.tracePath()
-	if p == "" {
+	if p == "" || limit <= 0 {
 		return nil
 	}
 	var out []TraceEntry
-	for _, f := range []string{p + ".1", p} {
-		b, err := os.ReadFile(f)
-		if err != nil {
-			continue
+	// 先读当前这代，不够再往上一代找
+	for _, f := range []string{p, p + ".1"} {
+		if len(out) >= limit {
+			break
 		}
-		for _, line := range strings.Split(string(b), "\n") {
-			if strings.TrimSpace(line) == "" {
+		out = append(out, tailTrace(f, repoDir, limit-len(out))...)
+	}
+	return out
+}
+
+// traceChunk 每次回读的块大小。留痕一行 200 字节上下，64KB 够覆盖几百条，
+// 绝大多数情况一块就够。
+const traceChunk = 64 << 10
+
+// tailTrace 从文件末尾往回扫，收集属于 repoDir 的留痕（新在前），最多 want 条。
+func tailTrace(path, repoDir string, want int) []TraceEntry {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	var (
+		out  []TraceEntry
+		pos  = st.Size()
+		rest []byte // 上一块开头那半行，拼到下一块（往回读）的末尾
+	)
+	for pos > 0 && len(out) < want {
+		n := int64(traceChunk)
+		if n > pos {
+			n = pos
+		}
+		pos -= n
+		buf := make([]byte, n)
+		if _, err := f.ReadAt(buf, pos); err != nil {
+			return out
+		}
+		buf = append(buf, rest...)
+		lines := bytes.Split(buf, []byte("\n"))
+		// 第一段可能是半行（除非已读到文件开头），留给下一块拼
+		if pos > 0 {
+			rest, lines = lines[0], lines[1:]
+		} else {
+			rest = nil
+		}
+		for i := len(lines) - 1; i >= 0 && len(out) < want; i-- {
+			line := bytes.TrimSpace(lines[i])
+			if len(line) == 0 {
 				continue
 			}
 			var e TraceEntry
-			if json.Unmarshal([]byte(line), &e) == nil && e.Repo == repoDir {
+			if json.Unmarshal(line, &e) == nil && e.Repo == repoDir {
 				out = append(out, e)
 			}
 		}
-	}
-	// 文件本身按时间追加，倒序 = 新在前
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
-	if len(out) > limit {
-		out = out[:limit]
 	}
 	return out
 }

--- a/backend/project/service.go
+++ b/backend/project/service.go
@@ -445,18 +445,50 @@ func (s *Store) tracePath() string {
 	return filepath.Join(filepath.Dir(s.path), "activity.log")
 }
 
-// Trace 追加留痕；超 5MB 轮转一代（.1），读放大有界。写失败只丢摘要，不影响主流程。
+// Trace 记一条留痕。写失败只丢摘要，不影响主流程。
 func (s *Store) Trace(e TraceEntry) {
+	e.At = time.Now().Unix()
+	if e.ID == "" {
+		e.ID = id.New()
+	}
+	if s.db.OK() {
+		s.traceDB(e)
+		return
+	}
+	s.traceFile(e)
+}
+
+// traceDB 落库，并把这个仓库的留痕修剪到 traceKeep 条。
+//
+// 文件形态靠「5MB 轮转一代」给读放大封顶；进了库那条机制就没了，可留痕仍是只增的。
+// 按仓库各留最近 traceKeep 条：修剪只在写时发生（合入/丢弃/清理都是人的动作，稀疏），
+// 而项目活动页要的永远是最近那几十条。
+func (s *Store) traceDB(e TraceEntry) {
+	if _, err := s.db.Exec(`INSERT OR REPLACE INTO project_traces
+		(id,repo,branch,head_oid,base,action,strategy,at,merged_into,merged_kind)
+		VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		e.ID, e.Repo, e.Branch, e.HeadOid, e.Base, e.Action, e.Strategy, e.At,
+		e.MergedInto, e.MergedKind); err != nil {
+		log.Printf("留痕写库失败（只丢这条摘要）: %v", err)
+		return
+	}
+	_, _ = s.db.Exec(`DELETE FROM project_traces WHERE repo=? AND id NOT IN
+		(SELECT id FROM project_traces WHERE repo=? ORDER BY at DESC, rowid DESC LIMIT ?)`,
+		e.Repo, e.Repo, traceKeep)
+}
+
+// traceKeep 每个仓库保留的留痕条数。UI 一次读 50，留 1000 条足够往回翻，
+// 也远到不了让「读最近 50 条」变慢的量级。
+const traceKeep = 1000
+
+// traceFile 是降级模式（开不了库）下的老路：JSONL 追加，超 5MB 轮转一代。
+func (s *Store) traceFile(e TraceEntry) {
 	p := s.tracePath()
 	if p == "" {
 		return
 	}
 	if st, err := os.Stat(p); err == nil && st.Size() > 5<<20 {
 		_ = os.Rename(p, p+".1")
-	}
-	e.At = time.Now().Unix()
-	if e.ID == "" {
-		e.ID = id.New()
 	}
 	b, err := json.Marshal(e)
 	if err != nil {
@@ -470,13 +502,44 @@ func (s *Store) Trace(e TraceEntry) {
 	_, _ = f.Write(append(b, '\n'))
 }
 
-// ReadTrace 读某仓库的留痕（两代合并、新在前、上限 limit）。
 // ReadTrace 读某仓库最近的留痕（新在前，最多 limit 条）。
-//
-// **从文件尾部往回读**：留痕是只追加的 JSONL，要的永远是最新那几条，而文件会长到
-// 5MB 才轮转一代。原先每次都把两代整个读进来解析（最多 10MB），只为挑出 50 条——
-// 项目活动页每打开一次就付一遍这个代价。现在按块回读，凑够就停。
 func (s *Store) ReadTrace(repoDir string, limit int) []TraceEntry {
+	if limit <= 0 {
+		return nil
+	}
+	if s.db.OK() {
+		return s.readTraceDB(repoDir, limit)
+	}
+	return s.readTraceFile(repoDir, limit)
+}
+
+// readTraceDB 按 (repo, at DESC) 走索引取最近几条。rowid 兜底定序：同一秒里
+// 连着落的几条（一次清理会一口气写好几条）光看 at 分不出先后。
+func (s *Store) readTraceDB(repoDir string, limit int) []TraceEntry {
+	rows, err := s.db.Query(`SELECT id, repo, IFNULL(branch,''), IFNULL(head_oid,''),
+		IFNULL(base,''), IFNULL(action,''), IFNULL(strategy,''), at,
+		IFNULL(merged_into,''), IFNULL(merged_kind,'')
+		FROM project_traces WHERE repo=? ORDER BY at DESC, rowid DESC LIMIT ?`, repoDir, limit)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []TraceEntry
+	for rows.Next() {
+		var e TraceEntry
+		if rows.Scan(&e.ID, &e.Repo, &e.Branch, &e.HeadOid, &e.Base, &e.Action,
+			&e.Strategy, &e.At, &e.MergedInto, &e.MergedKind) != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// readTraceFile 是降级模式下的老路：**从文件尾部往回读**。留痕是只追加的 JSONL，
+// 要的永远是最新那几条，而文件会长到 5MB 才轮转一代。整个读进来解析（最多 10MB）
+// 只为挑出 50 条，代价按打开次数付。按块回读，凑够就停。
+func (s *Store) readTraceFile(repoDir string, limit int) []TraceEntry {
 	p := s.tracePath()
 	if p == "" || limit <= 0 {
 		return nil

--- a/backend/project/service_test.go
+++ b/backend/project/service_test.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,7 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	_ "modernc.org/sqlite"
+
 	"ttmux-web/internal/id"
+	"ttmux-web/internal/metadb"
+	"ttmux-web/ttmux"
 )
 
 func TestStorePersistAndConverge(t *testing.T) {
@@ -234,5 +240,117 @@ func TestReadTraceFallsBackToRotated(t *testing.T) {
 	// 当前这代就够了的话，不必去翻上一代
 	if one := s.ReadTrace("/repo/a", 1); len(one) != 1 || one[0].Branch != "fresh" {
 		t.Fatalf("limit=1 应当只给最新那条: %+v", one)
+	}
+}
+
+// ── 直连模式下的留痕 ─────────────────────────────────────────────────────
+
+// dbStore 造一个直连模式的 Store：真 sqlite 文件 + 真握手路径（假 CLI 只负责报路径）。
+// 走 metadb.Open 而不是自己拼一个 DB，是为了让「库路径只能来自握手」那条约束在这里也成立。
+func dbStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.db")
+	raw, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(metadb.TestSchema); err != nil {
+		t.Fatal(err)
+	}
+	raw.Close()
+
+	bin := filepath.Join(dir, "ttmux")
+	script := "#!/bin/sh\nif [ \"$1\" = db ]; then printf '%s' '" +
+		`{"path":"` + path + `","schemaVersion":6,"minCompatible":1,"journalMode":"wal"}` + "'; fi\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := metadb.Open(context.Background(), ttmux.New(bin), "")
+	if !db.OK() {
+		t.Fatalf("应当直连成功: %s", db.Why())
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewStore(dir, db)
+}
+
+// 直连模式下留痕必须真的落库。
+//
+// 这是一条**回归**测试：并库之后 Store 在直连模式下不再有文件路径（path 只在降级
+// 分支赋值），而 Trace/ReadTrace 当时还只认文件——于是每一条留痕都被静默丢掉、
+// 项目活动恒空，还不报错。
+func TestTraceGoesToDBWhenConnected(t *testing.T) {
+	s := dbStore(t)
+	if s.tracePath() != "" {
+		t.Fatal("直连模式不该再有留痕文件路径")
+	}
+	s.Trace(TraceEntry{Repo: "/repo/a", Branch: "b1", Action: "merged"})
+	s.Trace(TraceEntry{Repo: "/repo/other", Branch: "noise", Action: "cleaned"})
+	s.Trace(TraceEntry{Repo: "/repo/a", Branch: "b2", Action: "discarded", MergedInto: "main", MergedKind: "squash"})
+
+	got := s.ReadTrace("/repo/a", 10)
+	if len(got) != 2 {
+		t.Fatalf("要 2 条（本仓库的）, got %d: %+v", len(got), got)
+	}
+	if got[0].Branch != "b2" || got[1].Branch != "b1" {
+		t.Fatalf("应当新在前: %+v", got)
+	}
+	if got[0].MergedInto != "main" || got[0].MergedKind != "squash" || got[0].Action != "discarded" {
+		t.Fatalf("字段丢了: %+v", got[0])
+	}
+	if got[0].At == 0 || got[0].ID == "" {
+		t.Fatalf("时间/id 应当写入时补上: %+v", got[0])
+	}
+}
+
+// 同一秒里连着落的几条（一次清理会一口气写好几条）光看 at 分不出先后，
+// 得靠 rowid 兜底定序，否则活动列表的顺序会随查询计划漂。
+func TestTraceOrdersWithinSameSecond(t *testing.T) {
+	s := dbStore(t)
+	for i := 0; i < 5; i++ {
+		s.Trace(TraceEntry{Repo: "/repo/a", Branch: fmt.Sprintf("b%d", i), Action: "cleaned"})
+	}
+	got := s.ReadTrace("/repo/a", 3)
+	for i, want := range []string{"b4", "b3", "b2"} {
+		if got[i].Branch != want {
+			t.Fatalf("第 %d 条 = %q, want %q", i, got[i].Branch, want)
+		}
+	}
+}
+
+// 文件形态靠 5MB 轮转给读放大封顶；进了库要自己修剪，否则只增不减。
+func TestTraceTrimsPerRepo(t *testing.T) {
+	s := dbStore(t)
+	// 先灌满（直接写库，省掉一千次 autocommit），再让 Trace 走一次真实写入
+	if _, err := s.db.Exec(`WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i<?)
+		INSERT INTO project_traces(id,repo,branch,action,at) SELECT 'old-'||i,'/repo/a','b'||i,'merged',i FROM n`,
+		traceKeep+19); err != nil {
+		t.Fatal(err)
+	}
+	s.Trace(TraceEntry{Repo: "/repo/b", Branch: "keep-me", Action: "merged"})
+	s.Trace(TraceEntry{Repo: "/repo/a", Branch: "newest", Action: "merged"})
+
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM project_traces WHERE repo='/repo/a'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != traceKeep {
+		t.Fatalf("应当修剪到 %d 条, got %d", traceKeep, n)
+	}
+	// 修剪掉的必须是最老的那些，而且别动别的仓库
+	if got := s.ReadTrace("/repo/a", 1); len(got) != 1 || got[0].Branch != "newest" {
+		t.Fatalf("最新那条不该被修剪掉: %+v", got)
+	}
+	// 被砍掉的是最老的那 20 条
+	var oldest string
+	if err := s.db.QueryRow(`SELECT branch FROM project_traces WHERE repo='/repo/a'
+		ORDER BY at ASC LIMIT 1`).Scan(&oldest); err != nil {
+		t.Fatal(err)
+	}
+	if oldest != "b21" {
+		t.Fatalf("砍掉的应当是最老的那些，现存最老是 %q", oldest)
+	}
+	if got := s.ReadTrace("/repo/b", 10); len(got) != 1 {
+		t.Fatalf("修剪串到别的仓库了: %+v", got)
 	}
 }

--- a/backend/project/service_test.go
+++ b/backend/project/service_test.go
@@ -2,8 +2,10 @@ package project
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"ttmux-web/internal/id"
@@ -164,5 +166,73 @@ func TestLoadMergesDuplicateDirs(t *testing.T) {
 		if d, ok := s.Dir(k); !ok || d != "/x" {
 			t.Fatalf("老 key %s 应仍解析到 /x", k)
 		}
+	}
+}
+
+// 留痕从文件尾部回读：要的永远是最新那几条，而文件会长到 5MB 才轮转。
+// 这几条同时钉住「新在前」「按仓库过滤」「跨块边界不丢行」「够了就不再往回读」。
+func TestReadTraceReturnsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, nil)
+	for i := 0; i < 5; i++ {
+		s.Trace(TraceEntry{Repo: "/repo/a", Branch: fmt.Sprintf("b%d", i), Action: "merged"})
+		s.Trace(TraceEntry{Repo: "/repo/other", Branch: "noise", Action: "cleaned"})
+	}
+	got := s.ReadTrace("/repo/a", 3)
+	if len(got) != 3 {
+		t.Fatalf("要 3 条, got %d", len(got))
+	}
+	for i, want := range []string{"b4", "b3", "b2"} {
+		if got[i].Branch != want {
+			t.Fatalf("第 %d 条 = %q, want %q（新在前）", i, got[i].Branch, want)
+		}
+	}
+	for _, e := range got {
+		if e.Repo != "/repo/a" {
+			t.Fatalf("串了别的仓库: %+v", e)
+		}
+	}
+}
+
+// 单条留痕远小于块大小，但总量要能跨过 64KB 的块边界——回读时那里最容易丢行。
+func TestReadTraceAcrossChunkBoundary(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, nil)
+	// 每条塞一段长 branch 名，几百条就能跨过 64KB
+	pad := strings.Repeat("x", 300)
+	const n = 400
+	for i := 0; i < n; i++ {
+		s.Trace(TraceEntry{Repo: "/repo/a", Branch: fmt.Sprintf("%s-%d", pad, i), Action: "merged"})
+	}
+	got := s.ReadTrace("/repo/a", n)
+	if len(got) != n {
+		t.Fatalf("跨块回读丢了行: got %d, want %d", len(got), n)
+	}
+	if !strings.HasSuffix(got[0].Branch, fmt.Sprintf("-%d", n-1)) {
+		t.Fatalf("最新那条不对: %q", got[0].Branch)
+	}
+	if !strings.HasSuffix(got[n-1].Branch, "-0") {
+		t.Fatalf("最老那条不对: %q", got[n-1].Branch)
+	}
+}
+
+// 轮转过一代之后，当前这代不够就该往上一代找。
+func TestReadTraceFallsBackToRotated(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, nil)
+	old := filepath.Join(dir, "activity.log.1")
+	line, _ := json.Marshal(TraceEntry{Repo: "/repo/a", Branch: "ancient", Action: "merged"})
+	if err := os.WriteFile(old, append(line, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.Trace(TraceEntry{Repo: "/repo/a", Branch: "fresh", Action: "merged"})
+
+	got := s.ReadTrace("/repo/a", 10)
+	if len(got) != 2 || got[0].Branch != "fresh" || got[1].Branch != "ancient" {
+		t.Fatalf("轮转两代应当都读到且新在前: %+v", got)
+	}
+	// 当前这代就够了的话，不必去翻上一代
+	if one := s.ReadTrace("/repo/a", 1); len(one) != 1 || one[0].Branch != "fresh" {
+		t.Fatalf("limit=1 应当只给最新那条: %+v", one)
 	}
 }

--- a/backend/project/trace_bench_test.go
+++ b/backend/project/trace_bench_test.go
@@ -1,0 +1,24 @@
+package project
+
+import (
+	"fmt"
+	"testing"
+)
+
+// 留痕长到轮转阈值时读最近 50 条。
+//
+// 改成尾部回读之前是整文件解析：同一份数据上 35.9ms → 0.10ms（约 350 倍），
+// 而项目活动页每打开一次就付一遍。这条基准留着，免得哪天又被改回全量读。
+func BenchmarkReadTraceLargeLog(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir, nil)
+	for i := 0; i < 20000; i++ {
+		s.Trace(TraceEntry{Repo: "/repo/a", Branch: fmt.Sprintf("feat/branch-name-%d", i), Action: "merged"})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := s.ReadTrace("/repo/a", 50); len(got) != 50 {
+			b.Fatalf("got %d", len(got))
+		}
+	}
+}

--- a/cli/ttmux-cli-go/internal/command/db/db.go
+++ b/cli/ttmux-cli-go/internal/command/db/db.go
@@ -46,10 +46,12 @@ func Run(rt runtime.Runtime, args []string, w io.Writer) error {
 		return setHome(rt, rest, w)
 	case "history":
 		return history(rt, rest, asJSON, w)
+	case "link-agent":
+		return linkAgent(rt, rest, w)
 	case "restore":
 		return restore(rt, rest, asJSON, w)
 	default:
-		return fmt.Errorf("未知子命令 %q（可用：status | migrate | backup | history | restore | set-home）", sub)
+		return fmt.Errorf("未知子命令 %q（可用：status | migrate | backup | history | restore | set-home | link-agent）", sub)
 	}
 }
 
@@ -257,6 +259,24 @@ func backup(rt runtime.Runtime, rest []string, asJSON bool, w io.Writer) error {
 	}
 	ui.Ok(w, "已备份到 %s", ui.Bold(path))
 	return nil
+}
+
+// linkAgent 把会话和它那段 agent 对话（Claude Code 的 <uuid>.jsonl）关联起来。
+//
+// ttmux 自己拉起的 agent 靠 --session-id，关联由构造保证；用户在会话里手敲
+// `claude` 的那些只能由上层推断，所以这里**只记一次不覆盖**——先前确定下来的
+// 那次比后来推断的更可信。
+func linkAgent(rt runtime.Runtime, rest []string, w io.Writer) error {
+	if len(rest) < 2 {
+		return fmt.Errorf("用法：ttmux db link-agent <会话> <对话uuid>")
+	}
+	sess := rt.Resolve(rest[0])
+	if sess == "" {
+		sess = rest[0]
+	}
+	meta := sessmeta.New(rt.HomeDir)
+	meta.DataDir = rt.DataDir
+	return meta.SetAgentSession(sess, rest[1])
 }
 
 // setHome 记会话归属的**台账事实**。后端事后改钉（cdInto 之后、fork 继承父归属）

--- a/cli/ttmux-cli-go/internal/metadb/legacy.go
+++ b/cli/ttmux-cli-go/internal/metadb/legacy.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,14 +31,14 @@ var errNoDataDir = fmt.Errorf("缺 DataDir，跳过旧台账收编: %w", ErrStep
 
 // Report 说明这次收编搬了什么，给 `ttmux db migrate` 打印、也进测试断言。
 type Report struct {
-	Projects, Aliases, Races, Homes, Members, Cards int
+	Projects, Aliases, Races, Homes, Members, Cards, Traces int
 	// SkippedSwarms 是磁盘上有目录、swarms 表里却没有登记的孤儿群。
 	SkippedSwarms []string
 }
 
 func (r Report) String() string {
-	s := fmt.Sprintf("项目 %d · 别名 %d · 竞赛 %d · 会话归属 %d · 蜂群成员 %d · 卡片 %d",
-		r.Projects, r.Aliases, r.Races, r.Homes, r.Members, r.Cards)
+	s := fmt.Sprintf("项目 %d · 别名 %d · 竞赛 %d · 会话归属 %d · 蜂群成员 %d · 卡片 %d · 留痕 %d",
+		r.Projects, r.Aliases, r.Races, r.Homes, r.Members, r.Cards, r.Traces)
 	if len(r.SkippedSwarms) > 0 {
 		s += fmt.Sprintf("（跳过 %d 个孤儿蜂群目录）", len(r.SkippedSwarms))
 	}
@@ -423,4 +424,76 @@ func copySwarmDetail(tx *sql.Tx, dbPath, swarmID string, rep *Report) error {
 		}
 	}
 	return nil
+}
+
+// ── activity.log ────────────────────────────────────────────────────────
+
+type legacyTrace struct {
+	ID         string `json:"id"`
+	Repo       string `json:"repo"`
+	Branch     string `json:"branch"`
+	HeadOid    string `json:"headOid"`
+	Base       string `json:"base"`
+	Action     string `json:"action"`
+	Strategy   string `json:"strategy"`
+	At         int64  `json:"at"`
+	MergedInto string `json:"mergedInto"`
+	MergedKind string `json:"mergedKind"`
+}
+
+// importTraces 收编 activity.log（两代）。
+//
+// 与别的收编不同，这份是 **JSONL 而非 JSON**：一行坏了只丢那一行，不该让整个文件
+// 作废——留痕本来就是「尽力而为的摘要」，半条记录不值得挡住迁移。
+func importTraces(tx *sql.Tx, opt Options) error {
+	if opt.DataDir == "" {
+		return errNoDataDir
+	}
+	n := 0
+	// 先老（.1）后新：同 id 撞上时 INSERT OR IGNORE 保留先插进去的那条，
+	// 而两代之间本来就不会有同 id，顺序只是让 rowid 与时间同向。
+	for _, name := range []string{"activity.log.1", "activity.log"} {
+		b, err := os.ReadFile(filepath.Join(opt.DataDir, name))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var e legacyTrace
+			if json.Unmarshal([]byte(line), &e) != nil {
+				continue // 半条/坏行：丢它一条，别丢整个文件
+			}
+			if e.ID == "" {
+				e.ID = traceID(line) // 老行没有 id 字段；按内容派一个，重跑不会翻倍
+			}
+			res, err := tx.Exec(`INSERT OR IGNORE INTO project_traces
+				(id,repo,branch,head_oid,base,action,strategy,at,merged_into,merged_kind)
+				VALUES(?,?,?,?,?,?,?,?,?,?)`,
+				e.ID, e.Repo, e.Branch, e.HeadOid, e.Base, e.Action, e.Strategy, e.At,
+				e.MergedInto, e.MergedKind)
+			if err != nil {
+				return err
+			}
+			if aff, _ := res.RowsAffected(); aff > 0 {
+				n++
+			}
+		}
+	}
+	// 收编那步（v3）在老机器上早已盖过章，这里只补自己这一格。
+	lastReport.Traces = n
+	return nil
+}
+
+// traceID 给没有 id 的老留痕派一个稳定 id：同一行内容永远得到同一个 id，
+// 于是「导一半崩了再来一遍」不会把已经进库的那些翻倍。
+func traceID(line string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(line))
+	return fmt.Sprintf("t-%016x", h.Sum64())
 }

--- a/cli/ttmux-cli-go/internal/metadb/metadb_test.go
+++ b/cli/ttmux-cli-go/internal/metadb/metadb_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,7 +36,8 @@ func TestFreshDBReachesLatestVersion(t *testing.T) {
 		t.Fatalf("版本 = %d, want %d", v, want)
 	}
 	for _, tb := range []string{"sessions", "swarms", "plugins", "projects",
-		"project_aliases", "races", "session_homes", "swarm_members", "swarm_cards", "tmux_epochs"} {
+		"project_aliases", "races", "session_homes", "swarm_members", "swarm_cards",
+		"tmux_epochs", "project_traces"} {
 		if !HasTable(d.DB, tb) {
 			t.Errorf("表 %s 没建出来", tb)
 		}
@@ -285,4 +287,68 @@ func TestNewerDBVersionIsTolerated(t *testing.T) {
 		t.Fatalf("版本比本二进制新时不该报错: %v", err)
 	}
 	defer Discard(again.Path())
+}
+
+// activity.log 收编：两代都要收，坏行只丢自己，重跑不翻倍。
+func TestImportsActivityLog(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, lines ...string) {
+		if err := os.WriteFile(filepath.Join(dir, name),
+			[]byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("activity.log.1", `{"id":"t-old","repo":"/repo/a","branch":"ancient","action":"merged","at":100}`)
+	write("activity.log",
+		`{"id":"t-new","repo":"/repo/a","branch":"fresh","action":"discarded","at":200,"mergedInto":"main","mergedKind":"squash"}`,
+		`{"repo":"/repo/b","branch":"noid","action":"cleaned","at":150}`, // 老行没有 id
+		`{"repo":"/repo/b","branch":"半`, // 坏行：只丢它一条
+	)
+
+	d, err := Open(dir, Options{DataDir: dir, Now: func() time.Time { return time.Unix(0, 0) }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer Discard(d.Path())
+
+	var n int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM project_traces`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Fatalf("应当收 3 条（坏行丢掉）, got %d", n)
+	}
+	var branch, into, kind string
+	if err := d.QueryRow(`SELECT branch, IFNULL(merged_into,''), IFNULL(merged_kind,'')
+		FROM project_traces WHERE id='t-new'`).Scan(&branch, &into, &kind); err != nil {
+		t.Fatal(err)
+	}
+	if branch != "fresh" || into != "main" || kind != "squash" {
+		t.Fatalf("字段没搬全: %s %s %s", branch, into, kind)
+	}
+	// 没有 id 的老行按内容派了一个稳定 id
+	var noid string
+	if err := d.QueryRow(`SELECT id FROM project_traces WHERE branch='noid'`).Scan(&noid); err != nil {
+		t.Fatal(err)
+	}
+	if noid == "" {
+		t.Fatal("老行应当派到 id")
+	}
+
+	// 再跑一遍收编（模拟「导到一半崩了」重来）：不该翻倍
+	if err := importTraces2(d, dir); err != nil {
+		t.Fatal(err)
+	}
+	var again int
+	if err := d.QueryRow(`SELECT COUNT(*) FROM project_traces`).Scan(&again); err != nil {
+		t.Fatal(err)
+	}
+	if again != n {
+		t.Fatalf("重跑翻倍了: %d → %d", n, again)
+	}
+}
+
+// importTraces2 手动再跑一次收编（版本链已盖章，正常路径不会再跑）。
+func importTraces2(d *DB, dataDir string) error {
+	return d.Tx(func(tx *sql.Tx) error { return importTraces(tx, Options{DataDir: dataDir}) })
 }

--- a/cli/ttmux-cli-go/internal/metadb/migrate_test.go
+++ b/cli/ttmux-cli-go/internal/metadb/migrate_test.go
@@ -241,9 +241,13 @@ func TestDeferredStepDoesNotBlockLaterOnes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	last := mainSteps[len(mainSteps)-1].Version
-	if !done[last] {
-		t.Fatalf("最后一步（v%d）应当照常应用，实际已应用 %v", last, done)
+	// 收编类的步骤都吃 DataDir，缺它就该推迟；**其余每一步都必须照常应用**——
+	// 尤其是排在推迟那步后面的。
+	needsDataDir := map[string]bool{"import-legacy": true, "import-traces": true}
+	for _, st := range mainSteps {
+		if !needsDataDir[st.Name] && !done[st.Version] {
+			t.Fatalf("v%d(%s) 应当照常应用，实际已应用 %v", st.Version, st.Name, done)
+		}
 	}
 	// 推迟的那步确实没盖章，留着下次补
 	var deferred int

--- a/cli/ttmux-cli-go/internal/metadb/schema.go
+++ b/cli/ttmux-cli-go/internal/metadb/schema.go
@@ -17,7 +17,34 @@ var mainSteps = []Step{
 	{Version: 2, Name: "ledger-tables", SQL: ledgerTables},
 	{Version: 3, Name: "import-legacy", Fn: importLegacy},
 	{Version: 4, Name: "agent-session", Fn: addAgentSession},
+	{Version: 5, Name: "project-traces", SQL: createProjectTraces},
+	{Version: 6, Name: "import-traces", Fn: importTraces},
 }
+
+// createProjectTraces 收尾留痕（合入 / 丢弃 / 清理）进表。
+//
+// 它原先是 <dataDir>/activity.log —— 一个只追加的 JSONL，5MB 轮转一代。那形态在
+// M2 并库时被漏下了，代价是双重的：一来重启后它跟别的台账不在同一份快照里，
+// 备份/恢复各走各的；二来 M2 之后 Store 在直连模式下压根不再有文件路径，
+// 于是每一条留痕都被静默丢弃、项目活动恒空（这个洞由本步骤连带堵上）。
+//
+// 建表与收编分成两步：DataDir 拿不到时收编那步会推迟（plugind 之类的入口开库
+// 时就没有），但表必须先建出来 —— 否则后端接上库却无处可写。
+const createProjectTraces = `
+CREATE TABLE IF NOT EXISTS project_traces(
+	id          TEXT PRIMARY KEY,
+	repo        TEXT NOT NULL DEFAULT '',
+	branch      TEXT,
+	head_oid    TEXT,
+	base        TEXT,
+	action      TEXT,
+	strategy    TEXT,
+	at          INTEGER NOT NULL DEFAULT 0,
+	merged_into TEXT,
+	merged_kind TEXT
+);
+CREATE INDEX IF NOT EXISTS project_traces_repo ON project_traces(repo, at DESC);
+`
 
 // addAgentSession 给 sessions 加 agent_session_uuid：agent 那一侧的对话 id。
 //

--- a/cli/ttmux-cli-go/internal/sessmeta/sessmeta.go
+++ b/cli/ttmux-cli-go/internal/sessmeta/sessmeta.go
@@ -249,6 +249,8 @@ func (s *Store) SetRestoredFrom(session, from string) error {
 // SetAgentSession 记 agent 那一侧的对话 id（Claude Code 的 <uuid>.jsonl）。
 // 拉起 agent 时传了 --session-id，这里把同一个 uuid 落进台账——「重开并接回原对话」
 // 全靠它，而它必须在会话还活着的时候记下来。
+// **只记一次，不覆盖**：一个会话里可能先后跑过好几段 claude，我们要的是它自己
+// 那一段的起点；而上层的关联多少带点推断成分，覆盖只会让先前确定的那次变得不确定。
 func (s *Store) SetAgentSession(session, uuid string) error {
 	if session == "" || uuid == "" {
 		return nil
@@ -257,7 +259,8 @@ func (s *Store) SetAgentSession(session, uuid string) error {
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(`UPDATE sessions SET agent_session_uuid=? WHERE id=?`, uuid, session)
+	_, err = db.Exec(`UPDATE sessions SET agent_session_uuid=?
+		WHERE id=? AND IFNULL(agent_session_uuid,'')=''`, uuid, session)
 	return err
 }
 

--- a/docs/design/web/19-metadata-durability/_parts/concurrency.html
+++ b/docs/design/web/19-metadata-durability/_parts/concurrency.html
@@ -19,7 +19,7 @@ WAL 能让读写并发，写本身仍然是串行的；真正省掉锁竞争的�
 <tr><td><code>sessions</code> · <code>tmux_epochs</code></td><td><b>ttmux CLI</b></td><td>后端只读；要写就调 <code>ttmux</code> 子命令</td><td>会话 id 的唯一出处在 CLI，编排逻辑也在 CLI（「薄封装」原则）</td></tr>
 <tr><td><code>swarms</code> · <code>swarm_members</code></td><td><b>ttmux CLI</b></td><td>同上</td><td>蜂群编排整个在 CLI</td></tr>
 <tr><td><code>plugin_sessions</code> · <code>plugin_findings</code></td><td><b>ttmux CLI</b></td><td>同上</td><td>插件宿主在 CLI</td></tr>
-<tr><td><code>projects</code> · <code>project_aliases</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>项目是 Web 侧的概念，CLI 里没有</td></tr>
+<tr><td><code>projects</code> · <code>project_aliases</code> · <code>project_traces</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>项目是 Web 侧的概念，CLI 里没有</td></tr>
 <tr><td><code>races</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>竞赛只有 Web 有入口</td></tr>
 </tbody>
 </table>
@@ -95,6 +95,7 @@ CLI 建会话、后端下一轮轮询时才把项目记上。并库之后可以�
 <tr><td><code>session-homes.json</code></td><td><code>sessions.home_dir</code></td><td>按 <code>$N</code> 认不到会话的，用 name 快照回填成 dead 行</td></tr>
 <tr><td><code>meta/&lt;id&gt;/*.txt</code></td><td><code>sessions</code> 的 kind / home_dir / created_at</td><td>目录保留（CLI 老路径还在读）</td></tr>
 <tr><td><code>races.json</code></td><td><code>races</code></td><td>—</td></tr>
+<tr><td><code>activity.log</code>（两代）</td><td><code>project_traces</code></td><td>JSONL 坏行只丢自己那一行；没有 <code>id</code> 的老行按内容派一个稳定 id，重跑不翻倍。标记单独一个 <code>metadb-traces.done</code>——共用 v3 的标记，老机器就永远轮不到退休它</td></tr>
 <tr><td><code>swarms/&lt;群&gt;/swarm.db</code> 的 <code>members</code> / <code>cards</code></td><td><code>swarm_members</code> / <code>swarm_cards</code></td><td><code>posts</code> 原地不动（§9.3）</td></tr>
 <tr><td>老 <code>sessions</code> 表</td><td>v1 主键就是会话名，直搬；v2 按 name 列重建主键，parent 的 <code>$N</code> 用<b>同表内</b>映射翻译</td><td>解析不出的落成 dead 行，先整库备份</td></tr>
 </tbody>

--- a/docs/design/web/19-metadata-durability/_parts/schema.html
+++ b/docs/design/web/19-metadata-durability/_parts/schema.html
@@ -113,6 +113,20 @@ CREATE TABLE <b>projects</b> (
 );
 CREATE TABLE <b>project_aliases</b> (alias TEXT PRIMARY KEY, project_id TEXT NOT NULL);
 
+<s>-- 收尾留痕（merged / discarded / cleaned）。原先是 activity.log（JSONL，5MB 轮转一代）。</s>
+<s>-- 并库时被漏下，代价是双重的：它与别的台账不在同一份快照里，备份/恢复各走各的；</s>
+<s>-- 而后端一旦直连就没有文件路径了，于是每条留痕都被静默丢弃、项目活动恒空。</s>
+CREATE TABLE <b>project_traces</b> (
+  <i>id</i>          TEXT PRIMARY KEY,
+  repo        TEXT NOT NULL DEFAULT '',  <s>-- = projects.dir</s>
+  branch      TEXT, head_oid TEXT, base TEXT,
+  action      TEXT,                      <s>-- merged | discarded | cleaned</s>
+  strategy    TEXT, merged_into TEXT, merged_kind TEXT,
+  at          INTEGER NOT NULL DEFAULT 0
+);
+<s>-- 文件形态靠轮转给读放大封顶；进了库改成按仓库各留最近 1000 条，写时修剪。</s>
+CREATE INDEX project_traces_repo ON project_traces(repo, at DESC);
+
 <s>-- 主键是**持久会话 id**（= tmux 会话名，见 docs/design/session-identity.md）：</s>
 <s>-- 由创建时刻派生、不可变、跨 tmux server 重启唯一且永不复用 —— 天生就是对的主键。</s>
 CREATE TABLE <b>sessions</b> (

--- a/docs/design/web/19-metadata-durability/design.html
+++ b/docs/design/web/19-metadata-durability/design.html
@@ -385,6 +385,20 @@ CREATE TABLE <b>projects</b> (
 );
 CREATE TABLE <b>project_aliases</b> (alias TEXT PRIMARY KEY, project_id TEXT NOT NULL);
 
+<s>-- 收尾留痕（merged / discarded / cleaned）。原先是 activity.log（JSONL，5MB 轮转一代）。</s>
+<s>-- 并库时被漏下，代价是双重的：它与别的台账不在同一份快照里，备份/恢复各走各的；</s>
+<s>-- 而后端一旦直连就没有文件路径了，于是每条留痕都被静默丢弃、项目活动恒空。</s>
+CREATE TABLE <b>project_traces</b> (
+  <i>id</i>          TEXT PRIMARY KEY,
+  repo        TEXT NOT NULL DEFAULT '',  <s>-- = projects.dir</s>
+  branch      TEXT, head_oid TEXT, base TEXT,
+  action      TEXT,                      <s>-- merged | discarded | cleaned</s>
+  strategy    TEXT, merged_into TEXT, merged_kind TEXT,
+  at          INTEGER NOT NULL DEFAULT 0
+);
+<s>-- 文件形态靠轮转给读放大封顶；进了库改成按仓库各留最近 1000 条，写时修剪。</s>
+CREATE INDEX project_traces_repo ON project_traces(repo, at DESC);
+
 <s>-- 主键是**持久会话 id**（= tmux 会话名，见 docs/design/session-identity.md）：</s>
 <s>-- 由创建时刻派生、不可变、跨 tmux server 重启唯一且永不复用 —— 天生就是对的主键。</s>
 CREATE TABLE <b>sessions</b> (
@@ -659,7 +673,7 @@ WAL 能让读写并发，写本身仍然是串行的；真正省掉锁竞争的�
 <tr><td><code>sessions</code> · <code>tmux_epochs</code></td><td><b>ttmux CLI</b></td><td>后端只读；要写就调 <code>ttmux</code> 子命令</td><td>会话 id 的唯一出处在 CLI，编排逻辑也在 CLI（「薄封装」原则）</td></tr>
 <tr><td><code>swarms</code> · <code>swarm_members</code></td><td><b>ttmux CLI</b></td><td>同上</td><td>蜂群编排整个在 CLI</td></tr>
 <tr><td><code>plugin_sessions</code> · <code>plugin_findings</code></td><td><b>ttmux CLI</b></td><td>同上</td><td>插件宿主在 CLI</td></tr>
-<tr><td><code>projects</code> · <code>project_aliases</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>项目是 Web 侧的概念，CLI 里没有</td></tr>
+<tr><td><code>projects</code> · <code>project_aliases</code> · <code>project_traces</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>项目是 Web 侧的概念，CLI 里没有</td></tr>
 <tr><td><code>races</code></td><td><b>Roam 后端</b></td><td>CLI 不碰</td><td>竞赛只有 Web 有入口</td></tr>
 </tbody>
 </table>
@@ -735,6 +749,7 @@ CLI 建会话、后端下一轮轮询时才把项目记上。并库之后可以�
 <tr><td><code>session-homes.json</code></td><td><code>sessions.home_dir</code></td><td>按 <code>$N</code> 认不到会话的，用 name 快照回填成 dead 行</td></tr>
 <tr><td><code>meta/&lt;id&gt;/*.txt</code></td><td><code>sessions</code> 的 kind / home_dir / created_at</td><td>目录保留（CLI 老路径还在读）</td></tr>
 <tr><td><code>races.json</code></td><td><code>races</code></td><td>—</td></tr>
+<tr><td><code>activity.log</code>（两代）</td><td><code>project_traces</code></td><td>JSONL 坏行只丢自己那一行；没有 <code>id</code> 的老行按内容派一个稳定 id，重跑不翻倍。标记单独一个 <code>metadb-traces.done</code>——共用 v3 的标记，老机器就永远轮不到退休它</td></tr>
 <tr><td><code>swarms/&lt;群&gt;/swarm.db</code> 的 <code>members</code> / <code>cards</code></td><td><code>swarm_members</code> / <code>swarm_cards</code></td><td><code>posts</code> 原地不动（§8.3）</td></tr>
 <tr><td>老 <code>sessions</code> 表</td><td>v1 主键就是会话名，直搬；v2 按 name 列重建主键，parent 的 <code>$N</code> 用<b>同表内</b>映射翻译</td><td>解析不出的落成 dead 行，先整库备份</td></tr>
 </tbody>

--- a/scripts/dev/quality/check.sh
+++ b/scripts/dev/quality/check.sh
@@ -89,6 +89,19 @@ if [ -n "$staged" ]; then
     echo ".env must not be committed. Use configs/config.yaml.template for documented config instead." >&2
     exit 1
   fi
+  # 按内容拦编译产物：上面两条按名字认，而名字永远认不出下一个意外——
+  # 一个 34MB 的后端二进制曾经落在 .gitignore 没盖住的路径上，就这么进了一次提交。
+  # 仓库里最大的正经文件也就几百 KB，1MB 以上的二进制一律当误提交。
+  while IFS= read -r f; do
+    [ -n "$f" ] && [ -f "$f" ] || continue
+    size="$(wc -c < "$f" | tr -d ' ')"
+    [ "$size" -gt 1048576 ] || continue
+    grep -Iq . "$f" 2>/dev/null && continue   # -I：二进制文件永不匹配
+    echo "$f is a $((size / 1024 / 1024))MB binary. Build output must not be committed — add it to .gitignore." >&2
+    exit 1
+  done <<EOF
+$staged
+EOF
 fi
 
 section "Quality gate passed"


### PR DESCRIPTION
## 1. 收尾留痕进库（本 PR 的主菜）

留痕（merged / discarded / cleaned）此前是 `<dataDir>/activity.log`，一个只追加的 JSONL。M2 并库时把它漏下了，代价是双重的：

1. **它与别的台账不在同一份快照里**。备份/恢复各走各的，「重启后能恢复」这句话对它不成立 —— 而它恰恰是 worktree 删掉之后唯一还能回答「这个任务去哪了」的东西。
2. **更要紧的是它其实已经不写了。** `Store` 的文件路径只在降级分支赋值，直连模式下直接 `return`，于是 `tracePath()` 恒空 —— `Trace()` 每一条都被丢掉、`ReadTrace()` 恒返回 nil，还一声不吭。本机上最后一条留痕停在 `8-12 18:08`，正是迁移落库那一刻。

现在建表 `project_traces`（schema v5）+ 收编两代 `activity.log`（v6），后端直连时读写都走库；开不了库仍走老的文件路径。

几个决定：

- **建表与收编分成两步**。`DataDir` 拿不到时收编会推迟（plugind 之类的入口开库时就没有），但表必须先建出来，否则后端接上库却无处可写。
- **修剪代替轮转**。文件形态靠「5MB 轮转一代」给读放大封顶，进了库那条没了 —— 按仓库各留最近 1000 条、写时修剪（合入/丢弃/清理都是人的动作，稀疏）。
- **收编标记单独一个** `metadb-traces.done`。留痕是后来才收编的，而 v3 的标记在老机器上早就落下了 —— 共用一个标记等于「这台机器永远轮不到退休 `activity.log`」，源文件就一直躺着，谁再打开它就看到一份与库分叉的旧数据。
- 排序 `at DESC, rowid DESC`：一次清理会在同一秒里一口气写好几条，光看 `at` 分不出先后，活动列表的顺序会随查询计划漂。
- 后端那份测试骨架 schema 导出复用，不新摆第三份定义（漂了有 `TestSchemaMatchesRealCLI` 对拍兜着）。

**本机验过**：迁移收编 51 条留痕（29 条属于本仓库），`activity.log` 已退休改名 `.bak-20260813-071053`。

## 2. 手敲起来的 claude 会话也能接回对话

「重开并接回原对话」此前只对 ttmux 拉起的 agent 成立（spawn / 蜂群成员走 `--session-id`，关联由构造保证）。可日常用法是「`ttmux new` 建个会话，然后自己在里面敲 `claude`」—— 那条路插不进参数，重开只能给个空壳。

**认法**：会话开始跑 claude 的那一刻，先把它工作目录下已有的对话文件名记下来；之后哪一份是新冒出来的，哪一份就是它的。挂在 `/projects` 那次进程树扫描上，不额外付代价。

两个细节是真机踩出来的：

- **不能只看跃迁后那一轮**。Claude Code 要等**第一条消息**才把对话落盘，中间隔多久取决于人什么时候开口。第一版只在跃迁那一轮看了一眼，实测什么也认不到；改成一直等到它出现（30 分钟封顶）。
- **不能用 mtime 判「新」**。同目录里别的会话继续说话时，它自己那份的 mtime 也会被刷新，看起来就像新出现的。判据必须是文件名集合的差集。

**宁可不认也不认错**：同一目录同时有两个会话在等，就一个都不认（本机 13 个活会话挤在 7 个目录里，这是常态）；一轮冒出好几份对话也不认。空着顶多是重开时给个空壳，认错了却是把别人的对话摆到你面前。

**真机验过闭环**：建会话 → 手敲 claude → 说一句话 → 杀掉 → 重开，原对话原样接回。

## 3. 降级模式下的留痕读取 35.9ms → 0.10ms

`ReadTrace` 原先把两代 `activity.log` 整个读进来解析，只为挑最近 50 条。改成从尾部按块回读、凑够就停（同一份 1.9MB 数据约 350 倍）。留痕进库后这条路只在开不了库时才走，但那正是最该还能用的时候。

## 验收

- `scripts/dev/quality/check.sh quick` 通过
- 新增测试：留痕直连读写 3 条（含那个「静默丢弃」的回归锁）、收编 1 条、退休标记 2 条、关联 7 条、尾部回读 3 条 + 1 条基准
- 真机：迁移 → 收编 → 退休 → 重启后端全程验过
