### PR TITLE
fix(layout): 小屏开文件面板，右边空出一条黑边 —— Canvas 让掉的宽度没人接

### DIFF
--- a/frontend/src/components/shell/useWorkspaceLayout.ts
+++ b/frontend/src/components/shell/useWorkspaceLayout.ts
@@ -94,8 +94,8 @@ export function canvasFitsWith(o: {
  * Inspector 打开时 Dock 实际渲染多宽。让位次序三步，一步比一步肉疼：
  *
  *   1. 保得住 Canvas 560 → 从 Dock 借到刚好（不低于 480、不超过用户拖出来的宽度）；
- *   2. 保不住 → Canvas 让位，终端一寸不动（「终端窄 13%」不如「页面整个消失」难受，
- *      但页面反正要让掉，就别再折腾终端）；
+ *   2. 保不住 → Canvas 让位，终端**长满**它腾出来的宽度（页面反正要让掉，
+ *      就别再折腾终端；也别让那条宽度谁都不要，空在右边成一道黑边）；
  *   3. Canvas 让光了还不够 → **终端跟着让**，让到 480 为止。
  *
  * 第 3 步是「抽屉向左长」这件事的地基：抽屉两层加起来能到一千出头，终端一寸不让的话
@@ -109,7 +109,11 @@ export function effectiveDockWidth(o: {
   // 三步共用的硬底线：Dock + Inspector 不许撑破工作区（撑破 = 文档横向溢出 = 10px 滚动条）
   const hard = o.workspaceWidth - SPLIT_RAIL * 2 - o.inspectorWidth
   if (!canvasFitsWith({ workspaceWidth: o.workspaceWidth, inspectorWidth: o.inspectorWidth, hasDock: true })) {
-    return Math.max(DOCK_MIN, Math.min(o.dockWidth, hard))
+    // Canvas 已经让光，这条剩余宽度没有第三者要用 —— 终端把它吃满。
+    // 从前这里是 min(dockWidth, hard)：终端守着自己拖出来的宽度不动，
+    // Inspector 守着自己的，两者加起来不满工作区，右边就空出一条黑边
+    // （1366 的笔记本上实测 192px）。「终端一寸不让」说的是不缩，不是不长。
+    return Math.max(DOCK_MIN, hard)
   }
   const room = o.workspaceWidth - CANVAS_MIN - SPLIT_RAIL * 2 - o.inspectorWidth
   return Math.max(DOCK_MIN, Math.min(o.dockWidth, room, hard))

--- a/frontend/src/components/shell/workspace-layout.test.ts
+++ b/frontend/src/components/shell/workspace-layout.test.ts
@@ -143,12 +143,13 @@ describe('Inspector 让位次序', () => {
     expect(w - dock - SPLIT_RAIL * 2 - ins).toBeGreaterThanOrEqual(CANVAS_MIN)
   })
 
-  it('1440：借不够，Canvas 让位，且 Dock 用回原宽（终端一寸不变）', () => {
+  it('1440：借不够，Canvas 让位，终端长满它腾出来的宽度', () => {
     const w = workspace(1440) // 1216
     expect(canvasFitsWith({ workspaceWidth: w, inspectorWidth: ins, hasDock: true })).toBe(false)
     const mine = defaultDockWidth(1440, w)
-    expect(effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true }))
-      .toBe(mine)
+    const dock = effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true })
+    expect(dock).toBeGreaterThan(mine)                  // 守着原宽 = 右边留一条黑边
+    expect(dock + SPLIT_RAIL * 2 + ins).toBe(w)         // 正好铺满
   })
 
   it('借宽绝不越过用户拖出来的宽度，也绝不低于 480', () => {
@@ -156,7 +157,11 @@ describe('Inspector 让位次序', () => {
       const w = workspace(viewport)
       for (const mine of [DOCK_MIN, 600, 880]) {
         const got = effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true })
-        expect(got).toBeLessThanOrEqual(mine)
+        // 「不越过原宽」是**借宽**这一步的约束（第 1 步，Canvas 还在）。Canvas 让掉之后
+        // 走的是第 2 步「长满」，那里越过原宽正是要的结果。
+        if (canvasFitsWith({ workspaceWidth: w, inspectorWidth: ins, hasDock: true })) {
+          expect(got).toBeLessThanOrEqual(mine)
+        }
         expect(got).toBeGreaterThanOrEqual(DOCK_MIN)
       }
     }
@@ -195,10 +200,28 @@ describe('Inspector 让位次序', () => {
     expect(dock + SPLIT_RAIL * 2 + want).toBeLessThanOrEqual(w)
   })
 
-  it('抽屉够放时终端一寸不动——退让只在真不够的时候发生', () => {
-    const w = workspace(1600, false)
-    const mine = 900
-    const dock = effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: 552, inspectorOpen: true })
+  it('Canvas 保得住时终端一寸不动——借宽只在真不够的时候发生', () => {
+    const w = workspace(1600, false) // 1552
+    const mine = 500
+    expect(canvasFitsWith({ workspaceWidth: w, inspectorWidth: ins, hasDock: true })).toBe(true)
+    const dock = effectiveDockWidth({ workspaceWidth: w, dockWidth: mine, inspectorWidth: ins, inspectorOpen: true })
     expect(dock).toBe(mine)
+  })
+
+  // 这次的 bug：Canvas 让掉之后那条宽度谁都没接，右边空出一道黑边（1366 笔记本上 192px）。
+  // 三列几何的硬契约是**既不溢出、也不留白**——溢出招来 10px 文档滚动条，留白就是那张截图。
+  it('Canvas 让位之后，Dock + Inspector 正好铺满工作区', () => {
+    for (const viewport of [1280, 1366, 1440, 1600, 1920]) {
+      for (const navExpanded of [true, false]) {
+        const w = workspace(viewport, navExpanded)
+        const cap = inspectorBounds({ workspaceWidth: w, hasDock: true }).max
+        for (const want of [INSPECTOR_MIN, INSPECTOR_DEFAULT, 552, 945]) {
+          const insW = Math.min(want, cap)
+          if (canvasFitsWith({ workspaceWidth: w, inspectorWidth: insW, hasDock: true })) continue
+          const dock = effectiveDockWidth({ workspaceWidth: w, dockWidth: DOCK_MIN, inspectorWidth: insW, inspectorOpen: true })
+          expect(dock + SPLIT_RAIL * 2 + insW).toBe(w)
+        }
+      }
+    }
   })
 })


### PR DESCRIPTION
## 现象

1366 的笔记本上打开文件面板，右边空出一条黑边（实测 192px）。

## 根因

三列摆不下（`560 + 8 + 480 + 8 + 360 = 1416 > 1318`），按设计 Canvas 让位。让位之后：

| | 宽度 |
|---|---|
| Dock（终端） | 750（它拖出来的宽度） |
| rail ×2 | 16 |
| Inspector（文件面板） | 360 |
| **合计** | **1126** |
| 工作区 | **1318** |
| **没人要的** | **192** |

三列的 flex 全是 `0 0 <定值>`，谁都不 grow，那 192px 就空在那儿。

数值真相在 `effectiveDockWidth` 的第 2 步：`min(dockWidth, hard)`。它把「终端一寸不让」理解成了「一寸不动」——可那句话说的是**不缩**，不是不长。Canvas 已经让光，这条剩余宽度没有第三者要用。

## 改动

`min(dockWidth, hard)` → `max(DOCK_MIN, hard)`。

1366 实测：终端 **728 → 917px**，留白 0，无横向溢出。

## 测试

三条旧断言把「留白」写成了契约，跟着改（每条都核对过几何）：

- 「1440 借不够…Dock 用回原宽」测的就是这一步，断言即 bug 本身；
- 「借宽绝不越过原宽」说的是第 1 步（借 = 缩），第 2 步是填满，两回事——按 `canvasFitsWith` 分开；
- 「抽屉够放时终端一寸不动」的几何其实 `canvasFits=false`（`1552 − 480 − 8 − 552 − 8 = 504 < 560`），名不副实，换成真保得住 Canvas 的一组。

新增一条该守的不变量：**Canvas 让位后 `dock + 2×rail + inspector` 必须正好等于工作区宽**——既不溢出（招 10px 文档滚动条）也不留白。覆盖 5 档视口 × 2 种导航态 × 4 种面板宽。

`workspace-layout.test.ts` 23 passed；`npm run typecheck && i18n:check && hover:check && vitest run`（300 passed）+ `check.sh quick` 全过。浏览器侧用 Chrome CDP 在 1366×768 实测确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW