### PR TITLE
fix(monitor): 交换空间用满要看得见 —— 它是整机卡死的前兆

### DIFF
--- a/frontend/src/components/plugins/HostMonitorPanel.swap.test.tsx
+++ b/frontend/src/components/plugins/HostMonitorPanel.swap.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+//
+// 交换空间用满是**整机卡死的前兆**，不是「内存用得比较多」。这块面板一直在采它、
+// 也一直在画它，但画成了一根固定灰色的小条：98% 和 5% 长得一模一样。
+// 本机 2026-08-12 下午就是这么冻死的（ping 通、ssh 进不去，只能按电源键），
+// 而之前三天 swap 一直贴着 98%——数字就在屏幕上，没人可能看出来。
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import HostMonitorPanel, { type Snapshot } from './HostMonitorPanel'
+
+const GB = 1024 ** 3
+
+function snapshot(swapUsed: number, swapTotal: number): Snapshot {
+  return {
+    time: '2026-08-13T08:00:00Z',
+    host: { hostname: 'box', load1: 1, load5: 1, load15: 1 },
+    cpu: { cores: 8, usagePercent: 10 },
+    memory: { total: 32 * GB, used: 20 * GB, available: 12 * GB, usagePercent: 62, swapTotal, swapUsed },
+    disks: null, gpus: null,
+    network: { rxBytesPerSec: 0, txBytesPerSec: 0 },
+    history: null,
+  }
+}
+
+// t 直接回 key：断言看的是「这句话出没出现」，不依赖任何一种语言的措辞。
+const show = (used: number, total = 8 * GB) =>
+  render(<HostMonitorPanel pluginId="roam.host-monitor" enabled t={(k) => k}
+    fetchSnapshot={async () => snapshot(used, total)} />)
+
+const swapBar = () => document.querySelectorAll('.ant-progress-line .ant-progress-bg')[0] as HTMLElement | undefined
+
+afterEach(cleanup)
+
+describe('交换空间告警', () => {
+  it('快用完时变红并说明后果', async () => {
+    show(7.9 * GB)
+    await waitFor(() => expect(screen.getByText('plugins.monitor.swapCritical')).toBeTruthy())
+    expect(swapBar()?.style.background).toContain('--danger')
+  })
+
+  it('用得不多时不喊，也不刺眼', async () => {
+    show(0.8 * GB)
+    await waitFor(() => expect(screen.getByText(/^Swap /)).toBeTruthy())
+    expect(screen.queryByText('plugins.monitor.swapCritical')).toBeNull()
+    expect(swapBar()?.style.background).toContain('--ok')
+  })
+
+  // 没有交换分区的机器（容器里常见）不该出现一根 NaN% 的条
+  it('没有交换分区就整块不画', async () => {
+    show(0, 0)
+    await waitFor(() => expect(screen.getByText('box')).toBeTruthy())
+    expect(screen.queryByText(/^Swap /)).toBeNull()
+  })
+})

