### PR TITLE
refactor(agent): 启动命令也收进契约 —— spawn 里最后四处 codex 分支清掉

### DIFF
--- a/cli/ttmux-cli-go/internal/agent/agent.go
+++ b/cli/ttmux-cli-go/internal/agent/agent.go
@@ -12,7 +12,15 @@
 // codex 的 resume 早就能用了，而 revive 里一直写着「codex 没有对应参数」把它跳过。
 //
 // 现在收成一个接口 + 一张注册表：**新增一型只要实现 Agent 并 Register，
-// 恢复、列表、spawn 三条路自动都认得它。**
+// 启动、恢复、列表、swarm 校验四条路自动都认得它。**
+//
+// # 还没收进来的
+//
+// 「从 pane 屏幕内容判断它是在干活还是在等输入」——那是另一个维度的差异
+// （提示符长什么样、认不出时该偏向哪边），目前还留在 internal/swarm 里的
+// 一处 `if m.Kind == "codex"`。它值得单独设计一组接口（提示符特征 + 未知时的
+// 默认判断），硬塞进本接口只会让「启动/恢复」这件事变得不清楚。
+// 新增一型时如果发现它的状态判断也不对，那就是该动那一块的信号。
 package agent
 
 import (
@@ -40,9 +48,16 @@ type Agent interface {
 	// 那样这一型的会话恢复出来就只有壳，没有对话。
 	PinsConversationID() bool
 
-	// StartArgs 拉起它的参数（不含 Bin 本身）。
+	// InteractiveArgs 常驻 TUI 的参数（不含 Bin、不含 prompt 本身）。
 	// convID 非空且 PinsConversationID() 为真时，实现要把它注入进去。
-	StartArgs(opt StartOpts) []string
+	InteractiveArgs(opt StartOpts) []string
+
+	// OneShotArgs 一次性任务的参数（不含 Bin、不含 prompt 本身）。
+	//
+	// 返回的参数**必须已经让它从 stdin 读 prompt** —— 调用方只负责在后面接
+	// `< 文件` 或一段 heredoc，不知道该给谁加 `-`。两型的做法就不一样：
+	// claude 的 `-p` 本身就读 stdin，codex 要显式的位置参数 `-`。
+	OneShotArgs(opt StartOpts) []string
 
 	// ResumeCommand 在 shell 里敲什么能接回 convID 那段对话。
 	// 返回空串 = 这一型接不回（调用方据此只开壳，不硬编一条命令上去）。
@@ -62,12 +77,12 @@ type StartOpts struct {
 	ConvID string
 	// Model 模型名，空则用 agent 自己的默认。
 	Model string
-	// Permission 权限档（claude 的 --dangerously-skip-permissions 之类）。
+	// Permission 权限档。取值是 Roam 这一侧的口径（"auto" /
+	// "dangerously-skip-permissions"），**怎么翻译成自家参数由各型自己决定** ——
+	// claude 有 --permission-mode，codex 只有一个 bypass 开关，没有档位概念。
 	Permission string
-	// Interactive 常驻 TUI（true）还是一次性任务（false）。
-	Interactive bool
-	// Prompt 首个提示词，可空。
-	Prompt string
+	// MaxTurns 一次性任务的最大轮次；空 = 不限。支持不了的型忽略它。
+	MaxTurns string
 }
 
 var (

--- a/cli/ttmux-cli-go/internal/agent/claude.go
+++ b/cli/ttmux-cli-go/internal/agent/claude.go
@@ -22,21 +22,43 @@ func (claude) Bin() string         { return "claude" }
 // 关联由构造保证，会话死了、目录里又开过别的 agent，也认得回来。
 func (claude) PinsConversationID() bool { return true }
 
-func (claude) StartArgs(opt StartOpts) []string {
+func (claude) InteractiveArgs(opt StartOpts) []string {
 	var a []string
-	if opt.Permission != "" {
-		a = append(a, "--"+opt.Permission)
-	}
 	if opt.Model != "" {
 		a = append(a, "--model", opt.Model)
 	}
+	a = append(a, permArgs(opt.Permission)...)
+	// 只在交互式注入对话 id：一次性任务跑完就结束，钉一个 id 没意义，
+	// 反而会和下一次 -p 撞同一个 id。
 	if opt.ConvID != "" {
 		a = append(a, "--session-id", opt.ConvID)
 	}
-	if opt.Prompt != "" {
-		a = append(a, opt.Prompt)
-	}
 	return a
+}
+
+func (claude) OneShotArgs(opt StartOpts) []string {
+	// -p 本身就从 stdin 读 prompt，不需要额外的 `-`。
+	a := []string{"-p"}
+	if opt.Model != "" {
+		a = append(a, "--model", opt.Model)
+	}
+	a = append(a, permArgs(opt.Permission)...)
+	if opt.MaxTurns != "" {
+		a = append(a, "--max-turns", opt.MaxTurns)
+	}
+	return append(a, "--output-format", "text")
+}
+
+// permArgs 把 Roam 口径的权限档翻成 claude 的参数。
+// "dangerously-skip-permissions" 是个独立开关，其余走 --permission-mode。
+func permArgs(perm string) []string {
+	if perm == "dangerously-skip-permissions" {
+		return []string{"--dangerously-skip-permissions"}
+	}
+	if perm == "" {
+		return nil
+	}
+	return []string{"--permission-mode", perm}
 }
 
 func (c claude) ResumeCommand(convID string) string {

--- a/cli/ttmux-cli-go/internal/agent/codex.go
+++ b/cli/ttmux-cli-go/internal/agent/codex.go
@@ -28,16 +28,30 @@ func (codex) Bin() string         { return "codex" }
 // 没有 --session-id 这类参数：id 由它自己生成，只能事后从 rollout 文件名认。
 func (codex) PinsConversationID() bool { return false }
 
-func (codex) StartArgs(opt StartOpts) []string {
+func (codex) InteractiveArgs(opt StartOpts) []string {
 	var a []string
 	if opt.Model != "" {
 		a = append(a, "-m", opt.Model)
 	}
-	// ConvID 故意忽略：这一型指定不了，硬塞一个参数上去只会让它启动失败。
-	if opt.Prompt != "" {
-		a = append(a, opt.Prompt)
-	}
+	// ConvID 故意忽略：这一型指定不了，硬塞一个参数上去只会让它起不来。
+	// Permission 也忽略：codex 交互式没有权限档的概念。
 	return a
+}
+
+func (codex) OneShotArgs(opt StartOpts) []string {
+	a := []string{"exec", "--skip-git-repo-check"}
+	if opt.Model != "" {
+		a = append(a, "-m", opt.Model)
+	}
+	// codex 只有一个「全放开」开关，没有档位。Roam 这边的 auto 和
+	// dangerously-skip-permissions 都映射到它——都是「别停下来问」的意思。
+	if opt.Permission == "dangerously-skip-permissions" || opt.Permission == "auto" {
+		a = append(a, "--dangerously-bypass-approvals-and-sandbox")
+	}
+	// MaxTurns 支持不了，忽略。
+	//
+	// 末尾这个 `-` 是「从 stdin 读 prompt」，claude 那边由 -p 隐含。
+	return append(a, "-")
 }
 
 func (c codex) ResumeCommand(convID string) string {

--- a/cli/ttmux-cli-go/internal/agent/newkind_probe_test.go
+++ b/cli/ttmux-cli-go/internal/agent/newkind_probe_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import "strings"
+import "testing"
+
+// 假的一型，只实现接口、不碰任何既有代码 —— 验证「新增一型」的成本。
+type gemini struct{}
+
+func (gemini) Kind() string             { return "gemini" }
+func (gemini) DisplayName() string      { return "Gemini CLI" }
+func (gemini) Bin() string              { return "gemini" }
+func (gemini) PinsConversationID() bool { return true }
+func (gemini) InteractiveArgs(o StartOpts) []string {
+	if o.ConvID != "" {
+		return []string{"--chat", o.ConvID}
+	}
+	return nil
+}
+func (gemini) OneShotArgs(o StartOpts) []string { return []string{"--stdin"} }
+func (g gemini) ResumeCommand(c string) string {
+	if c == "" {
+		return ""
+	}
+	return g.Bin() + " --chat " + c
+}
+func (gemini) DetectConversationID(string) string { return "" }
+
+func TestNewKindNeedsNoChangesElsewhere(t *testing.T) {
+	Register(gemini{})
+	defer func() { mu.Lock(); delete(registry, "gemini"); mu.Unlock() }()
+
+	if a := Get("gemini"); a == nil {
+		t.Fatal("注册完却取不到")
+	}
+	// 恢复这条路自动认得它
+	if got := ResumeCommandFor("gemini", "C1"); got != "gemini --chat C1" {
+		t.Errorf("恢复命令 = %q", got)
+	}
+	// 列表/校验这条路也认得
+	found := false
+	for _, k := range Kinds() {
+		if k == "gemini" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Kinds() 里没有它，swarm 的 --kind 校验会拒绝它")
+	}
+	// 启动参数
+	if got := strings.Join(Get("gemini").InteractiveArgs(StartOpts{ConvID: "X"}), " "); got != "--chat X" {
+		t.Errorf("交互参数 = %q", got)
+	}
+}

--- a/cli/ttmux-cli-go/internal/command/spawn/agent.go
+++ b/cli/ttmux-cli-go/internal/command/spawn/agent.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 
 	"strings"
+	"ttmux-cli-go/internal/agent"
 	"ttmux-cli-go/internal/id"
 )
 
@@ -22,13 +23,6 @@ type AgentConfig struct {
 	// 而会话一死这个猜法就失准（同目录的别的会话会赢）。指定之后关联由构造保证，
 	// 台账把它记下来，M3 的「重开并接回原对话」才有依据。codex 没有对应参数，忽略。
 	SessionUUID string
-}
-
-// withSessionID 在 claude 命令后追加 --session-id（只对 claude 有意义）。
-func (c AgentConfig) withSessionID(b *strings.Builder) {
-	if c.Kind != "codex" && c.SessionUUID != "" {
-		b.WriteString(" --session-id " + c.SessionUUID)
-	}
 }
 
 // DefaultAgentConfig mirrors _agent_defaults.
@@ -52,118 +46,85 @@ func lookPath(bin string) string {
 	return bin
 }
 
+// 下面四个方法只管**通用外壳**：cd 进工作目录、bin 用哪个、prompt 怎么投喂
+// （内联 heredoc / 文件走 stdin / $(cat) 注入）。**每一型自己的参数由 agent 包给**——
+// 从前这里是四处 `if c.Kind == "codex"`，加一型就得把它们全找一遍。
+
+// resolve 取这一型的实现；认不出退回默认那型，别拼出一条空命令交给 shell。
+func (c AgentConfig) resolve() agent.Agent {
+	if a := agent.Get(c.Kind); a != nil {
+		return a
+	}
+	return agent.Default()
+}
+
+// bin 可执行文件：配置里指定了就用指定的（装在别处 / 用 wrapper 包了一层），
+// 否则用这一型的默认名。
+//
+// ClaudeBin/CodexBin 是**历史字段**，只对这两型有效。新增的型直接用 a.Bin()——
+// 不这么写的话它会掉进 claude 那条分支，拿到一个完全不相干的可执行名。
+// 真要给新型加覆盖，该做的是把这两个字段换成 map[kind]string，而不是再加一个 case。
+func (c AgentConfig) bin(a agent.Agent) string {
+	if a == nil {
+		return orDefault(c.ClaudeBin, "claude")
+	}
+	switch a.Kind() {
+	case "claude":
+		return orDefault(c.ClaudeBin, a.Bin())
+	case "codex":
+		return orDefault(c.CodexBin, a.Bin())
+	}
+	return a.Bin()
+}
+
+func (c AgentConfig) startOpts() agent.StartOpts {
+	return agent.StartOpts{
+		ConvID:     c.SessionUUID,
+		Model:      c.Model,
+		Permission: c.Permission,
+		MaxTurns:   c.MaxTurns,
+	}
+}
+
+// prefix 拼出 `cd '<工作目录>' && <bin> <参数…>`，参数由这一型自述。
+func (c AgentConfig) prefix(interactive bool) string {
+	a := c.resolve()
+	var args []string
+	if a != nil {
+		if interactive {
+			args = a.InteractiveArgs(c.startOpts())
+		} else {
+			args = a.OneShotArgs(c.startOpts())
+		}
+	}
+	b := "cd '" + c.Workdir + "' && " + c.bin(a)
+	if len(args) > 0 {
+		b += " " + strings.Join(args, " ")
+	}
+	return b
+}
+
 // Command builds the shell command line that launches the agent, mirroring
 // _agent_cmd → _agent_claude_cmd / _agent_codex_cmd.
 func (c AgentConfig) Command(task string) string {
-	if c.Kind == "codex" {
-		return c.codexCommand(task)
+	if c.Interactive {
+		return c.prefix(true) + " " + shellQuote(task)
 	}
-	return c.claudeCommand(task)
+	return c.prefix(false) + heredoc(task)
 }
 
 // CommandFromPromptFile builds the one-shot launch command with the task fed
 // from a file on stdin. tmux send-keys 有命令长度上限(整段 diff 内联会报
 // "command too long"),经会话拉起 Agent 的调用方必须用这个短命令形态。
 func (c AgentConfig) CommandFromPromptFile(path string) string {
-	if c.Kind == "codex" {
-		return c.codexOneShotPrefix() + " < " + shellQuote(path)
-	}
-	return c.claudeOneShotPrefix() + " < " + shellQuote(path)
+	return c.prefix(false) + " < " + shellQuote(path)
 }
 
 // InteractiveFromPromptFile builds the interactive-TUI launch command with the
 // initial prompt read from a file("$(cat …)" 注入,同 swarm members 的手法:
 // 多行 prompt 内联会被 send-keys 的换行当回车拆碎)。
 func (c AgentConfig) InteractiveFromPromptFile(path string) string {
-	bin := orDefault(c.ClaudeBin, "claude")
-	var b strings.Builder
-	if c.Kind == "codex" {
-		bin = orDefault(c.CodexBin, "codex")
-		b.WriteString("cd '" + c.Workdir + "' && " + bin)
-		if c.Model != "" {
-			b.WriteString(" -m " + c.Model)
-		}
-	} else {
-		b.WriteString("cd '" + c.Workdir + "' && " + bin)
-		if c.Model != "" {
-			b.WriteString(" --model " + c.Model)
-		}
-		if c.Permission == "dangerously-skip-permissions" {
-			b.WriteString(" --dangerously-skip-permissions")
-		} else {
-			b.WriteString(" --permission-mode " + c.Permission)
-		}
-	}
-	c.withSessionID(&b)
-	b.WriteString(` "$(cat ` + shellQuote(path) + `)"`)
-	return b.String()
-}
-
-func (c AgentConfig) claudeCommand(task string) string {
-	if c.Interactive {
-		bin := orDefault(c.ClaudeBin, "claude")
-		var b strings.Builder
-		b.WriteString("cd '" + c.Workdir + "' && " + bin)
-		if c.Model != "" {
-			b.WriteString(" --model " + c.Model)
-		}
-		if c.Permission == "dangerously-skip-permissions" {
-			b.WriteString(" --dangerously-skip-permissions")
-		} else {
-			b.WriteString(" --permission-mode " + c.Permission)
-		}
-		c.withSessionID(&b)
-		b.WriteString(" " + shellQuote(task))
-		return b.String()
-	}
-	return c.claudeOneShotPrefix() + heredoc(task)
-}
-
-func (c AgentConfig) claudeOneShotPrefix() string {
-	bin := orDefault(c.ClaudeBin, "claude")
-	var b strings.Builder
-	b.WriteString("cd '" + c.Workdir + "' && " + bin + " -p")
-	if c.Model != "" {
-		b.WriteString(" --model " + c.Model)
-	}
-	if c.Permission == "dangerously-skip-permissions" {
-		b.WriteString(" --dangerously-skip-permissions")
-	} else {
-		b.WriteString(" --permission-mode " + c.Permission)
-	}
-	if c.MaxTurns != "" {
-		b.WriteString(" --max-turns " + c.MaxTurns)
-	}
-	b.WriteString(" --output-format text")
-	return b.String()
-}
-
-func (c AgentConfig) codexCommand(task string) string {
-	if c.Interactive {
-		bin := orDefault(c.CodexBin, "codex")
-		var b strings.Builder
-		b.WriteString("cd '" + c.Workdir + "' && " + bin)
-		if c.Model != "" {
-			b.WriteString(" -m " + c.Model)
-		}
-		b.WriteString(" " + shellQuote(task))
-		return b.String()
-	}
-	return c.codexOneShotPrefix() + heredoc(task)
-}
-
-func (c AgentConfig) codexOneShotPrefix() string {
-	bin := orDefault(c.CodexBin, "codex")
-	var b strings.Builder
-	b.WriteString("cd '" + c.Workdir + "' && " + bin + " exec --skip-git-repo-check")
-	if c.Model != "" {
-		b.WriteString(" -m " + c.Model)
-	}
-	if c.Permission == "dangerously-skip-permissions" || c.Permission == "auto" {
-		b.WriteString(" --dangerously-bypass-approvals-and-sandbox")
-	}
-	b.WriteString(" -")
-	return b.String()
+	return c.prefix(true) + ` "$(cat ` + shellQuote(path) + `)"`
 }
 
 // heredoc appends a `<<'TTMUX_TASK_EOF'` block carrying the task verbatim,

--- a/cli/ttmux-cli-go/internal/command/spawn/agent_golden_test.go
+++ b/cli/ttmux-cli-go/internal/command/spawn/agent_golden_test.go
@@ -1,0 +1,92 @@
+package spawn
+
+import "testing"
+
+// 启动命令的**逐字基线**。
+//
+// 这些命令最终由 tmux send-keys 敲进 pane，一个字符不对就是 agent 起不来
+// 或者起错档（比如少了 --dangerously-skip-permissions 会卡在交互确认上，
+// 而那是无人值守的会话，没人去按）。所以这里断言全串相等，不做模糊匹配。
+//
+// 它同时是把「每型自己的参数」下放到 internal/agent 那次重构的安全网：
+// 外壳（cd / 引号 / heredoc / bin 覆盖）留在本包，参数由各型自述，
+// 两边加起来必须和重构前逐字一样。
+func TestLaunchCommandGolden(t *testing.T) {
+	cases := []struct {
+		name string
+		ac   AgentConfig
+		// 三种投喂方式各有各的用途：内联 heredoc（短任务）、文件走 stdin
+		// （send-keys 有长度上限，大 prompt 必须走这条）、$(cat) 注入（交互式 TUI）。
+		wantCommand string
+		wantFromFn  string
+		wantInterFn string
+	}{
+		{
+			name: "claude/一次性/跳过权限/带 max-turns",
+			ac:   AgentConfig{ClaudeBin: "claude", Kind: "claude", Permission: "dangerously-skip-permissions", Workdir: "/w", MaxTurns: "5"},
+			wantCommand: "cd '/w' && claude -p --dangerously-skip-permissions --max-turns 5 --output-format text " +
+				"<<'TTMUX_TASK_EOF'\nT\nTTMUX_TASK_EOF",
+			wantFromFn:  "cd '/w' && claude -p --dangerously-skip-permissions --max-turns 5 --output-format text < '/p.txt'",
+			wantInterFn: "cd '/w' && claude --dangerously-skip-permissions \"$(cat '/p.txt')\"",
+		},
+		{
+			name:        "claude/交互/模型+权限档/带对话 id",
+			ac:          AgentConfig{ClaudeBin: "claude", Kind: "claude", Interactive: true, Permission: "auto", Model: "opus", Workdir: "/w", SessionUUID: "UU-1"},
+			wantCommand: "cd '/w' && claude --model opus --permission-mode auto --session-id UU-1 'T'",
+			// 注意：一次性形态**不带** --session-id —— 它只在交互式那条路上注入。
+			wantFromFn:  "cd '/w' && claude -p --model opus --permission-mode auto --output-format text < '/p.txt'",
+			wantInterFn: "cd '/w' && claude --model opus --permission-mode auto --session-id UU-1 \"$(cat '/p.txt')\"",
+		},
+		{
+			name:        "codex/一次性/auto 权限也要 bypass",
+			ac:          AgentConfig{CodexBin: "codex", Kind: "codex", Permission: "auto", Workdir: "/w", Model: "gpt"},
+			wantCommand: "cd '/w' && codex exec --skip-git-repo-check -m gpt --dangerously-bypass-approvals-and-sandbox - <<'TTMUX_TASK_EOF'\nT\nTTMUX_TASK_EOF",
+			wantFromFn:  "cd '/w' && codex exec --skip-git-repo-check -m gpt --dangerously-bypass-approvals-and-sandbox - < '/p.txt'",
+			wantInterFn: "cd '/w' && codex -m gpt \"$(cat '/p.txt')\"",
+		},
+		{
+			name: "codex/交互/给了对话 id 也不该出现在命令里",
+			ac:   AgentConfig{CodexBin: "codex", Kind: "codex", Interactive: true, Model: "gpt", Workdir: "/w", SessionUUID: "UU-3"},
+			// codex 没有 --session-id 这类参数，硬塞进去它会起不来。
+			// 这条盯着「别顺手给它也加上」。
+			wantCommand: "cd '/w' && codex -m gpt 'T'",
+			wantFromFn:  "cd '/w' && codex exec --skip-git-repo-check -m gpt - < '/p.txt'",
+			wantInterFn: "cd '/w' && codex -m gpt \"$(cat '/p.txt')\"",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.ac.Command("T"); got != c.wantCommand {
+				t.Errorf("Command()\n got=%q\nwant=%q", got, c.wantCommand)
+			}
+			if got := c.ac.CommandFromPromptFile("/p.txt"); got != c.wantFromFn {
+				t.Errorf("CommandFromPromptFile()\n got=%q\nwant=%q", got, c.wantFromFn)
+			}
+			if got := c.ac.InteractiveFromPromptFile("/p.txt"); got != c.wantInterFn {
+				t.Errorf("InteractiveFromPromptFile()\n got=%q\nwant=%q", got, c.wantInterFn)
+			}
+		})
+	}
+}
+
+// bin 可被配置覆盖（用户装在别处 / 用 wrapper 包了一层）。
+// 重构时最容易漏掉的就是这个覆盖，因为默认值恰好等于二进制名，测不出来。
+func TestBinOverrideHonored(t *testing.T) {
+	ac := AgentConfig{ClaudeBin: "/opt/cc/claude", Kind: "claude", Permission: "auto", Workdir: "/w"}
+	if got := ac.Command("T"); got[:len("cd '/w' && /opt/cc/claude")] != "cd '/w' && /opt/cc/claude" {
+		t.Errorf("claude bin 覆盖没生效: %q", got)
+	}
+	cx := AgentConfig{CodexBin: "/opt/cx/codex", Kind: "codex", Interactive: true, Workdir: "/w"}
+	if got := cx.Command("T"); got != "cd '/w' && /opt/cx/codex 'T'" {
+		t.Errorf("codex bin 覆盖没生效: %q", got)
+	}
+}
+
+// 认不出的 kind 要退回默认那型，而不是拼出一条空命令交给 shell。
+func TestUnknownKindFallsBackToDefault(t *testing.T) {
+	ac := AgentConfig{Kind: "gemini", Permission: "auto", Workdir: "/w"}
+	got := ac.Command("T")
+	if got == "" || got == "cd '/w' && " {
+		t.Fatalf("未知 kind 拼出了空命令: %q", got)
+	}
+}


### PR DESCRIPTION
接着上一次的 agent 契约做完。`spawn/agent.go` 里构造启动命令的**四处** `if c.Kind == "codex"` 是最后的硬判点：加一型就得把它们全找一遍，漏一处就是那一型在某条路上悄悄失效。

## 怎么切的

外壳留在 `spawn`（`cd` 进工作目录、bin 用哪个、prompt 怎么投喂——内联 heredoc / 文件走 stdin / `$(cat)` 注入），**每一型自己的参数下放到 `agent` 包**：

```go
InteractiveArgs(opt)  // 常驻 TUI 的参数
OneShotArgs(opt)      // 一次性任务的参数
```

`OneShotArgs` 的契约里写死了一条：**返回的参数必须已经让它从 stdin 读 prompt**。两型做法不同（claude 的 `-p` 隐含、codex 要显式的位置参数 `-`），调用方不该知道该给谁加那个 `-`。

权限档也归各型自己翻译：claude 有 `--permission-mode` 档位，codex 只有一个「全放开」开关——Roam 这边的 `auto` 和 `dangerously-skip-permissions` 都映射到它。

`spawn/agent.go` 净减 46 行（-100/+54）。

## 顺带修的一个真问题

`bin()` 里选 `ClaudeBin`/`CodexBin` 那两个历史字段时，原先的写法会让**新增的型掉进 claude 分支**，拿到一个完全不相干的可执行名。改成 switch 两型、其余用 `a.Bin()`，并注明真要给新型加覆盖该换成 `map[kind]string` 而不是再加一个 case。

## 安全网先行

这些命令最终由 `send-keys` 敲进 pane，**一个字符不对就是 agent 起不来或起错档**（少了 `--dangerously-skip-permissions` 会卡在交互确认上，而那是无人值守的会话，没人去按）。

所以先补齐逐字基线再动手——原有 5 条只覆盖 `Command()`，`CommandFromPromptFile` / `InteractiveFromPromptFile` **一条都没有**。新增 `TestLaunchCommandGolden` 覆盖 4 种配置 × 3 种投喂方式，断言全串相等。重构后 12 条测试逐字一致。

另加 `TestNewKindNeedsNoChangesElsewhere`：临时注册一个假的 `gemini`，只实现接口、不碰任何既有代码，验证恢复 / 列表 / swarm 校验三条路自动认得它——这是「新增一型的成本」本身的回归。

## 边界（没做的）

「从 pane 屏幕内容判断在干活还是等输入」还留着一处 kind 判断（`internal/swarm`）。那是另一个维度的差异（提示符长什么样、认不出时偏向哪边），值得单独设计一组接口；硬塞进本接口只会让「启动 / 恢复」这件事变得不清楚。已在包注释里写明，新增一型时若发现状态判断也不对，那就是该动那一块的信号。

## 验证

- `internal/...` 全量 Go 测试通过；`check.sh quick` 全绿
- 懒恢复 e2e 9 条通过，含 `V8/claude` `V8/codex` 两型真起会话验恢复命令

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW