### PR TITLE
feat(chat): 对话里被 @ 引用的图片，渲染成能点开的缩略图卡片

### DIFF
--- a/frontend/src/agent-paths.test.ts
+++ b/frontend/src/agent-paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { appendPaths, atPath, atPaths } from './agent-paths'
+import { appendPaths, atPath, atPaths, splitAtPaths } from './agent-paths'
 
 describe('交给 agent 的路径写法', () => {
   it('每个路径都带上 @', () => {
@@ -32,5 +32,57 @@ describe('交给 agent 的路径写法', () => {
   it('已有文字末尾的空白折成一个', () => {
     expect(appendPaths('看看这个   ', ['/tmp/a.png'])).toBe('看看这个 @/tmp/a.png ')
     expect(appendPaths('', ['/tmp/a.png'])).toBe('@/tmp/a.png ')
+  })
+})
+
+describe('splitAtPaths', () => {
+  const png = (p: string) => /\.png$/i.test(p)
+
+  it('把认得的路径单独切出来，前后文字原样保留', () => {
+    expect(splitAtPaths('看看 @/tmp/a.png 这个', png)).toEqual([
+      { kind: 'text', text: '看看 ' },
+      { kind: 'path', path: '/tmp/a.png' },
+      { kind: 'text', text: ' 这个' },
+    ])
+  })
+
+  it('不认的路径留在文字里，不单独成段', () => {
+    // 否则「看看 @a.txt 和 @b.txt 的区别」会被拆成三块，句子读不成句子
+    expect(splitAtPaths('看 @/tmp/a.txt 和 @/tmp/b.png', png)).toEqual([
+      { kind: 'text', text: '看 @/tmp/a.txt 和 ' },
+      { kind: 'path', path: '/tmp/b.png' },
+    ])
+  })
+
+  it('只认绝对路径——相对路径没有基准目录，取不出文件', () => {
+    expect(splitAtPaths('@src/a.png', png)).toEqual([{ kind: 'text', text: '@src/a.png' }])
+  })
+
+  it('@ 前面必须是行首或空白，别把 foo@/bar.png 认成引用', () => {
+    expect(splitAtPaths('mail:foo@/x.png', png)).toEqual([{ kind: 'text', text: 'mail:foo@/x.png' }])
+  })
+
+  it('开头就是路径 / 连着两条 / 空文本', () => {
+    expect(splitAtPaths('@/tmp/a.png', png)).toEqual([{ kind: 'path', path: '/tmp/a.png' }])
+    expect(splitAtPaths('@/tmp/a.png @/tmp/b.png', png)).toEqual([
+      { kind: 'path', path: '/tmp/a.png' },
+      { kind: 'text', text: ' ' },
+      { kind: 'path', path: '/tmp/b.png' },
+    ])
+    expect(splitAtPaths('', png)).toEqual([])
+  })
+
+  it('atPaths 拼出来的东西切得回来——两个方向必须对得上', () => {
+    const paths = ['/tmp/a.png', '/tmp/b.png']
+    const segs = splitAtPaths(appendPaths('看这个', paths), png)
+    expect(segs.filter((s) => s.kind === 'path').map((s: any) => s.path)).toEqual(paths)
+  })
+
+  // 正则是模块级的，带 /g 就带着 lastIndex —— 忘了清会让第二次调用从上次的位置开始，
+  // 表现是「同一条消息，重渲染之后图片没了」。
+  it('连续调用两次结果一样', () => {
+    const a = splitAtPaths('看 @/tmp/a.png', png)
+    const b = splitAtPaths('看 @/tmp/a.png', png)
+    expect(b).toEqual(a)
   })
 })

--- a/frontend/src/agent-paths.ts
+++ b/frontend/src/agent-paths.ts
@@ -28,3 +28,35 @@ export function appendPaths(prev: string, paths: string[]): string {
   if (!seg) return prev
   return (prev ? prev.replace(/\s*$/, ' ') : '') + seg
 }
+
+/** 一段文本切开之后的片段：普通文字，或一条被 @ 引用的路径。 */
+export type AtSegment = { kind: 'text'; text: string } | { kind: 'path'; path: string }
+
+// 只认**绝对路径**：相对路径没有基准目录，取不出文件来，渲染成缩略图只会得到一个碎图标。
+// 边界取到空白为止 —— 这与 atPaths 用空格分隔多条路径的写法是同一套约定，
+// 所以带空格的文件名在这条链路上从来就表达不了（拼进去就已经分不出边界了）。
+const AT_PATH = /(^|\s)@(\/\S+)/g
+
+/**
+ * 把文本按「被 @ 引用的路径」切成片段，accept 决定哪些路径值得单独拎出来。
+ *
+ * 不认的路径**留在文字里**，不单独成段：对话正文是给人读的句子，
+ * 把每个路径都抠出来会把「看看 @a.txt 和 @b.txt 的区别」拆成三块。
+ */
+export function splitAtPaths(text: string, accept: (path: string) => boolean): AtSegment[] {
+  if (!text) return []
+  const out: AtSegment[] = []
+  let last = 0
+  const push = (s: string) => { if (s) out.push({ kind: 'text', text: s }) }
+  AT_PATH.lastIndex = 0
+  for (let m = AT_PATH.exec(text); m; m = AT_PATH.exec(text)) {
+    const path = m[2]
+    if (!accept(path)) continue
+    // m[1] 是前导空白，它属于左边那段文字，不能吞掉 —— 吞了「看看 @x.png」会粘成「看看@x.png」
+    push(text.slice(last, m.index + m[1].length))
+    out.push({ kind: 'path', path })
+    last = m.index + m[0].length
+  }
+  push(text.slice(last))
+  return out
+}

--- a/frontend/src/components/chat/MentionedImage.test.tsx
+++ b/frontend/src/components/chat/MentionedImage.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ChatMessage } from './Message'
+import { I18nProvider } from '../../i18n'
+import type { Msg } from './types'
+
+afterEach(cleanup)
+
+const user = (text: string): Msg => ({ role: 'user', blocks: [{ kind: 'text', text }], id: 'u1' })
+const show = (text: string) => render(<I18nProvider><ChatMessage m={user(text)} results={{}} side="claude" /></I18nProvider>)
+
+describe('对话里被 @ 引用的图片', () => {
+  it('渲染成能点开的卡片，而不是一行路径', () => {
+    show('看看这个 @/tmp/clipboard-20260823.png')
+    const card = screen.getByRole('button', { name: /clipboard-20260823\.png/ })
+    expect(card).toBeTruthy()
+    // 缩略图指向后端 raw，路径要转义（文件名里带空格 / # 的话不转义就断在半路）
+    const img = card.querySelector('img')
+    expect(img?.getAttribute('src')).toContain(encodeURIComponent('/tmp/clipboard-20260823.png'))
+    // 卡片上给的是文件名，不是整条路径 —— 气泡宽度有限，整条路径会把它撑爆
+    expect(card.textContent).toContain('clipboard-20260823.png')
+    expect(card.textContent).not.toContain('/tmp/')
+  })
+
+  it('路径两边的文字留在原地，句子不断开', () => {
+    const { container } = show('看看 @/tmp/a.png 这个问题')
+    const txt = container.textContent || ''
+    expect(txt).toContain('看看')
+    expect(txt).toContain('这个问题')
+  })
+
+  it('非图片的 @ 路径不动它 —— 那还是句子的一部分', () => {
+    const { container } = show('读一下 @/tmp/notes.txt')
+    expect(screen.queryByRole('button', { name: /notes\.txt/ })).toBeNull()
+    expect(container.textContent).toContain('@/tmp/notes.txt')
+  })
+
+  it('取不到图就退回原样的路径文字', () => {
+    // 对话是历史记录，文件早被删掉是常态：那时候一张碎图标比一行路径更没用
+    const { container } = show('@/tmp/gone.png')
+    const img = container.querySelector('.tt-atimg img') as HTMLImageElement
+    expect(img).toBeTruthy()
+    fireEvent.error(img)
+    expect(container.querySelector('.tt-atimg')).toBeNull()
+    expect(container.textContent).toContain('@/tmp/gone.png')
+  })
+
+  it('一条消息里多张图各出一张卡', () => {
+    show('@/tmp/a.png @/tmp/b.jpg')
+    expect(screen.getByRole('button', { name: /a\.png/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /b\.jpg/ })).toBeTruthy()
+  })
+
+  it('没有图片的消息照常走 Markdown', () => {
+    const { container } = show('普通一句话')
+    expect(container.querySelector('.tt-atimg')).toBeNull()
+    expect(container.textContent).toContain('普通一句话')
+  })
+})
+
+describe('长文件名', () => {
+  it('从中间断，扩展名留住 —— 手机上气泡窄，尾部省略会把它吃掉', () => {
+    show('@/tmp/Screenshot_2026-08-24-10-03-09-56_3ded4b2ed06754eed0cc76c603f59da4.jpg')
+    const card = screen.getByRole('button', { name: /Screenshot/ })
+    expect(card.textContent).toContain('.jpg')
+    expect(card.textContent).toContain('…')
+    // aria-label 与 title 仍给完整名字，读屏和悬停都拿得到
+    expect(card.getAttribute('aria-label')).toContain('3ded4b2ed06754eed0cc76c603f59da4.jpg')
+  })
+})

--- a/frontend/src/components/chat/MentionedImage.tsx
+++ b/frontend/src/components/chat/MentionedImage.tsx
@@ -1,0 +1,90 @@
+// 消息正文里被 @ 引用的图片，渲染成一张能点开看的缩略图卡片。
+//
+// 从前它只是一行 `@/tmp/Screenshot-….jpg`：粘完图发出去，自己回头翻这段对话，
+// 得先把那串路径读懂、再想办法把文件找出来，才知道当时给 agent 看的是什么。
+// 路径本身仍然要留给 agent（它就是靠 @ 认文件的），但**给人看的那一面**应该是图。
+import { useState } from 'react'
+import { Image } from 'antd'
+import { nodeApi } from '../cluster/node-url'
+import { useI18n } from '../../i18n'
+import { ImageIcon } from '../../icons'
+
+// 缩略图边长。coarse 指针下 44px 是可点的下限，这里给到 56 —— 卡片整体更高，
+// 手指落在哪儿都点得中。
+const THUMB = 56
+
+export function MentionedImage({ path, onAccent }: {
+  path: string
+  /** 在实心强调色气泡里（用户消息）：卡片要用半透明白，默认那套边框在蓝底上看不见 */
+  onAccent?: boolean
+}) {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(false)
+  const [dim, setDim] = useState('')
+  const [broken, setBroken] = useState(false)
+  const raw = nodeApi(`/file/raw?path=${encodeURIComponent(path)}`)
+  const name = path.split('/').filter(Boolean).pop() || path
+
+  // 缓存命中时 onLoad 会在 React 把它绑上去之前就烧掉，尺寸于是永远不出现。
+  // ref 回调里补读一次 complete：翻回一段旧对话时走的正是这条路。
+  const measure = (el: HTMLImageElement | null) => {
+    if (el?.complete && el.naturalWidth) setDim(`${el.naturalWidth}×${el.naturalHeight}`)
+  }
+
+  // 取不到图就退回原样的路径文字：对话是历史记录，文件早被删掉是常态，
+  // 那时候一张碎图标比一行路径更没用 —— 至少路径还告诉你它当时在哪。
+  if (broken) {
+    return <code style={{ fontSize: 'var(--fs-meta)', opacity: .85, wordBreak: 'break-all' }}>@{path}</code>
+  }
+
+  // 手机上气泡窄，尾部省略会把扩展名一起吃掉，而「.jpg 还是 .pdf」正是一眼要看的东西。
+  // 从中间断，两头都留住。
+  const shown = name.length > 34 ? `${name.slice(0, 20)}…${name.slice(-11)}` : name
+
+  const border = onAccent ? '1px solid rgba(255,255,255,.28)' : '1px solid var(--border)'
+  const dimText = onAccent ? 'rgba(255,255,255,.75)' : 'var(--text-dim)'
+
+  return (
+    <>
+      {/* antd 的 preview 挂在一张隐藏图上，由卡片受控打开：
+          这样整张卡片都是热区，而不是只有那块缩略图能点。 */}
+      <Image
+        src={raw}
+        style={{ display: 'none' }}
+        preview={{ visible: open, src: raw, onVisibleChange: (v) => setOpen(v) }}
+      />
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`${t('chat.viewImage')} ${name}`}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 'var(--sp-2)',
+          maxWidth: '100%', padding: 'var(--sp-1)', textAlign: 'left',
+          border, borderRadius: 'var(--r-card)',
+          background: onAccent ? 'rgba(255,255,255,.12)' : 'var(--bg-container)',
+          color: 'inherit', cursor: 'pointer', font: 'inherit',
+        }}
+        className="tt-atimg"
+      >
+        <img
+          src={raw}
+          alt={name}
+          width={THUMB}
+          height={THUMB}
+          loading="lazy"
+          ref={measure}
+          onLoad={(e) => measure(e.currentTarget)}
+          onError={() => setBroken(true)}
+          style={{ width: THUMB, height: THUMB, objectFit: 'cover', borderRadius: 'var(--r-sm)', flex: '0 0 auto', background: 'var(--bg-base)' }}
+        />
+        <span style={{ minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span title={name} style={{ fontSize: 'var(--fs-meta)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{shown}</span>
+          <span style={{ fontSize: 'var(--fs-micro)', color: dimText, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <ImageIcon size={11} />
+            {dim ? `${dim} · ` : ''}{t('chat.viewImage')}
+          </span>
+        </span>
+      </button>
+    </>
+  )
+}

--- a/frontend/src/components/chat/Message.tsx
+++ b/frontend/src/components/chat/Message.tsx
@@ -10,6 +10,9 @@ import { useI18n } from '../../i18n'
 import type { Block, Msg } from './types'
 import { LooseResult, ToolView } from './tool-render'
 import { TerminalIcon } from '../../icons'
+import { splitAtPaths } from '../../agent-paths'
+import { IMG_EXT } from '../files/file-utils'
+import { MentionedImage } from './MentionedImage'
 
 export const CODEX_ACCENT = 'var(--ok)' // Codex 一方的强调色＝全站唯一那支绿
 
@@ -84,6 +87,26 @@ function Prose({ blocks, accent, side }: { blocks: Block[]; accent: string; side
 
 // 用户气泡：右侧实心块。命令小标、命令回显、系统提醒都挪到气泡外，
 // 免得白字压在实心底色上再套一层折叠框。
+const isImagePath = (p: string) => IMG_EXT.includes((p.split('.').pop() || '').toLowerCase())
+
+/**
+ * 正文里被 @ 引用的图片就地换成缩略图卡片，其余文字照常走 Markdown。
+ *
+ * 就地替换而不是「正文照旧、图片另起一排」：路径常常嵌在句子里（「看看 @/tmp/a.png
+ * 这个问题」），把它抽到底下，句子就断在半空；而留在原地又等于把同一件事说两遍。
+ */
+function BodyWithImages({ text, accent }: { text: string; accent: string }) {
+  const segs = splitAtPaths(text, isImagePath)
+  if (segs.length === 1 && segs[0].kind === 'text') return <Markdown accent={accent}>{text}</Markdown>
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)', alignItems: 'flex-start' }}>
+      {segs.map((sg, i) => (sg.kind === 'path'
+        ? <MentionedImage key={i} path={sg.path} onAccent={accent === '#fff'} />
+        : <Markdown key={i} accent={accent}>{sg.text}</Markdown>))}
+    </div>
+  )
+}
+
 function UserMessage({ m, accent }: { m: Msg; accent: string }) {
   const { t } = useI18n()
   const parsed = m.blocks.map((b) => (b.kind === 'text' ? parseUserText(b.text || '') : null))
@@ -98,7 +121,7 @@ function UserMessage({ m, accent }: { m: Msg; accent: string }) {
           {m.blocks.map((b, i) => {
             const p = parsed[i]
             // 实心底上正文是白字，链接跟着走白色——默认那支蓝压在蓝底上根本看不见
-            if (!p) return b.text ? <Markdown key={i} accent="#fff">{b.text}</Markdown> : null
+            if (!p) return b.text ? <BodyWithImages key={i} text={b.text} accent="#fff" /> : null
             return (
               <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--sp-1)' }}>
                 {p.command && (
@@ -106,7 +129,7 @@ function UserMessage({ m, accent }: { m: Msg; accent: string }) {
                     <TerminalIcon size={12} />{p.command}{p.args ? ` ${p.args}` : ''}
                   </span>
                 )}
-                {p.body && <Markdown accent="#fff">{p.body}</Markdown>}
+                {p.body && <BodyWithImages text={p.body} accent="#fff" />}
               </div>
             )
           })}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -563,6 +563,7 @@ const enUS = {
   'chat.taskStatus.deleted': 'Deleted',
   'chat.systemReminder': 'System reminder',
   'chat.imageBlock': '[image]',
+  'chat.viewImage': 'View',
   'prompt.confirmRequired': 'Confirmation required',
   'prompt.yes': 'Yes (y)',
   'prompt.no': 'No (n)',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -565,6 +565,7 @@ const zhCN = {
   'chat.taskStatus.deleted': '已删除',
   'chat.systemReminder': '系统提醒',
   'chat.imageBlock': '[图片]',
+  'chat.viewImage': '点击查看',
   'prompt.confirmRequired': '需要你确认',
   'prompt.yes': '是 (y)',
   'prompt.no': '否 (n)',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1453,6 +1453,14 @@ html[data-pointer="coarse"] .ant-tooltip { display: none; }
 :where(html[data-pointer="fine"]) .tt-act.danger:hover { color: var(--danger); border-color: var(--danger-border); background: var(--danger-soft); }
 :where(html[data-pointer="fine"]) .tt-act.ok:hover { color: var(--ok); border-color: var(--ok-border); background: var(--ok-soft); }
 .tt-act:active { background: var(--list-hover); }
+
+/* 对话正文里被 @ 引用的图片卡片。整张卡是按钮，hover 只给一点亮度反馈——
+   它嵌在句子中间，描重了就成了一颗按钮夹在文字里。 */
+.tt-atimg { transition: background .12s, border-color .12s; }
+:where(html[data-pointer="fine"]) .tt-atimg:hover { background: var(--list-hover); border-color: var(--border); }
+:where(html[data-pointer="fine"]) .tt-atimg:hover img { filter: brightness(1.06); }
+.tt-atimg:active { transform: scale(.99); }
+
 .tt-act.danger:active { background: var(--danger-soft); color: var(--danger); }
 .tt-act.ok:active { background: var(--ok-soft); color: var(--ok); }
 .tt-act:focus-visible { outline: 1px solid var(--accent-border); outline-offset: 1px; }


### PR DESCRIPTION
## 现在

粘完图发出去，正文里留下的是一行路径：

```
@/tmp/Screenshot_2026-08-24-10-03-09-56_3ded4b2ed06754eed0cc76c603f59da4.jpg
这种能独特渲染下，可以点击查看
```

回头翻这段对话，得先把那串路径读懂、再想办法把文件找出来，才知道当时给 agent 看的是什么。

路径本身仍然要留给 agent（它就是靠 `@` 认文件的），但**给人看的那一面**应该是图。

## 改成

正文里的 @图片路径就地换成一张卡片：缩略图 + 文件名 + 原始尺寸，点开走 antd 的 preview 看大图。

就地替换而不是「正文照旧、图片另起一排」——路径常常嵌在句子里（「看看 `@/tmp/a.png` 这个问题」），抽到底下句子就断在半空，留在原地又等于把同一件事说两遍。

## 几处不显然的

| | 为什么 |
|---|---|
| **只认绝对路径** | 相对路径没有基准目录，取不出文件，渲染出来只会是个碎图标 |
| **不认的路径留在文字里**，不单独成段 | 否则「看看 @a.txt 和 @b.txt 的区别」会被拆成三块，句子读不成句子 |
| **取不到图就退回原样的路径文字** | 对话是历史记录，文件早被删掉是常态——那时候一张碎图标比一行路径更没用，至少路径还告诉你它当时在哪 |
| **`ref` 里补读一次 `complete`** | 缓存命中时 `onLoad` 会在 React 把它绑上去之前就烧掉，尺寸于是永远不出现。翻回一段旧对话走的正是这条路 |
| **长文件名从中间断** | 手机上气泡窄，尾部省略会把扩展名一起吃掉，而「.jpg 还是 .pdf」正是一眼要看的东西。完整名字仍在 `aria-label` 与 `title` 里 |
| **切分正则用完清 `lastIndex`** | 模块级 + `/g` 就带着位置，忘了清会让第二次调用从上次的地方开始——表现是「同一条消息，重渲染之后图片没了」。有一条测试专门守它 |

切分函数放进 `agent-paths.ts`：那里是「@ 引用」这件事的单一出处，提取是拼接的逆操作。它不认识「什么是图片」，由调用方传 `accept` 判定。

## 验证

在**真实对话**上跑通两档（不是造的数据——就是这条消息本身）：

| | 卡片宽 | 卡片高 | 文件名 |
|---|---|---|---|
| 桌面 1440 | 506 | 66 | 完整显示 |
| 手机 412（compact） | 271 | 66 | `Screenshot_2026-08-2…3f59da4.jpg` |

两档都：缩略图加载成功、`1080×2376 · 点击查看` 正常、点击开大图。66px 高过了 coarse 指针 44px 的下限。

13 条切分测试 + 7 条组件测试（含「文件已删退回路径文字」「非图片路径不动它」「一条消息多张图」）。`check.sh quick` 与前端四道门禁全过。

## 没做的

终端里的 @路径没动——xterm 是字符网格，塞不进 DOM 卡片。要做得另起一套（link provider 或 decoration 覆盖层），而那会和 agent TUI 的重绘打架。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW