### PR TITLE
perf(chat): 对话首屏只取尾部 · 滚上去不再被拽回底部

### DIFF
--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -538,25 +538,46 @@ func (a *API) ClaudeTranscript(c *gin.Context) {
 	}
 	defer f.Close()
 
-	msgs := []cMsg{}
+	tail := tailLimit(c, offset)
+	win := newTranscriptWindow(tail)
 	st := cStatus{}
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 1024*1024), 8*1024*1024) // 容纳长行
 	n := 0
-	for sc.Scan() {
-		n++
-		if n <= offset {
-			continue
-		}
-		line := sc.Text()
-		st = scanStatus(line, st)
-		if m := parseLine(line); m != nil {
-			if m.ID == "" { // uuid 缺失时用行号兜底，保证稳定 key
-				m.ID = strconv.Itoa(n)
+	if tail > 0 {
+		// 首屏：只解析尾部那几百行。状态字段(cwd/model/branch/mode)每行都带，尾部就够。
+		lines, first, total := tailLines(sc, tail*tailLineFactor)
+		for i, line := range lines {
+			st = scanStatus(line, st)
+			if m := parseLine(line); m != nil {
+				if m.ID == "" {
+					m.ID = strconv.Itoa(first + i)
+				}
+				win.add(*m)
 			}
-			msgs = append(msgs, *m)
+		}
+		n = total
+		if first > 1 {
+			win.dropped = true // 前面还有整整一截没读，别让前端以为这就是全部
+		}
+	} else {
+		for sc.Scan() {
+			n++
+			if n <= offset {
+				continue
+			}
+			line := sc.Text()
+			st = scanStatus(line, st)
+			if m := parseLine(line); m != nil {
+				if m.ID == "" { // uuid 缺失时用行号兜底，保证稳定 key
+					m.ID = strconv.Itoa(n)
+				}
+				win.add(*m)
+			}
 		}
 	}
+	msgs, truncated := win.out()
 	// 这一轮没扫到新行时 status 是空的；前端 sticky 保留上一次的值。
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"messages": msgs, "nextOffset": n, "file": file, "status": st}})
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{
+		"messages": msgs, "nextOffset": n, "file": file, "status": st, "truncated": truncated}})
 }

--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -367,27 +367,46 @@ func (a *API) CodexTranscript(c *gin.Context) {
 	}
 	defer f.Close()
 
-	msgs := []cMsg{}
+	tail := tailLimit(c, offset)
+	win := newTranscriptWindow(tail)
 	st := cStatus{}
 	quota := 0.0
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 1024*1024), 8*1024*1024)
 	n := 0
