### PR TITLE
style(phone): 页头收成一条灵动岛 · 画面顶到四周

### DIFF
--- a/frontend/src/components/mirror/PhoneView.tsx
+++ b/frontend/src/components/mirror/PhoneView.tsx
@@ -10,8 +10,8 @@ import { api } from '../../api'
 import { useI18n } from '../../i18n'
 import { connect, type DuplexTransport } from '../../p2p/transport'
 import { devKindText, devStateText, listPhoneDevices, selectPhoneDevice, type PhoneDevice } from '../../phone-devices'
-import { AppsIcon, DeviceIcon, PhoneAssistIcon, PhoneBackIcon, PhoneHomeIcon, PhoneRecentsIcon, PowerIcon, RefreshIcon, SearchIcon } from '../../icons'
-import { fmtRate, IconBtn, MirrorChrome, MirrorMenu, Omnibox, StatusChip, StreamControl, useShelf, type Quality } from './mirror'
+import { AppsIcon, ChevronDown, DeviceIcon, PhoneAssistIcon, PhoneBackIcon, PhoneHomeIcon, PhoneRecentsIcon, PowerIcon, RefreshIcon, SearchIcon } from '../../icons'
+import { fmtRate, IconBtn, MirrorChrome, MirrorMenu, Omnibox, StreamControl, useShelf, type Quality } from './mirror'
 
 interface PhoneApp { id: string; name?: string }
 
@@ -231,9 +231,10 @@ export default function PhoneView() {
     { key: 'reconnect', icon: <RefreshIcon size={14} />, label: t('phone.reconnect'), onClick: () => setReconnectKey((n) => n + 1) },
   ]
 
-  // 设备芯片：一眼是哪台，点开换一台（浏览器页的设备芯片同一套写法）。
+  // 设备身份：名字 + 它是什么（本机模拟器/真机/远程），点开换一台。
+  // 名字和类型说的是同一台机器，所以是一枚可点的整体，不是并排两枚胶囊。
   const cur = devices.find((d) => d.current)
-  const deviceChip = (
+  const deviceIdentity = (
     <Dropdown trigger={['click']} placement="bottomRight"
       onOpenChange={(v) => { if (v) loadDevices() }}
       menu={{
@@ -248,9 +249,11 @@ export default function PhoneView() {
           }
         }) : [{ key: 'none', disabled: true, label: t('phone.devNone') }],
       }}>
-      {/* onClick 空实现是给 StatusChip 要一个真 <button>（可聚焦、看着能点）——开合由 Dropdown 接冒泡管。 */}
-      <span><StatusChip icon={<DeviceIcon />} text={platform === 'ios' ? 'iOS' : 'Android'}
-        strong={cur ? devKindText(cur, t) : undefined} onClick={() => {}} /></span>
+      <button type="button" className="mc-omni-txt mc-omni-id" title={`${devName || t('nav.phone')}${cur ? ' · ' + devKindText(cur, t) : ''}`}>
+        <span className="host">{devName || t('nav.phone')}</span>
+        {cur && <span className="kind"><DeviceIcon size={12} />{devKindText(cur, t)}</span>}
+        <ChevronDown size={10} />
+      </button>
     </Dropdown>
   )
 
@@ -285,6 +288,7 @@ export default function PhoneView() {
           <Omnibox
             readOnly
             value={devName || t('nav.phone')}
+            identity={deviceIdentity}
             sub={[devOs, `${sizeRef.current.w}×${sizeRef.current.h}`].filter(Boolean).join(' · ')}
             lead={<StreamControl
               connected={connected} label={connected ? t('phone.connected') : t('phone.disconnected')}
@@ -296,7 +300,6 @@ export default function PhoneView() {
               ? <span className="mc-omni-num">{`${latency == null ? '—' : latency + 'ms'} · ${fmtRate(bw)} · ${fps}fps`}</span>
               : undefined}
           />
-          {shelf !== 'narrow' && deviceChip}
           {/* 应用启动器：从前是个 160px 的 Select，窄屏上要独占一整行 */}
           <Dropdown trigger={['click']} placement="bottomRight" open={appsOpen} onOpenChange={(v) => { setAppsOpen(v); if (v) loadApps() }}
             popupRender={() => (
@@ -324,10 +327,6 @@ export default function PhoneView() {
           </Dropdown>
           <MirrorMenu label={t('common.more')} items={menuItems} />
         </>}
-        chips={shelf === 'narrow' ? <>
-          {deviceChip}
-          {!!devOs && <StatusChip text={devOs} />}
-        </> : undefined}
       />
 
       <style>{`

--- a/frontend/src/components/mirror/mirror.tsx
+++ b/frontend/src/components/mirror/mirror.tsx
@@ -140,7 +140,7 @@ export function splitUrl(raw: string): { host: string; rest: string } {
  * 浏览器页：可编辑地址（失焦＝域名亮/路径灰；聚焦＝全选整条 + ✕ 清空 + 「前往」）。
  * 手机页：`readOnly` ＝ 只读 devbox（设备名 + 系统/分辨率）——它是身份不是输入。
  */
-export function Omnibox({ value, onChange, onSubmit, onFocusChange, lead, trailing, sub, readOnly, placeholder, goLabel }: {
+export function Omnibox({ value, onChange, onSubmit, onFocusChange, lead, trailing, sub, identity, readOnly, placeholder, goLabel }: {
   value: string
   onChange?: (v: string) => void
   onSubmit?: () => void
@@ -151,6 +151,8 @@ export function Omnibox({ value, onChange, onSubmit, onFocusChange, lead, traili
   trailing?: ReactNode
   /** 只读态右侧的次要信息（系统、分辨率） */
   sub?: string
+  /** 只读态的主体：给得出更多的（可点开换一台的设备身份）就用它，代替那行纯文本 */
+  identity?: ReactNode
   readOnly?: boolean
   placeholder?: string
   goLabel?: string
@@ -172,7 +174,7 @@ export function Omnibox({ value, onChange, onSubmit, onFocusChange, lead, traili
     return (
       <div className="mc-omni is-readonly">
         {lead}
-        <span className="mc-omni-txt" title={value}><span className="host">{value}</span></span>
+        {identity || <span className="mc-omni-txt" title={value}><span className="host">{value}</span></span>}
         {sub && <span className="mc-omni-sub">{sub}</span>}
         {trailing}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -737,6 +737,18 @@ html[data-pointer="coarse"] .mc { --ctl-h: 36px; }
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-variant-numeric: tabular-nums; white-space: nowrap; padding-right: 6px;
 }
+/* 岛内的设备身份：名字 + 它是什么 + 一个下拉角标，整条可点（点开换一台）。
+   类型是名字的注脚，所以压暗、贴着名字走，不另起一枚胶囊——那样等于把同一台机器说两遍。 */
+.mc-omni-id {
+  display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+  color: var(--text-dimmer);
+}
+.mc-omni-id .host { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
+.mc-omni-id .kind {
+  flex: 0 0 auto; display: inline-flex; align-items: center; gap: 4px;
+  font-size: var(--fs-micro); color: var(--text-dim); white-space: nowrap;
+}
+:where(html[data-pointer="fine"]) .mc-omni-id:hover .kind { color: var(--text-bright); }
 .mc-omni-input {
   flex: 1 1 auto; min-width: 0; border: 0; outline: none; background: transparent;
   color: var(--text-bright); font-size: var(--fs-sm);
@@ -1155,6 +1167,12 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
   min-height: 0;
   overflow: hidden;
 }
+/* 手机镜像页满幅：这一页的主角是一块画面，四周留白只是把它按比例缩小一圈，
+   什么也没多说明。工具条自带底边框，不靠外边距跟画布分开。
+   底部例外——手机上要给底栏/会话坞让位，否则画面被压在它们下面。 */
+.tt-page-phone { padding: 0; }
+.tt-page-phone.tt-page-mobile { padding-bottom: calc(76px + env(safe-area-inset-bottom)); }
+.tt-page-phone.tt-page-mobile.has-dock { padding-bottom: calc(126px + env(safe-area-inset-bottom)); }
 .tt-page-files > *,
 .tt-page-phone > *,
 .tt-page-browser > *,


### PR DESCRIPTION
## 改了什么

三样东西原本摆成三处，说的却是同一件事——第二行的设备芯片「Android · 本机模拟器」、第一行地址框里的设备名、框右边的分辨率。窄档下那第二行还把画面往下压掉一整条。

现在合成一条岛，从左到右一句话读完：

```
( ● 已连接 · 标清 ▾ │ sdk_google_atv64_x86_64 (emulator-5554) ▯ 本机模拟器 ▾ │ 1920×1080  1ms · 226 KB/s · 4fps )
  这条连接怎么样        这是谁                        它是什么              它多大 · 跑得怎么样
```

**设备名和类型是一枚可点的整体**（点开换一台），不是并排两枚胶囊：它们说的是同一台机器，拆成两枚等于把同一件事说两遍，而右边那枚还得再画一圈描边来跟左边那枚划清界限。类型压暗当名字的注脚，末尾一个下拉角标交代「这儿能点」。系统名不会丢——它一直在次要信息里（系统 · 分辨率）。

**画面顶到四周。** 这一页取消 16px 页边距：主角是一块画面，四周留白只是把它按比例缩小一圈，什么也没多说明；工具条自带底边框，不靠外边距跟画布分开。底部例外——手机上仍给底栏（76px）和会话坞（126px）让位。

## 实测

桌面 Chrome 1440 / 900 / 430 三档：第二行（`.mc-chips`）不再出现，`.tt-page-phone` 页边距 `0px 0px 0px 0px`，手机档底部仍 76px（有坞 126px），画面起点 x=0；点设备名能拉出设备菜单（两台都在，当前那台选中）。

## 门禁

`check.sh quick` 通过；typecheck / i18n:check / hover:check / vitest(290) / build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
