### PR TITLE
fix(term): 终端翻不动页 —— pane 级 tmux 命令的目标少了个冒号

### DIFF
--- a/backend/pty/pty.go
+++ b/backend/pty/pty.go
@@ -62,6 +62,15 @@ func SanitizeSessionName(name string) string {
 // 这一条在 AGENTS.md 里写死了，本文件从前只有 exists() 遵守。
 func target(name string) string { return "=" + name }
 
+// paneTarget 是「这个会话当前窗口的活动 pane」。
+//
+// 那个尾冒号不是可有可无：tmux 3.4 下 `-t "=name"` 会被当成 **pane** 目标去解析，
+// 直接 `can't find pane: =name`，于是 copy-mode / send-keys -X / display-message 的
+// pane 变量全都静默失效——表现就是「终端翻不动页」：普通屏进不去 copy-mode，
+// 备用屏那边 paneState 拿回一片空、alternate_on 判成 false，于是又走去 copy-mode。
+// `=name` 只适合 has-session / set-option 这类会话级命令。
+func paneTarget(name string) string { return "=" + name + ":" }
+
 // sessionExists 判断会话是否真的还在（精确匹配，见 target）。
 func sessionExists(name string) bool {
 	return exec.Command("tmux", "has-session", "-t", target(name)).Run() == nil
@@ -75,7 +84,7 @@ func sessionExists(name string) bool {
 //     表现就是命令行被 "65;137;33M65;137;33M…" 灌满、整屏花掉。
 //   - sgr：应用用 SGR(1006) 扩展坐标编码；否则回退 X10 编码。
 func paneState(name string) (alt, mouseOn, sgr bool, w, h int) {
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", target(name), "-F",
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneTarget(name), "-F",
 		"#{alternate_on} #{pane_width} #{pane_height} #{mouse_any_flag} #{mouse_standard_flag} #{mouse_button_flag} #{mouse_all_flag} #{mouse_sgr_flag}").Output()
 	if err != nil {
 		return false, false, false, 0, 0
@@ -124,7 +133,7 @@ func altScreenWheel(name, dir string, notches, w, h int, sgr bool) {
 		}
 		seq = fmt.Sprintf("\x1b[M%c%c%c", rune(32+btn), rune(32+col), rune(32+row))
 	}
-	_ = exec.Command("tmux", "send-keys", "-t", target(name), "-l", "--", strings.Repeat(seq, notches)).Run()
+	_ = exec.Command("tmux", "send-keys", "-t", paneTarget(name), "-l", "--", strings.Repeat(seq, notches)).Run()
 }
 
 // tmuxScroll 滚动会话历史，返回本连接是否仍停在 tmux copy-mode（供 handler 决定真实键入前是否需退出）。
@@ -155,14 +164,14 @@ func tmuxScroll(name, dir string, lines int) (inCopyMode bool) {
 	n := strconv.Itoa(lines)
 	switch dir {
 	case "up":
-		_ = exec.Command("tmux", "copy-mode", "-t", target(name)).Run()
-		_ = exec.Command("tmux", "send-keys", "-t", target(name), "-N", n, "-X", "scroll-up").Run()
+		_ = exec.Command("tmux", "copy-mode", "-t", paneTarget(name)).Run()
+		_ = exec.Command("tmux", "send-keys", "-t", paneTarget(name), "-N", n, "-X", "scroll-up").Run()
 		return true
 	case "down":
-		_ = exec.Command("tmux", "send-keys", "-t", target(name), "-N", n, "-X", "scroll-down").Run()
+		_ = exec.Command("tmux", "send-keys", "-t", paneTarget(name), "-N", n, "-X", "scroll-down").Run()
 		return true
 	case "bottom":
-		_ = exec.Command("tmux", "send-keys", "-t", target(name), "-X", "cancel").Run() // 退出 copy-mode 回到最新
+		_ = exec.Command("tmux", "send-keys", "-t", paneTarget(name), "-X", "cancel").Run() // 退出 copy-mode 回到最新
 	}
 	return false
 }
@@ -336,7 +345,7 @@ func Handler(c *gin.Context) {
 	// 上次滚动历史进了 copy-mode 后断线重连时，本连接的 inCopy 会重置为 false，但 tmux 仍停在
 	// copy-mode，键入被导航键吃掉到不了 shell（表现为「要先按底才能输入」）。这里让新客户端
 	// 一律从实时提示符开始。
-	_ = exec.Command("tmux", "send-keys", "-t", target(name), "-X", "cancel").Run()
+	_ = exec.Command("tmux", "send-keys", "-t", paneTarget(name), "-X", "cancel").Run()
 
 	cmd := exec.Command("tmux", "attach", "-t", target(name))
 	cmd.Env = utf8Env(append(os.Environ(), "TERM=xterm-256color"))

--- a/backend/pty/scroll_test.go
+++ b/backend/pty/scroll_test.go
@@ -35,6 +35,16 @@ func newSession(t *testing.T, name, cmdline string) string {
 	return name
 }
 
+// tmuxProp 问 tmux 要某个 pane 变量的真值（断言「真的滚了」用，不看被吞掉的返回码）。
+func tmuxProp(t *testing.T, name, format string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", "="+name+":", format).Output()
+	if err != nil {
+		t.Fatalf("display-message %s: %v", format, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func capture(t *testing.T, name string) string {
 	t.Helper()
 	out, err := exec.Command("tmux", "capture-pane", "-t", "="+name+":", "-p").Output()
@@ -112,6 +122,15 @@ func TestScrollNormalScreenUsesCopyModeNotWheel(t *testing.T) {
 
 	if !inCopy {
 		t.Error("普通屏向上滚应进入 copy-mode")
+	}
+	// 只信返回值不够：tmuxScroll 里的 tmux 命令是 `_ =` 吞掉错误的，目标写错时它
+	// 照样报「进了 copy-mode」，而实际上 tmux 回的是 can't find pane，屏幕一动不动。
+	// 这里问 tmux 要真相——翻页失效那次就是这么漏过去的。
+	if mode := tmuxProp(t, name, "#{pane_in_mode}"); mode != "1" {
+		t.Errorf("tmux 说自己没在 copy-mode(pane_in_mode=%q)：命令根本没落到 pane 上", mode)
+	}
+	if pos := tmuxProp(t, name, "#{scroll_position}"); pos == "" || pos == "0" {
+		t.Errorf("scroll_position=%q，说明没真的往上滚", pos)
 	}
 	for _, junk := range []string{"64;", "65;", "33M", "M64", "M65"} {
 		if strings.Contains(after, junk) {


### PR DESCRIPTION
## 现象

会话里滚轮/手指上翻下翻，一动不动。前端是好的（实测确实发出了 `{"type":"scroll","dir":"up","lines":14}`），问题全在后端。

## 根因

`-t "=会话名"` 在 tmux 3.4 下被当成 **pane** 目标解析，直接回 `can't find pane: =会话名`。本机实测：

```
$ tmux copy-mode -t "=probe"        → can't find pane: =probe
$ tmux send-keys -t "=probe" -N 5 -X scroll-up → can't find pane: =probe
$ tmux copy-mode -t "=probe:" && tmux send-keys -t "=probe:" -N 5 -X scroll-up
  → pane_in_mode=1  scroll_position=5   ✅
```

而 `pty.go` 里这些命令的错误全是 `_ =` 吞掉的，于是两条路一起断：

- **普通屏**：`copy-mode` 与 `send-keys -X scroll-up` 双双落空，滚轮按了等于没按；
- **备用屏**：`display-message` 的 pane 变量全回空串 → `paneState` 拿到 0 个字段 → `alternate_on` 判成 `false` → 全屏 TUI（Claude/Codex）也被当普通屏送进 copy-mode，同样一动不动。

一句错都不报，所以表现就是「会话无法上翻下翻」。

## 改动

新增 `paneTarget(name) = "=" + name + ":"`，pane 级命令（`display-message` / `copy-mode` / `send-keys -X` / `send-keys -l`）全部改用它。`=name` 只适合 `has-session` / `set-option` 这类会话级命令。

本仓库别处（`cli/.../group.go`、`backend/worktree/sessionhome.go`）早就是带冒号的写法，连**这个文件自己的测试辅助函数**都写对了，唯独产品代码没有。

## 测试也一并加固

原用例只断言 `tmuxScroll` 的返回值——而那个返回值是「我打算进 copy-mode」，不是「真进了」：错误被吞掉时它照样返回 true。所以这 bug 从测试底下大摇大摆走了过去。

改成向 tmux 要真相（`pane_in_mode` / `scroll_position`）。**只回退 `pty.go`（保留新断言）该用例立刻失败**：

```
--- FAIL: TestScrollNormalScreenUsesCopyModeNotWheel
    tmux 说自己没在 copy-mode(pane_in_mode="0")：命令根本没落到 pane 上
    scroll_position=""，说明没真的往上滚
```

## 验证

- 单元：`go test ./pty/` 三个滚动用例全绿；回退修复即红（见上）
- 线上：浏览器里对 Claude TUI 会话滚滚轮，`capture-pane` 前后内容确实变了（滚上去看到更早的对话）

🤖 Generated with [Claude Code](https://claude.com/claude-code)