-	for sc.Scan() {
-		n++
-		if n <= offset {
-			continue
-		}
-		line := sc.Text()
-		st = scanCodexStatus(line, st, &quota)
-		if m := parseCodexLine(line); m != nil {
-			if m.ID == "" { // 行号作稳定 key（前端窗口化/折叠态持久化用）
-				m.ID = strconv.Itoa(n)
+	if tail > 0 {
+		lines, first, total := tailLines(sc, tail*tailLineFactor) // 首屏只解析尾部，见 transcript-window.go
+		for i, line := range lines {
+			st = scanCodexStatus(line, st, &quota)
+			if m := parseCodexLine(line); m != nil {
+				if m.ID == "" {
+					m.ID = strconv.Itoa(first + i)
+				}
+				win.add(*m)
 			}
-			msgs = append(msgs, *m)
+		}
+		n = total
+		if first > 1 {
+			win.dropped = true
+		}
+	} else {
+		for sc.Scan() {
+			n++
+			if n <= offset {
+				continue
+			}
+			line := sc.Text()
+			st = scanCodexStatus(line, st, &quota)
+			if m := parseCodexLine(line); m != nil {
+				if m.ID == "" { // 行号作稳定 key（前端窗口化/折叠态持久化用）
+					m.ID = strconv.Itoa(n)
+				}
+				win.add(*m)
+			}
 		}
 	}
-	data := gin.H{"messages": msgs, "nextOffset": n, "file": file, "status": st}
+	msgs, truncated := win.out()
+	data := gin.H{"messages": msgs, "nextOffset": n, "file": file, "status": st, "truncated": truncated}
 	if quota > 0 {
 		data["quota"] = quota
 	}

--- a/backend/api/transcript-window.go
+++ b/backend/api/transcript-window.go
@@ -1,0 +1,89 @@
+package api
+
+// transcript-window.go：转录首屏的尾部滑窗。
+//
+// 一卷转录能长到几万条（本机最大的 JSONL 已经 155MB），而对话界面开屏只渲染最近一屏。
+// 把整卷搬过去纯属白搬：实测一个 3542 条的会话首屏要传 3MB、等 4.6s，其中 94% 的消息
+// 前端拿到就扔。tail=N 让首屏只带最近 N 条，增量轮询照旧按 offset 走（那时一条都不能丢）。
+
+import (
+	"bufio"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+const maxTranscriptTail = 2000
+
+// tailLimit 读 ?tail=N：只在首屏(offset=0)生效，增量轮询必须原样返回新行。
+func tailLimit(c *gin.Context, offset int) int {
+	if offset != 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(c.Query("tail"))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	if n > maxTranscriptTail {
+		return maxTranscriptTail
+	}
+	return n
+}
+
+// transcriptWindow 累积消息但只留最后 limit 条；limit<=0 表示不限。
+type transcriptWindow struct {
+	limit   int
+	msgs    []cMsg
+	dropped bool // 真丢过东西：前端据此显示「加载更早」
+}
+
+func newTranscriptWindow(limit int) *transcriptWindow {
+	return &transcriptWindow{limit: limit, msgs: []cMsg{}}
+}
+
+func (w *transcriptWindow) add(m cMsg) {
+	w.msgs = append(w.msgs, m)
+	if w.limit <= 0 || len(w.msgs) <= 2*w.limit {
+		return
+	}
+	// 攒到两倍再压一次：每加一条就重切，底层数组会一直跟着最长的那次不放。
+	w.msgs = append(w.msgs[:0], w.msgs[len(w.msgs)-w.limit:]...)
+	w.dropped = true
+}
+
+// out 返回要发出去的消息与「是否截过头」。
+func (w *transcriptWindow) out() ([]cMsg, bool) {
+	if w.limit > 0 && len(w.msgs) > w.limit {
+		return w.msgs[len(w.msgs)-w.limit:], true
+	}
+	return w.msgs, w.dropped
+}
+
+// 一条消息通常不止一行（thinking / tool_result 之类的行不产出消息），
+// 所以按行取尾时多带几倍，尽量凑够要的条数。
+const tailLineFactor = 4
+
+// tailLines 扫完整份转录，但只留最后 keep 行原文，不解析 JSON。
+// 首屏那几秒的大头是「整卷 JSON 解析」而不是传输：一个 7185 行的会话，
+// 全量解析 3.4s、传 3MB，而前端只渲染最后一屏。这里把解析量压到尾部那几百行。
+// 返回：尾部行、其中第一行的行号(1-based)、文件总行数。
+func tailLines(sc *bufio.Scanner, keep int) (lines []string, firstLine int, total int) {
+	if keep <= 0 {
+		return nil, 0, 0
+	}
+	ring := make([]string, keep)
+	for sc.Scan() {
+		ring[total%keep] = sc.Text()
+		total++
+	}
+	n := keep
+	if total < keep {
+		n = total
+	}
+	out := make([]string, 0, n)
+	start := total - n
+	for i := start; i < total; i++ {
+		out = append(out, ring[i%keep])
+	}
+	return out, start + 1, total
+}

--- a/backend/api/transcript_window_test.go
+++ b/backend/api/transcript_window_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// 尾部滑窗：首屏只要最近 N 条，且要如实说「截过头」——前端据此决定显不显示「加载更早」。
+func TestTranscriptWindow(t *testing.T) {
+	w := newTranscriptWindow(3)
+	for i := 0; i < 10; i++ {
+		w.add(cMsg{ID: string(rune('a' + i))})
+	}
+	msgs, truncated := w.out()
+	if len(msgs) != 3 || !truncated {
+		t.Fatalf("要留最后 3 条且标记截断，得到 %d 条 truncated=%v", len(msgs), truncated)
+	}
+	if msgs[0].ID != "h" || msgs[2].ID != "j" {
+		t.Errorf("留错了段：%s..%s，要 h..j", msgs[0].ID, msgs[2].ID)
+	}
+	// 没超上限就不该说自己截过
+	w2 := newTranscriptWindow(5)
+	w2.add(cMsg{ID: "x"})
+	if msgs, truncated := w2.out(); len(msgs) != 1 || truncated {
+		t.Errorf("没截却报截断: %d %v", len(msgs), truncated)
+	}
+	// limit<=0 = 不限（增量轮询那条路，一条都不能丢）
+	w3 := newTranscriptWindow(0)
+	for i := 0; i < 50; i++ {
+		w3.add(cMsg{})
+	}
+	if msgs, truncated := w3.out(); len(msgs) != 50 || truncated {
+		t.Errorf("不限模式不该丢: %d %v", len(msgs), truncated)
+	}
+	// 空窗口也要回 []（前端按数组用，null 会炸）
+	if msgs, _ := newTranscriptWindow(10).out(); msgs == nil {
+		t.Error("空窗口要回 []，不能是 nil")
+	}
+}
+
+// 取尾部：只留最后 keep 行，并如实报出「第一行是第几行」与总行数——
+// 行号是前端的稳定 key，错一位就会在增量轮询时和新行撞车。
+func TestTailLines(t *testing.T) {
+	mk := func(s string) *bufio.Scanner { return bufio.NewScanner(strings.NewReader(s)) }
+	lines, first, total := tailLines(mk("a\nb\nc\nd\ne\n"), 2)
+	if len(lines) != 2 || lines[0] != "d" || lines[1] != "e" || first != 4 || total != 5 {
+		t.Fatalf("尾部取错: %v first=%d total=%d", lines, first, total)
+	}
+	// 不足 keep 行：全给，且从第 1 行起
+	lines, first, total = tailLines(mk("a\nb\n"), 10)
+	if len(lines) != 2 || first != 1 || total != 2 {
+		t.Errorf("不足 keep 时该全给: %v first=%d total=%d", lines, first, total)
+	}
+	// 空文件
+	if lines, first, total = tailLines(mk(""), 5); len(lines) != 0 || total != 0 || first != 1 {
+		t.Errorf("空文件: %v first=%d total=%d", lines, first, total)
+	}
+	// 末行没有换行符也算一行（转录正被写入时就是这样）
+	if _, _, total = tailLines(mk("a\nb"), 5); total != 2 {
+		t.Errorf("末行无换行也要算: total=%d", total)
+	}
+}

--- a/frontend/src/components/chat/ChatShell.tsx
+++ b/frontend/src/components/chat/ChatShell.tsx
@@ -1,7 +1,7 @@
 // 对话页外壳：滚动区 / 交互选择框 / 输入发送。
 // 会话名、切回终端、文件面板都在上方的会话工具条里，这里不再重复一行头部。
 // Claude、Codex 共用，差异只在 accent、占位文案与消息渲染(renderMessage)。
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Button, Input, App as AntApp } from 'antd'
 import { api, upload, makeClipboardImageFile } from '../../api'
 import { PromptPanel } from '../prompt'
@@ -19,7 +19,7 @@ import type { TaskIndex } from './tasks'
 import { StatusBar, type StatusActions } from './StatusBar'
 import type { AgentStatus } from './status'
 
-export function ChatShell({ name, accent, placeholder, messages, results, renderMessage, pending, busy, error, onOpenFile, tasks, status, onOpenGit, lastErrorId }: {
+export function ChatShell({ name, accent, placeholder, messages, results, renderMessage, pending, busy, error, onOpenFile, tasks, status, onOpenGit, lastErrorId, hasEarlier, onLoadEarlier }: {
   name: string
   accent: string
   placeholder: string
@@ -35,6 +35,10 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
   status?: AgentStatus
   onOpenGit?: () => void
   lastErrorId?: string
+  /** 后端首屏截过头：还有更早的没取过来 */
+  hasEarlier?: boolean
+  /** 把首屏窗口放大一档重取（往回翻） */
+  onLoadEarlier?: () => void
 }) {
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
@@ -134,16 +138,30 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
   // 单独成一条消息，一串 5 条命令就是 5 条消息，消息内部的分段对它无能为力。
   const items = useMemo(() => (results ? groupRuns(visible, results) : null), [visible, results])
 
-  // 贴底时自动跟随新消息；用户上滚后不打扰，改成累计未读
-  useEffect(() => {
+  // 贴底时自动跟随新消息；用户上滚后不打扰，改成累计未读。
+  //
+  // 离底时还要「锚住」：新消息一来，只渲染最近 N 条的窗口就往前滑，顶上那几条被摘掉，
+  // 剩下的内容整体上移——你读着读着字自己往上跑，手感就是「滚不上去、老被拽回底部」。
+  // 所以顶部身份一变就按高度差回补 scrollTop，让眼皮底下那段纹丝不动。
+  // 必须是 useLayoutEffect：它在 paint 之前跑完，补位是「本来就没动过」；
+  // 放在 useEffect 里补，用户会先看见跳一下再跳回来。
+  const anchor = useRef({ height: 0, top: 0, firstId: '' })
+  useLayoutEffect(() => {
+    const el = boxRef.current
+    if (!el) return
+    const firstId = visible[0]?.id || ''
     if (atBottom.current) {
-      if (boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight
+      el.scrollTop = el.scrollHeight
       seenCount.current = messages.length
       setUnread(0)
     } else {
+      if (anchor.current.firstId && firstId !== anchor.current.firstId) {
+        el.scrollTop = anchor.current.top + (el.scrollHeight - anchor.current.height)
+      }
       setUnread(Math.max(0, messages.length - seenCount.current))
     }
-  }, [messages, pending])
+    anchor.current = { height: el.scrollHeight, top: el.scrollTop, firstId }
+  }, [messages, pending, visible])
 
   const onScroll = () => {
     const el = boxRef.current
@@ -238,11 +256,12 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
         <div style={{ position: 'relative', flex: 1, minHeight: 0, display: 'flex' }}>
           <div ref={boxRef} onScroll={onScroll} style={{ flex: 1, minHeight: 0, overflowY: 'auto', overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch', padding: '8px 12px' }}>
             {messages.length === 0 && !pending && <div style={{ color: 'var(--text-dim)', textAlign: 'center', marginTop: 30 }}>{t('chat.loadingTranscript')}</div>}
-            {hidden > 0 && (
+            {(hidden > 0 || hasEarlier) && (
               <div style={{ textAlign: 'center', margin: '2px 0 8px' }}>
-                <a onClick={() => setLimit((l) => l + 200)} style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--sp-1)', color: 'var(--text-dim)', fontSize: 'var(--fs-meta)' }}>
-                  <ArrowUp size={12} />{t('chat.loadEarlier', { count: hidden })}
-                </a>
+                {/* 先放本地渲染窗口(手里已有的)，手里这些都放完了再回后端要更早的 */}
+                <button type="button" className="tt-act" onClick={() => (hidden > 0 ? setLimit((l) => l + 200) : onLoadEarlier?.())}>
+                  <ArrowUp size={12} />{hidden > 0 ? t('chat.loadEarlier', { count: hidden }) : t('chat.loadEarlierMore')}
+                </button>
               </div>
             )}
             {items

--- a/frontend/src/components/chat/ClaudeChat.tsx
+++ b/frontend/src/components/chat/ClaudeChat.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '../../i18n'
 
 export default function ClaudeChat({ name, file, onOpenFile, onOpenGit }: { name: string; file?: string; onOpenFile?: (path: string, line?: number) => void; onOpenGit?: () => void }) {
   const { t } = useI18n()
-  const { msgs, err, status: raw } = useTranscript(name, file, 'transcript')
+  const { msgs, err, status: raw, hasEarlier, loadEarlier } = useTranscript(name, file, 'transcript')
   const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
   const pending = isPending(view)
   // TaskUpdate 只给 {taskId,status}，标题在更早那次 TaskCreate 的结果里 —— 跨消息扫一遍才接得上
@@ -25,7 +25,7 @@ export default function ClaudeChat({ name, file, onOpenFile, onOpenGit }: { name
     <ChatShell
       name={name} accent="var(--accent)" error={err} onOpenFile={onOpenFile} tasks={tasks} status={status} onOpenGit={onOpenGit} lastErrorId={derived.lastErrorId}
       placeholder={t('chat.claudePlaceholder')}
-      messages={view} results={results}
+      messages={view} results={results} hasEarlier={hasEarlier} onLoadEarlier={loadEarlier}
       renderMessage={(m, i) => <ChatMessage key={m.id || i} m={m} results={results} side="claude" />}
       pending={pending ? <Typing color="var(--accent)" /> : undefined}
       busy={pending}

--- a/frontend/src/components/chat/CodexChat.tsx
+++ b/frontend/src/components/chat/CodexChat.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '../../i18n'
 
 export default function CodexChat({ name, file, onOpenFile, onOpenGit }: { name: string; file?: string; onOpenFile?: (path: string, line?: number) => void; onOpenGit?: () => void }) {
   const { t } = useI18n()
-  const { msgs, err, status: raw } = useTranscript(name, file, 'codex-transcript')
+  const { msgs, err, status: raw, hasEarlier, loadEarlier } = useTranscript(name, file, 'codex-transcript')
   const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
   const pending = isPending(view)
   // TaskUpdate 只给 {taskId,status}，标题在更早那次 TaskCreate 的结果里 —— 跨消息扫一遍才接得上
@@ -25,7 +25,7 @@ export default function CodexChat({ name, file, onOpenFile, onOpenGit }: { name:
     <ChatShell
       name={name} accent={CODEX_ACCENT} error={err} onOpenFile={onOpenFile} tasks={tasks} status={status} onOpenGit={onOpenGit} lastErrorId={derived.lastErrorId}
       placeholder={t('chat.codexPlaceholder')}
-      messages={view} results={results}
+      messages={view} results={results} hasEarlier={hasEarlier} onLoadEarlier={loadEarlier}
       renderMessage={(m, i) => <ChatMessage key={m.id || i} m={m} results={results} side="codex" />}
       pending={pending ? <Typing color={CODEX_ACCENT} /> : undefined}
       busy={pending}

--- a/frontend/src/components/chat/useTranscript.ts
+++ b/frontend/src/components/chat/useTranscript.ts
@@ -5,6 +5,9 @@ import { api } from '../../api'
 import type { Block, Msg } from './types'
 import type { RawStatus } from './status'
 
+/** 首屏只取最近这么多条。整卷搬过来的代价见 backend/api/transcript-window.go。 */
+export const FIRST_PAGE = 200
+
 export function useTranscript(name: string, file: string | undefined, path: string, interval = 1500) {
   const [msgs, setMsgs] = useState<Msg[]>([])
   const [err, setErr] = useState('')
@@ -12,7 +15,12 @@ export function useTranscript(name: string, file: string | undefined, path: stri
   // 会话闲着不动百分比就不动——那是对的，没发生新对话上下文确实没变。
   const [status, setStatus] = useState<RawStatus>({})
   const [refreshKey, setRefreshKey] = useState(0)
+  // 还有更早的没取：后端截过头才为真。前端不再自己算「隐藏了几条」——它手里根本没有全量。
+  const [hasEarlier, setHasEarlier] = useState(false)
+  const [tail, setTail] = useState(FIRST_PAGE)
   const refresh = useCallback(() => setRefreshKey((n) => n + 1), [])
+  // 加载更早：把首屏窗口放大一档重取。往回翻是低频动作，值得用一次全量重取换实现上的简单。
+  const loadEarlier = useCallback(() => setTail((n) => n + 400), [])
   useEffect(() => {
     let stop = false
     let offset = 0
@@ -22,6 +30,8 @@ export function useTranscript(name: string, file: string | undefined, path: stri
     const poll = async () => {
       try {
         const q = new URLSearchParams({ offset: String(offset) })
+        // 只有首屏带 tail：增量轮询要的是「新行」，一条都不能丢。
+        if (offset === 0) q.set('tail', String(tail))
         if (f) q.set('file', f)
         const r = await api('GET', `/sessions/${encodeURIComponent(name)}/${path}?${q.toString()}`)
         const d = r.data
@@ -41,6 +51,7 @@ export function useTranscript(name: string, file: string | undefined, path: stri
         if (d.status || typeof d.quota === 'number') {
           setStatus((prev) => mergeStatus(prev, d.status, d.quota))
         }
+        if (typeof d.truncated === 'boolean') setHasEarlier(d.truncated)
         if (d.messages?.length) { setMsgs((m) => [...m, ...d.messages]); offset = d.nextOffset }
         else if (typeof d.nextOffset === 'number') offset = d.nextOffset
       } catch (e: any) { if (!stop) setErr(e.message) }
@@ -49,18 +60,21 @@ export function useTranscript(name: string, file: string | undefined, path: stri
     const t = setInterval(poll, interval)
     return () => { stop = true; clearInterval(t) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [name, file, path, refreshKey])
-  return { msgs, err, refresh, status }
+  }, [name, file, path, refreshKey, tail])
+  return { msgs, err, refresh, status, hasEarlier, loadEarlier }
 }
 
 // 只有非空字段才覆盖：后端每轮只回它这次扫到的东西，缺的字段不该把已知值抹掉。
+// 没有任何字段变化时返回 prev 本身：React 靠引用相等跳过整棵对话树的重渲染，
+// 而这个函数每 1.5s 被调一次——每次都造新对象等于每 1.5s 白重渲染一次几百条消息。
 function mergeStatus(prev: RawStatus, next: RawStatus | undefined, quota?: number): RawStatus {
   const out: RawStatus = { ...prev }
+  let changed = false
   for (const [k, v] of Object.entries(next || {})) {
-    if (v !== '' && v !== 0 && v != null) (out as any)[k] = v
+    if (v !== '' && v !== 0 && v != null && (prev as any)[k] !== v) { (out as any)[k] = v; changed = true }
   }
-  if (typeof quota === 'number' && quota > 0) out.quota = quota
-  return out
+  if (typeof quota === 'number' && quota > 0 && prev.quota !== quota) { out.quota = quota; changed = true }
+  return changed ? out : prev
 }
 
 // 把 tool_result 按 tool_use_id 挂回对应 tool_use，并从消息流里隐去已收纳的独立结果气泡。

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -475,6 +475,7 @@ const enUS = {
   'chat.dropUpload': 'Drop to upload to working directory',
   'chat.loadingTranscript': 'Loading transcript…',
   'chat.loadEarlier': 'Load {count} earlier',
+  'chat.loadEarlierMore': 'Load earlier messages',
   'chat.jumpToBottom': 'Jump to bottom',
   'chat.uploadToCwd': 'Upload files to working directory',
   'chat.stopTitle': 'Send Esc to stop the current response',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -476,6 +476,7 @@ const zhCN = {
   'chat.dropUpload': '松开上传到工作目录',
   'chat.loadingTranscript': '加载对话记录…',
   'chat.loadEarlier': '加载更早 {count} 条',
+  'chat.loadEarlierMore': '加载更早的消息',
   'chat.jumpToBottom': '回到底部',
   'chat.uploadToCwd': '上传文件到工作目录',
   'chat.stopTitle': '发送 Esc 打断当前生成',


### PR DESCRIPTION
用户报的两件事——「对话不能上下滚动了」和「加载 Claude/Codex 模式很慢」——其实是同一件：**整卷转录搬进浏览器**。

一个 7185 行的会话，开「Claude 模式」要等 3.4s、传 3MB、在前端摊成 6237 条消息，而界面只渲染最近 200 条 —— 94% 的数据拉来就为了扔。摊开之后每轮轮询(1.5s)都要在这 6237 条上重跑一遍配对/分组/统计，主线程 8 秒里堵掉 533ms；滚轮/手指落在那 50~200ms 的长任务里就是白推一下。

更糟的是「只渲染最近 N 条」这个窗口会随新消息**前滑**：顶上几条被摘掉、剩下的整体上移，人正读着字自己往上跑，手感就是「滚不上去、老被拽回底部」。

## 改了什么

- **后端 `tail=N`**（仅首屏，增量轮询一条不丢）：一次遍历只把尾部几百行留在环形缓冲里，JSON 只解析这几百行。状态字段（cwd/model/branch/mode）每行都带，取尾部就够。
- **前端首屏只要 200 条**，「加载更早」再按档放大重取；不再自己算「隐藏了几条」——它手里本来就没有全量，那个数字（界面上显示的「加载更早 6037 条」）一直是假的。
- **离底时锚住滚动位置**：顶部身份一变就按高度差回补 `scrollTop`。用 `useLayoutEffect` 补在 paint 之前，不会看见跳一下再跳回来。
- **`mergeStatus` 无变化时返回原对象**：它每 1.5s 被调一次，每次造新对象等于每 1.5s 白重渲染一整棵对话树。

## 实测（tv优化 会话，7185 行 / 该项目最大转录 155MB）

| | 改前 | 改后 |
|---|---|---|
| 首屏（桌面） | 3.4s | **704ms** |
| 首屏（Redmi Note 8 真机） | 4.3s | **1.7s** |
| 下行 | 3.0 MB | **170 KB** |
| 8 秒内长任务 | 533ms | **0ms** |
| 滚动 | 推一下不动 / 被拽回底部 | 滚上去静置 5s 纹丝不动 |

桌面用 CDP 派发真实滚轮事件，手机用 `adb input swipe` 真手指划，两边各验一遍；增量轮询另外单独验过（首屏拿到 `nextOffset` 后再轮询，新消息照常进来）。

## 还没动的

看对话时底下那个终端仍在满速重绘（纯终端模式空转也有 415ms/8s）。在对话模式下暂停它能再省一截，但要处理切回来时的补画，风险比这几处大，单独再说。

🤖 Generated with [Claude Code](https://claude.com/claude-code)