--- a/frontend/src/components/plugins/HostMonitorPanel.tsx
+++ b/frontend/src/components/plugins/HostMonitorPanel.tsx
@@ -38,9 +38,35 @@ function fmtBytes(n: number, perSec = false): string {
 }
 
 function usageColor(p: number): string {
-  if (p >= 90) return '#f5222d'
-  if (p >= 70) return '#faad14'
+  if (p >= 90) return 'var(--danger)'
+  if (p >= 70) return 'var(--warn)'
   return 'var(--ok)'
+}
+
+// SwapBar 交换空间。
+//
+// 它和上面那个内存表盘不是一回事：内存用到 70% 很正常，交换空间用满则是**整机卡死的
+// 前兆**——一旦换页无处可去，内核就在直接回收里空转，ping 还通（内核收发 ICMP 不换页）
+// 但 ssh 再也进不来，只能按电源键。本机 2026-08-12 那次就是这么冻的，而那三天里 swap
+// 一直贴着 98%——数字一直在这块面板上，只是画成了一根永不变色的灰条，和 5% 长得一样。
+function SwapBar({ used, total, t }: {
+  used: number; total: number
+  t: (k: string, vars?: Record<string, string | number>) => string
+}) {
+  const pct = Math.round((used / total) * 100)
+  return (
+    <div style={{ marginTop: 'var(--sp-2)' }}>
+      <Typography.Text type="secondary" style={{ fontSize: 'var(--fs-meta)' }}>
+        Swap {fmtBytes(used)} / {fmtBytes(total)}
+      </Typography.Text>
+      <Progress percent={pct} showInfo={false} size="small" strokeColor={usageColor(pct)} />
+      {pct >= 90 && (
+        <div style={{ color: 'var(--danger)', fontSize: 'var(--fs-micro)' }}>
+          {t('plugins.monitor.swapCritical')}
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ── 轻量 SVG 面积走势图(不引图表库) ──
@@ -180,18 +206,10 @@ export default function HostMonitorPanel({ pluginId, enabled, t, fetchSnapshot }
             <Progress type="dashboard" size={88} percent={Math.round(memory.usagePercent)}
               strokeColor={usageColor(memory.usagePercent)} />
             <div style={{ flex: 1, minWidth: 0, alignSelf: 'stretch', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
-              <Sparkline series={history.map((h) => h.mem)} color="#d2a8ff" max={100} />
+              <Sparkline series={history.map((h) => h.mem)} color="var(--hl-title)" max={100} />
             </div>
           </Space>
-          {memory.swapTotal > 0 && (
-            <div style={{ marginTop: 8 }}>
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                Swap {fmtBytes(memory.swapUsed)} / {fmtBytes(memory.swapTotal)}
-              </Typography.Text>
-              <Progress percent={Math.round((memory.swapUsed / memory.swapTotal) * 100)}
-                showInfo={false} size="small" strokeColor="#8b949e" />
-            </div>
-          )}
+          {memory.swapTotal > 0 && <SwapBar used={memory.swapUsed} total={memory.swapTotal} t={t} />}
         </StatCard>
 
         {/* GPU */}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1520,6 +1520,7 @@ const enUS = {
   'plugins.monitor.pollFailed': 'Refresh failed',
   'plugins.monitor.cpu': 'CPU',
   'plugins.monitor.memory': 'Memory',
+  'plugins.monitor.swapCritical': 'Swap is nearly exhausted — more pressure will hang the whole machine (ping still replies, SSH will not).',
   'plugins.monitor.gpu': 'GPU',
   'plugins.monitor.disk': 'Disk',
   'plugins.monitor.network': 'Network',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1525,6 +1525,7 @@ const zhCN = {
   'plugins.monitor.pollFailed': '刷新失败',
   'plugins.monitor.cpu': 'CPU',
   'plugins.monitor.memory': '内存',
+  'plugins.monitor.swapCritical': '交换空间快用完了 —— 再吃内存整机会卡死到只能按电源键（ping 还通，ssh 进不来）',
   'plugins.monitor.gpu': 'GPU',
   'plugins.monitor.disk': '磁盘',
   'plugins.monitor.network': '网络',


### PR DESCRIPTION
## 事故

2026-08-12 下午本机冻死：**ping 通，ssh 进不去**，最后按电源键强制重启（也正是这次重启导致了项目/会话台账丢失，即 #210 那条链的起点）。

## 不是这个应用的锅，但它本该报警

排查结论按证据排：

| 怀疑 | 证据 | 结论 |
|---|---|---|
| CPU 打满 | `sar -q`：整个窗口 load 峰值 6.96 / 24 核，runq-sz ≤ 8，blocked ≤ 1 | 排除 |
| PID 耗尽 | `plist-sz` 全程 4700~5100 | 排除 |
| OOM 杀进程 | 上一个 boot 全程无 `oom-kill` / `Killed process` | 没发生 |
| 磁盘/文件系统 | 无 `I/O error` / `EXT4-fs error` / `blocked for more than 120s` | 排除 |
| 应用泄漏 | 后端常驻进程 RSS 44MB | 排除 |
| **换页耗尽** | `sar -S`：8G swap 连着三天贴 98~100%；`%commit` 180~205% | **就是它** |

swap 一满，内核就在直接回收里空转：ping 照样通（收发 ICMP 不需要换页），sshd 要 fork + 换入，于是永远排不上。这正是「ping 通 ssh 死」的教科书形态。

应用自己没泄漏，但它是**主要消耗方**：13 个 tmux 会话各挂一个 claude ≈ 3.9G，headless Chrome ≈ 2.9G。同机还有 Android 模拟器 5.3G、gradle/java 2.7G —— 都不是应用的。所以是整机长期超售，不是某一处 bug。

## 本 PR 改什么

**唯一的前兆一直在监控面板上，但画成了看不见的样子。** swap 条是固定 `#8b949e` 的小灰条 —— 98% 和 5% 长得一模一样；旁边的内存表盘反倒会随用量变色。

- swap 条改用和内存表盘同一套色阶（`--ok` → `--warn` → `--danger`）
- ≥90% 补一句说明**后果**：写明「ping 还通但 ssh 进不来」。光说「swap 高」没人知道那意味着要按电源键
- 顺带把这块的硬编码色值换回令牌：`#f5222d`/`#faad14` → `--danger`/`--warn`，`#d2a8ff` → `--hl-title`。AGENTS.md 本来就不许抄色值，而这次正是「颜色不表意」酿的祸
- 中心页的节点监控复用同一个组件，一处改两处生效
- 新增 3 条测试（变红并出警告 / 低位不喊 / 无交换分区整块不画）

## 还有一条我改不动：系统的 OOM 兜底是关的

`systemd-oomd` 在跑（当天早上被 `apt-daily-upgrade` 重启过，同秒又起来了，冻结时是活的），**但它什么都没管**：

```
$ oomctl
Swap Used Limit: 90.00%
Swap Monitored CGroups:        ← 空的
```

Ubuntu 默认给 `-.slice` 下的 drop-in 是 `ManagedOOMSwap=auto`，等于关掉了「按 swap 杀」这条路。所以 swap 满到 100% 也没有任何人来收拾，只能一直磨到人来按电源键。

本机 sudo 需要密码，我没法代劳。建议执行（当前 swap 41%，开了不会立刻杀东西，等再爬到 90% 才动手）：

```bash
sudo mkdir -p /etc/systemd/system/-.slice.d
printf "[Slice]\nManagedOOMSwap=kill\n" | sudo tee /etc/systemd/system/-.slice.d/50-oomd-swap.conf
sudo systemctl daemon-reload && sudo systemctl restart systemd-oomd
oomctl | head -8      # 确认 Swap Monitored CGroups 下出现 /

# 再给 sshd 留一条活路：压力再大也别把它的页换出去，好歹能 ssh 进来收拾
sudo systemctl edit ssh.service   # 加：[Service] 换行 MemoryMin=64M
```
