### PR TITLE
fix(avd): 本机模拟器起不来的三处 —— 4K 被按回 1080p、kvm 组要重新登录、无头下 -gpu host

### DIFF
--- a/backend/phone/android_avd.go
+++ b/backend/phone/android_avd.go
@@ -177,19 +177,41 @@ func avdRef(name string) string { return "avd:" + name }
 
 func avdNameFromRef(ref string) string { return strings.TrimPrefix(ref, "avd:") }
 
-// gpuMode 挑渲染后端：找到 Intel(0x8086)/AMD(0x1002) 渲染节点就走 host 硬件加速，否则软件渲染。
-// 跳过 NVIDIA(0x10de)：其专有驱动下 SurfaceFlinger 常起不来（redroid 时代同样的坑）。
+// gpuMode 挑渲染后端。
+//
+// **先看有没有显示**：-gpu host 走的是 GLX/EGL，要一个 X/Wayland 显示才拿得到 EGL display。
+// roam 后端常年是 systemd 用户服务，DISPLAY 是空的，那里 host 必然失败——日志里写着
+// 「Failed to get EGL display / Could not start renderer」，而 UI 上只剩一句「启动超时」。
+// 有独显也没用：显卡在，能画的那块屏不在。
+//
+// 有显示时才谈硬件加速：Intel(0x8086)/AMD(0x1002) 走 host，
+// 跳过 NVIDIA(0x10de)——其专有驱动下 SurfaceFlinger 常起不来（redroid 时代同样的坑）。
 func gpuMode() string {
 	if runtime.GOOS != "linux" {
 		return "auto" // macOS/Windows 交给模拟器自己挑（有 Metal/ANGLE 后端）
 	}
+	return linuxGPUMode(os.Getenv("DISPLAY"), os.Getenv("WAYLAND_DISPLAY"), drmVendors())
+}
+
+// drmVendors 读出本机各渲染节点的 PCI 厂商号。
+func drmVendors() []string {
 	nodes, _ := filepath.Glob("/sys/class/drm/renderD*/device/vendor")
+	var out []string
 	for _, n := range nodes {
-		b, err := os.ReadFile(n)
-		if err != nil {
-			continue
+		if b, err := os.ReadFile(n); err == nil {
+			out = append(out, strings.TrimSpace(string(b)))
 		}
-		switch strings.TrimSpace(string(b)) {
+	}
+	return out
+}
+
+// linuxGPUMode 是上面那条判断的纯函数部分。
+func linuxGPUMode(display, wayland string, vendors []string) string {
+	if strings.TrimSpace(display) == "" && strings.TrimSpace(wayland) == "" {
+		return "swiftshader_indirect" // 无头：只有软件渲染起得来
+	}
+	for _, v := range vendors {
+		switch v {
 		case "0x8086", "0x1002":
 			return "host"
 		}
@@ -248,7 +270,26 @@ func startAVD(name string, wipe bool) (string, error) {
 		return "", fmt.Errorf("启动模拟器失败: %w", err)
 	}
 	go func() { _ = cmd.Wait() }() // 只为回收僵尸；进程已 setsid，不随我们生死
-	return waitAVDBoot(name, 180*time.Second)
+	serial, err := waitAVDBoot(name, 180*time.Second)
+	if err != nil && serial == "" {
+		// 连 adb 都没登记过 = 它压根没起来（渲染器初始化失败就是这样）。
+		// 这种壳子必须收掉：它会一直握着 AVD 的 multiinstance.lock，
+		// 下一次点「启动」只换来一句 "AVD is already running" ——
+		// 一次失败毒死后面每一次。（同 AGENTS.md 那条：send 失败就 kill 掉刚建的会话。）
+		killProcessGroup(cmd.Process)
+	}
+	return serial, err
+}
+
+// killProcessGroup 收掉整棵进程树。emulator 会再 fork 出 qemu-system 与 crashpad，
+// 只 kill 首进程会留下一堆孤儿，AVD 的锁也还在它们手上；进程已 setsid，pgid 就是它自己。
+func killProcessGroup(p *os.Process) {
+	if p == nil {
+		return
+	}
+	_ = syscall.Kill(-p.Pid, syscall.SIGTERM)
+	time.Sleep(500 * time.Millisecond)
+	_ = syscall.Kill(-p.Pid, syscall.SIGKILL)
 }
 
 // waitAVDBoot 等 serial 出现并等到 sys.boot_completed=1。

--- a/backend/phone/android_avd.go
+++ b/backend/phone/android_avd.go
@@ -197,23 +197,6 @@ func gpuMode() string {
 	return "swiftshader_indirect"
 }
 
-// kvmUsable 判断当前进程能不能真的用上 KVM，并把修法直接写进错误里。
-func kvmUsable() error {
-	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
-	if err == nil {
-		f.Close()
-		return nil
-	}
-	if os.IsNotExist(err) {
-		return errors.New("没有 /dev/kvm：模拟器需要 KVM（虚拟机里要先开嵌套虚拟化）")
-	}
-	if os.IsPermission(err) {
-		return errors.New("无权访问 /dev/kvm：把当前用户加进 kvm 组后重新登录（sudo gpasswd -a $USER kvm），" +
-			"或临时授权 sudo setfacl -m u:$USER:rw /dev/kvm")
-	}
-	return fmt.Errorf("/dev/kvm 不可用: %w", err)
-}
-
 // avdStartMu 串行化启动：重复点击不该起出第二个 qemu 进程（同名 AVD 第二个会因锁失败，只留一堆日志）。
 var avdStartMu sync.Mutex
 
@@ -236,12 +219,13 @@ func startAVD(name string, wipe bool) (string, error) {
 	}
 	// KVM 先于启动检查：没有它 x86_64 镜像根本起不来，而 emulator 的原始报错埋在日志里，
 	// UI 上只剩一句「启动超时」——白等三分钟。
-	// 必须真开一次而不是 Stat：/dev/kvm 常年在那儿，权限却是 logind 按会话动态挂的 ACL，
-	// 文件存在和当前进程能不能用完全是两回事。
+	kvm := kvmOK
 	if runtime.GOOS == "linux" {
-		if err := kvmUsable(); err != nil {
+		st, err := kvmState()
+		if st != kvmOK && st != kvmViaGroup {
 			return "", err
 		}
+		kvm = st
 	}
 	logPath := filepath.Join(avdDir(), "avd-"+name+".log")
 	lf, err := os.Create(logPath)
@@ -253,7 +237,10 @@ func startAVD(name string, wipe bool) (string, error) {
 	if wipe {
 		args = append(args, "-wipe-data")
 	}
-	cmd := exec.Command(bin, args...)
+	// 组里加过 kvm 但本进程没带上时套一层 sg：那一格不套就永远起不来，
+	// 而用户已经照我们说的跑过 sudo 了 —— 再让他「重新登录一次」是我们没做完事。
+	spawnBin, spawnArgs := kvmSpawn(kvm, bin, args)
+	cmd := exec.Command(spawnBin, spawnArgs...)
 	// Setsid：脱离 ttmux 的会话与进程组。后端重启/退出不能把用户的模拟器一起带走。
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdout, cmd.Stderr = lf, lf

--- a/backend/phone/android_avd_create.go
+++ b/backend/phone/android_avd_create.go
@@ -478,7 +478,10 @@ func runCreate(t *avdTask, r avdCreateReq) {
 // tuneAVDConfig 改写新建 AVD 的 config.ini。
 //
 // 这步不能省：avdmanager 建出来的 TV 档未必带方向键，而没有 D-pad 的电视就是块砖——
-// 电视没有触摸屏，焦点走位是唯一的交互方式。分辨率同理，1920x1080@320 才是 960x540dp 的设计画布。
+// 电视没有触摸屏，焦点走位是唯一的交互方式。
+//
+// 分辨率则**只在调用方给了才改**：选了机型档时那一档自己写的才对（tv_4k 是
+// 3840x2160@640），这里再盖一层就把 4K 按回了 1080p。调用方只在没选档时兜一个值。
 func tuneAVDConfig(r avdCreateReq) error {
 	p := filepath.Join(avdHome(), r.Name+".avd", "config.ini")
 	b, err := os.ReadFile(p)

--- a/backend/phone/kvm.go
+++ b/backend/phone/kvm.go
@@ -1,0 +1,142 @@
+// kvm.go：本机模拟器能不能用上 KVM，以及用不上时缺的到底是哪一步。
+//
+// 单独成文是因为它有三种「起不来」，用户看到的却常常是同一句话：
+//
+//	没有 /dev/kvm      机器/虚拟机本身没开虚拟化 —— 谁也救不了，只能说清楚
+//	组里没名字          要一次 sudo：把用户加进 kvm 组
+//	组里有名字、进程没带  加过组但没重新登录 —— 命令明明成功了，模拟器还是起不来
+//
+// 第三种最坑：附加组是进程创建时定死的，systemd 的用户实例也是登录时定死的，
+// `systemctl --user restart roam` 换不来新组，用户于是以为那条 sudo 没生效。
+// 这一档我们自己兜住（见 sgCommand），不让它变成一次「重启试试」。
+package phone
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// kvmFixHint 是缺权限时给用户的那条命令。两条都要，分工不同：
+// setfacl 立刻生效（ACL 按 uid 匹配，正在跑的进程也能开），但它是 logind 挂的，
+// 换个座位会话就会被重挂掉；gpasswd 才持久，代价是要新登录才带得上。
+const kvmFixHint = "sudo gpasswd -a $USER kvm && sudo setfacl -m u:$USER:rw /dev/kvm"
+
+// kvmAccess 是本进程此刻对 /dev/kvm 的处境。
+type kvmAccess int
+
+const (
+	kvmOK       kvmAccess = iota // 直接开得了
+	kvmViaGroup                  // 组里有名字，本进程没带上 —— 借 sg 就能起
+	kvmNoDevice                  // 机器上就没有这个设备
+	kvmDenied                    // 有设备、没权限、组里也没名字
+)
+
+// kvmState 判断当前进程能不能真的用上 KVM。
+//
+// 必须真开一次而不是 Stat：/dev/kvm 常年在那儿，权限却是 logind 按会话动态挂的 ACL，
+// 文件存在和当前进程能不能用完全是两回事。
+func kvmState() (kvmAccess, error) {
+	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
+	if err == nil {
+		f.Close()
+		return kvmOK, nil
+	}
+	if os.IsNotExist(err) {
+		return kvmNoDevice, errors.New("没有 /dev/kvm：模拟器需要 KVM（虚拟机里要先开嵌套虚拟化）")
+	}
+	if os.IsPermission(err) {
+		if kvmGroupPending() {
+			return kvmViaGroup, nil
+		}
+		return kvmDenied, errors.New("无权访问 /dev/kvm，跑一次：" + kvmFixHint)
+	}
+	return kvmDenied, fmt.Errorf("/dev/kvm 不可用: %w", err)
+}
+
+// kvmUsable 保留给「只想知道行不行」的调用方；kvmViaGroup 算行，因为我们会套 sg 起。
+func kvmUsable() error {
+	st, err := kvmState()
+	if st == kvmOK || st == kvmViaGroup {
+		return nil
+	}
+	return err
+}
+
+// kvmGroupPending 报「/etc/group 里已经加过 kvm 组，但本进程没带上」。
+func kvmGroupPending() bool {
+	g, err := user.LookupGroup("kvm")
+	if err != nil {
+		return false
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return false
+	}
+	have, err := syscall.Getgroups()
+	if err != nil {
+		return false
+	}
+	u, err := user.Current()
+	if err != nil {
+		return false
+	}
+	ids, err := u.GroupIds() // 查的是组数据库，不是本进程 —— 两者不一致正是我们要认的那一格
+	if err != nil {
+		return false
+	}
+	return groupPending(gid, g.Gid, have, ids)
+}
+
+// groupPending 是上面那个判断的纯函数部分：组数据库里有、本进程组里没有。
+func groupPending(gid int, gidStr string, procGIDs []int, userGIDs []string) bool {
+	for _, x := range procGIDs {
+		if x == gid {
+			return false // 组已经带上了，还开不了就不是组的事（多半是 SELinux/权限位）
+		}
+	}
+	for _, s := range userGIDs {
+		if s == gidStr {
+			return true
+		}
+	}
+	return false
+}
+
+// sgCommand 在需要时把命令套进 `sg kvm -c "…"`。
+//
+// sg 会照组数据库重算整套组再执行，这正是「加了组但没重新登录」缺的那一下，
+// 而且不要口令 —— 用户本来就是成员。副作用只有一个：这条命令新建的文件属组变成 kvm，
+// 落在 AVD 自己的镜像文件上，无碍。
+//
+// 找不到 sg（shadow-utils 没装）就原样返回：起不来时的报错仍然说得清该干什么。
+func sgCommand(lookPath func(string) (string, error), group, bin string, args []string) (string, []string) {
+	sg, err := lookPath("sg")
+	if err != nil {
+		return bin, args
+	}
+	return sg, []string{group, "-c", shJoin(append([]string{bin}, args...))}
+}
+
+// shJoin 把参数拼成一行安全的 shell 命令：sg -c 收的是字符串，不是 argv。
+// 一律单引号包起来，内部的单引号按 '\” 转义 —— SDK 路径里出现空格并不稀奇。
+func shJoin(parts []string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, "'"+strings.ReplaceAll(p, "'", `'\''`)+"'")
+	}
+	return strings.Join(out, " ")
+}
+
+// kvmSpawn 按当前处境决定「用什么命令起模拟器」。
+func kvmSpawn(st kvmAccess, bin string, args []string) (string, []string) {
+	if st != kvmViaGroup {
+		return bin, args
+	}
+	return sgCommand(exec.LookPath, "kvm", bin, args)
+}

--- a/backend/phone/kvm_test.go
+++ b/backend/phone/kvm_test.go
@@ -1,0 +1,66 @@
+package phone
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestGroupPending(t *testing.T) {
+	const gid, gidStr = 993, "993"
+	cases := []struct {
+		name     string
+		procGIDs []int
+		userGIDs []string
+		want     bool
+	}{
+		{"组数据库里有、本进程没带上 —— 就是加完组没重新登录那一格", nil, []string{"1000", "993"}, true},
+		{"本进程已经带着 kvm 组：开不了就不是组的事，别乱指路", []int{1000, 993}, []string{"1000", "993"}, false},
+		{"压根没加过组：该让用户去跑那条 sudo", []int{1000}, []string{"1000"}, false},
+	}
+	for _, c := range cases {
+		if got := groupPending(gid, gidStr, c.procGIDs, c.userGIDs); got != c.want {
+			t.Errorf("%s: 得到 %v，想要 %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestShJoinQuotes(t *testing.T) {
+	// sg -c 收的是一行字符串不是 argv：路径里一个空格就能把命令拦腰截断。
+	got := shJoin([]string{"/opt/Android Sdk/emulator/emulator", "-avd", "xh_tv4k"})
+	want := `'/opt/Android Sdk/emulator/emulator' '-avd' 'xh_tv4k'`
+	if got != want {
+		t.Errorf("得到 %s，想要 %s", got, want)
+	}
+	if got := shJoin([]string{"a'b"}); got != `'a'\''b'` {
+		t.Errorf("单引号没转义: %s", got)
+	}
+}
+
+func TestKvmSpawnOnlyWrapsPendingGroup(t *testing.T) {
+	args := []string{"-avd", "xh_tv4k", "-no-window"}
+
+	// 能直接开就别套 sg：多一层 shell 就多一处能出错的地方，也让日志里的进程树变形。
+	bin, got := kvmSpawn(kvmOK, "/sdk/emulator", args)
+	if bin != "/sdk/emulator" || !reflect.DeepEqual(got, args) {
+		t.Errorf("kvmOK 不该改命令，得到 %s %v", bin, got)
+	}
+
+	bin, got = kvmSpawn(kvmViaGroup, "/sdk/emulator", args)
+	if bin == "/sdk/emulator" {
+		t.Fatalf("kvmViaGroup 应该套 sg（本机若没装 sg 则跳过）")
+	}
+	want := []string{"kvm", "-c", `'/sdk/emulator' '-avd' 'xh_tv4k' '-no-window'`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("得到 %v，想要 %v", got, want)
+	}
+}
+
+func TestSgCommandFallsBackWhenSgMissing(t *testing.T) {
+	// shadow-utils 没装的机器上不能因此起不来：原样返回，让 emulator 自己去报权限错。
+	missing := func(string) (string, error) { return "", errors.New("not found") }
+	bin, args := sgCommand(missing, "kvm", "/sdk/emulator", []string{"-avd", "x"})
+	if bin != "/sdk/emulator" || len(args) != 2 {
+		t.Errorf("没有 sg 时应原样返回，得到 %s %v", bin, args)
+	}
+}

--- a/backend/phone/kvm_test.go
+++ b/backend/phone/kvm_test.go
@@ -64,3 +64,30 @@ func TestSgCommandFallsBackWhenSgMissing(t *testing.T) {
 		t.Errorf("没有 sg 时应原样返回，得到 %s %v", bin, args)
 	}
 }
+
+func TestLinuxGPUModeHeadless(t *testing.T) {
+	intel := []string{"0x8086"}
+	nvidia := []string{"0x10de"}
+
+	// 无头是判据的第一位：显卡在，能画的那块屏不在。
+	// roam 后端常年是 systemd 用户服务（DISPLAY 空），从前这里回 host，
+	// emulator 拿不到 EGL display 直接死，UI 上只剩一句「启动超时」。
+	if got := linuxGPUMode("", "", intel); got != "swiftshader_indirect" {
+		t.Errorf("无头 + 核显应软件渲染，得到 %s", got)
+	}
+	if got := linuxGPUMode("", "", nvidia); got != "swiftshader_indirect" {
+		t.Errorf("无头 + 独显也一样，得到 %s", got)
+	}
+
+	// 有显示才谈硬件加速
+	if got := linuxGPUMode(":0", "", intel); got != "host" {
+		t.Errorf("有 X 显示 + 核显应走 host，得到 %s", got)
+	}
+	if got := linuxGPUMode("", "wayland-0", []string{"0x1002"}); got != "host" {
+		t.Errorf("Wayland + AMD 应走 host，得到 %s", got)
+	}
+	// NVIDIA 专有驱动下 SurfaceFlinger 常起不来，有显示也躲开
+	if got := linuxGPUMode(":0", "", nvidia); got != "swiftshader_indirect" {
+		t.Errorf("NVIDIA 应躲开 host，得到 %s", got)
+	}
+}

--- a/docs/development/phone.md
+++ b/docs/development/phone.md
@@ -262,6 +262,22 @@ mode 由地址形状决定，不是两个独立选择：`avd:<名>`/`emulator-xx
 云主机不该为一个用不上的功能弹口令框；`ROAM_NO_KVM=1` 显式跳过）。判据是**回读设备**，
 不是命令返回码——装上一个不生效的授权比没有更糟。
 
+### `-gpu host` 要一块能画的屏，不只是一张显卡
+
+`gpuMode()` 从前只看有没有 Intel/AMD 渲染节点就回 `host`。但 `-gpu host` 走的是 GLX/EGL，
+要一个 X/Wayland 显示才拿得到 EGL display，而 roam 后端常年是 systemd 用户服务，
+`DISPLAY` 是空的 —— 于是 emulator 在日志里写 `Failed to get EGL display / Could not start
+renderer` 然后停在那儿，UI 上只剩一句「启动超时」，白等三分钟。**无头就只能软件渲染**
+（`swiftshader_indirect`），有独显也一样：显卡在，能画的那块屏不在。
+
+代价是慢，但起得来：本机 4K（3840x2160）Android TV 冷启动 37s，之后走 quickboot 快照
+再起约 10s。
+
+顺带：**起失败要把壳子收干净**。渲染器初始化失败这类失败会留下一个永远不会开机的 qemu，
+它一直握着 AVD 的 `multiinstance.lock`，下一次点「启动」只换来一句 `AVD is already running`
+—— 一次失败毒死后面每一次。判据是「连 adb 都没登记过」：登记过但没开完机的那台还在正常
+往前走，不能杀。
+
 ### 机型档的分辨率归机型档
 
 `avdmanager create avd -d <档>` 会把该档自己的分辨率写进 `config.ini`（`tv_4k` 是

--- a/docs/development/phone.md
+++ b/docs/development/phone.md
@@ -236,6 +236,39 @@ mode 由地址形状决定，不是两个独立选择：`avd:<名>`/`emulator-xx
 - **就绪轮询**：Android 等 `adb wait-for-device` + `boot_completed`；iOS 等 `simctl bootstatus`。
 - **Shutdown**：Linux 停容器 / kill 模拟器；macOS `simctl shutdown`（可选保留，因为模拟器复用快）。
 
+### KVM 权限：三种「起不来」，别混成一句话
+
+本机模拟器（AVD）是 QEMU+KVM，开不了 `/dev/kvm` 就一定起不来，而 `emulator` 的原始
+报错埋在启动日志里，界面上只剩「启动超时」——白等三分钟。所以 `startAVD` 在拉起之前
+先自己开一次 `/dev/kvm`（`backend/phone/kvm.go`）。**必须真开一次而不是 `Stat`**：
+文件常年在那儿，权限却是 logind 按会话动态挂的 ACL。
+
+三种处境要分开说，因为解法不同：
+
+| 处境 | 判据 | 说法 / 做法 |
+| --- | --- | --- |
+| 没有设备 | `ENOENT` | 机器没开虚拟化（虚拟机里要先开嵌套虚拟化）。救不了，说清楚 |
+| 组里没名字 | `EACCES` 且组数据库里没有 | 让用户跑 `sudo gpasswd -a $USER kvm && sudo setfacl -m u:$USER:rw /dev/kvm` |
+| 组里有名字、进程没带上 | `EACCES` 且组数据库里有 | **我们自己兜住**：套一层 `sg kvm -c` 起模拟器 |
+
+第三格最坑：附加组是进程创建时定死的，systemd 的**用户实例**也是登录时定死的，
+`systemctl --user restart roam` 换不来新组。用户明明照做了那条 sudo，模拟器还是起不来，
+只会觉得那条命令没生效。`sg` 会照组数据库重算整套组再执行，不需要口令（本来就是成员），
+副作用只有「这条命令新建的文件属组变成 kvm」，落在 AVD 自己的镜像文件上，无碍。
+
+两条授权命令分工也不一样，所以两条都发：`setfacl` 立刻生效（ACL 按 uid 匹配，连正在
+跑的进程都能开）但不过重启、也会被 logind 重挂；`gpasswd` 持久，代价是要新登录。
+`install.sh` 的 `ensure_kvm` 在安装时把两条都办了（机器上没有 `/dev/kvm` 就整段跳过，
+云主机不该为一个用不上的功能弹口令框；`ROAM_NO_KVM=1` 显式跳过）。判据是**回读设备**，
+不是命令返回码——装上一个不生效的授权比没有更糟。
+
+### 机型档的分辨率归机型档
+
+`avdmanager create avd -d <档>` 会把该档自己的分辨率写进 `config.ini`（`tv_4k` 是
+`3840x2160@640`）。调用方**只在没选机型档时**才该给分辨率兜底——那时 avdmanager 会
+落到手机默认档，一台竖屏手机尺寸的「电视」才需要我们给 `1920x1080@320`。
+选了档还盖，用户选的 4K 就被按回 1080p，而且 `config.ini` 里看不出是谁按的。
+
 ## 8. 分步骤实施
 
 每步都有明确**验收标准**，做完能独立验证再进下一步。先单平台（Linux/Android）打通整条链路，再补 iOS。

--- a/docs/development/phone.md
+++ b/docs/development/phone.md
@@ -258,9 +258,17 @@ mode 由地址形状决定，不是两个独立选择：`avd:<名>`/`emulator-xx
 
 两条授权命令分工也不一样，所以两条都发：`setfacl` 立刻生效（ACL 按 uid 匹配，连正在
 跑的进程都能开）但不过重启、也会被 logind 重挂；`gpasswd` 持久，代价是要新登录。
-`install.sh` 的 `ensure_kvm` 在安装时把两条都办了（机器上没有 `/dev/kvm` 就整段跳过，
-云主机不该为一个用不上的功能弹口令框；`ROAM_NO_KVM=1` 显式跳过）。判据是**回读设备**，
-不是命令返回码——装上一个不生效的授权比没有更糟。
+授权本身的唯一实现是 [`scripts/install/kvm-access.sh`](../../scripts/install/kvm-access.sh)。
+`install.sh` 按「本地仓库 → 远端同源 raw → 只打印命令」三级取用它，不留第二份副本；
+`start.sh --dev` 直接 source 它。判据是**回读设备**，不是命令返回码——装上一个不生效的
+授权比没有更糟。机器上没有 `/dev/kvm` 就整段跳过（云主机不该为一个用不上的功能弹口令框，
+`ROAM_NO_KVM=1` 可显式跳过）。
+
+**提权只在提得起来的时候**，规矩沿用 `lib/platform.sh` 的 `can_autoinstall`：root /
+免密 sudo / 交互式终端才动手，否则打印命令。`curl … | bash` 的 stdin 是管道、systemd 下
+根本没有终端 —— 那里去 sudo 只会卡在密码输入上，一个装到一半卡死的安装器比不装更难查。
+所以 `start.sh` 分两档：`--dev`（源码档的安装+构建模式）替你办，普通启动只提醒 ——
+systemd 的 `ExecStart` 就是 `start.sh fg`，「启动服务」这件事本来就不该顺手要 root。
 
 ### `-gpu host` 要一块能画的屏，不只是一张显卡
 

--- a/frontend/src/avd-profile.test.ts
+++ b/frontend/src/avd-profile.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { purposeFilter, slugAvdName, tvSizeOverride } from './avd-profile'
+import type { AvdImage, DeviceProfile } from './avd-profile'
+
+const dev = (id: string, name: string, tag?: string): DeviceProfile => ({ id, name, tag })
+const img = (variant: string): AvdImage =>
+  ({ pkg: `system-images;android-36;${variant};x86_64`, api: '36', variant, abi: 'x86_64', installed: true })
+
+describe('电视的分辨率兜底', () => {
+  it('选了「电视(4K)」就不盖分辨率 —— 机型档自己写的是 3840x2160', () => {
+    // 这条是回归：从前无条件盖 1920x1080，选 4K 建出来的是一台 1080p 电视，
+    // 而 config.ini 里看不出是谁按下去的。
+    expect(tvSizeOverride('tv', 'tv_4k')).toEqual({})
+    expect(tvSizeOverride('tv', 'tv_720p')).toEqual({})
+  })
+
+  it('没选机型档才兜 1080p —— 否则 avdmanager 会落到手机默认档', () => {
+    expect(tvSizeOverride('tv', '')).toEqual({ width: 1920, height: 1080, density: 320 })
+    expect(tvSizeOverride('tv', '   ')).toEqual({ width: 1920, height: 1080, density: 320 })
+  })
+
+  it('手机/平板/自定义一律不插手', () => {
+    for (const p of ['phone', 'tablet', 'custom'] as const) {
+      expect(tvSizeOverride(p, '')).toEqual({})
+      expect(tvSizeOverride(p, 'pixel_9')).toEqual({})
+    }
+  })
+})
+
+describe('用途筛选', () => {
+  const devices = [
+    dev('pixel_9', 'Pixel 9'),
+    dev('pixel_tablet', 'Pixel Tablet'),
+    dev('tv_4k', 'Television (4K)', 'android-tv'),
+    dev('wearos_large_round', 'Wear OS Large Round', 'android-wear'),
+  ]
+  const pick = (p: Parameters<typeof purposeFilter>[0]) => devices.filter(purposeFilter(p).device).map((d) => d.id)
+
+  it('电视只留 tv 档，手表/平板不混进来', () => expect(pick('tv')).toEqual(['tv_4k']))
+  it('手机排除平板，也排除一切带 tag 的异形档', () => expect(pick('phone')).toEqual(['pixel_9']))
+  it('平板只留平板', () => expect(pick('tablet')).toEqual(['pixel_tablet']))
+  it('自定义全都给', () => expect(pick('custom')).toHaveLength(4))
+
+  it('镜像同理：手机档不给 tv/wear/automotive/desktop/xr', () => {
+    const imgs = [img('google_apis'), img('android-tv'), img('android-wear'), img('google_apis_playstore')]
+    expect(imgs.filter(purposeFilter('phone').image).map((i) => i.variant))
+      .toEqual(['google_apis', 'google_apis_playstore'])
+    expect(imgs.filter(purposeFilter('tv').image).map((i) => i.variant)).toEqual(['android-tv'])
+  })
+})
+
+describe('AVD 名', () => {
+  it('空格和中文就地转掉 —— avdmanager 不收，留给后端只会换来一句报错', () => {
+    expect(slugAvdName('小慧 TV 4K')).toBe('TV_4K')
+    expect(slugAvdName('xh tv4k')).toBe('xh_tv4k')
+    expect(slugAvdName('__a.b-c__')).toBe('a.b-c')
+  })
+})

--- a/frontend/src/avd-profile.ts
+++ b/frontend/src/avd-profile.ts
@@ -1,0 +1,39 @@
+// 新建模拟器时「用途 → 机型档/镜像」的挑选规则。
+//
+// 从组件里抽出来是为了能测：这几条规则错了不会报错，只会安静地建出一台不是你要的机器
+// —— 选「电视(4K)」拿到 1080p 那次就是这么来的，而那要等模拟器起来才看得见。
+export type Purpose = 'phone' | 'tablet' | 'tv' | 'custom'
+
+export type DeviceProfile = { id: string; name: string; oem?: string; tag?: string }
+export type AvdImage = { pkg: string; api: string; variant: string; abi: string; installed: boolean }
+
+// 变体按关键字认，不按白名单：Google 一直在加新档（google-tv、google_apis_ps16k、
+// *_tablet、aosp_atd…），写死名单等于每出一个新档就漏一个。
+const NON_HANDHELD = /tv|wear|automotive|desktop|xr/
+
+export const purposeFilter = (p: Purpose) => ({
+  device: (d: DeviceProfile) => {
+    const tablet = /tablet|nexus (7|9|10)/i.test(d.id + ' ' + d.name)
+    if (p === 'tv') return /tv/.test(d.tag || '')
+    if (p === 'tablet') return !d.tag && tablet
+    if (p === 'phone') return !d.tag && !tablet
+    return true
+  },
+  image: (i: AvdImage) => {
+    if (p === 'tv') return /tv/.test(i.variant)
+    if (p === 'phone' || p === 'tablet') return !NON_HANDHELD.test(i.variant)
+    return true
+  },
+})
+
+// tvSizeOverride 只在**没选机型档**时给电视兜一个 1080p。
+//
+// 选了档就绝不能盖：avdmanager -d 会把那一档自己的分辨率写进 config.ini
+// （tv_4k → 3840x2160@640），我们再盖一层 1920x1080@320，用户选的「电视(4K)」
+// 就被按回了 1080p —— 而且看不出是谁按的。
+// 没选档时 avdmanager 落到手机默认档，一台竖屏手机尺寸的「电视」，那才要兜。
+export const tvSizeOverride = (purpose: Purpose, device: string) =>
+  purpose === 'tv' && !device.trim() ? { width: 1920, height: 1080, density: 320 } : {}
+
+// AVD 名只收 [A-Za-z0-9._-]：avdmanager 拒绝空格和中文，就地转掉而不是留给后端报错。
+export const slugAvdName = (s: string) => s.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '')

--- a/frontend/src/components/settings/avd-create.tsx
+++ b/frontend/src/components/settings/avd-create.tsx
@@ -8,37 +8,14 @@ import { App as AntApp, Button, Checkbox, Drawer, Input, InputNumber, Segmented,
 import { api } from '../../api'
 import { nodeApi } from '../cluster/node-url'
 import { useI18n } from '../../i18n'
+import { purposeFilter, slugAvdName, tvSizeOverride } from '../../avd-profile'
+import type { AvdImage, DeviceProfile, Purpose } from '../../avd-profile'
 
-type DeviceProfile = { id: string; name: string; oem?: string; tag?: string }
-type Image = { pkg: string; api: string; variant: string; abi: string; installed: boolean }
+type Image = AvdImage
 type Catalog = {
   devices: DeviceProfile[]; images: Image[]; avds: string[]; abi: string
   tools: { emulator: boolean; sdkmanager: boolean; avdmanager: boolean; sdkRoot: string }
 }
-
-type Purpose = 'phone' | 'tablet' | 'tv' | 'custom'
-
-// 变体按关键字认，不按白名单：Google 一直在加新档（google-tv、google_apis_ps16k、
-// *_tablet、aosp_atd…），写死名单等于每出一个新档就漏一个。
-const NON_HANDHELD = /tv|wear|automotive|desktop|xr/
-
-const purposeFilter = (p: Purpose) => ({
-  device: (d: DeviceProfile) => {
-    const tablet = /tablet|nexus (7|9|10)/i.test(d.id + ' ' + d.name)
-    if (p === 'tv') return /tv/.test(d.tag || '')
-    if (p === 'tablet') return !d.tag && tablet
-    if (p === 'phone') return !d.tag && !tablet
-    return true
-  },
-  image: (i: Image) => {
-    if (p === 'tv') return /tv/.test(i.variant)
-    if (p === 'phone' || p === 'tablet') return !NON_HANDHELD.test(i.variant)
-    return true
-  },
-})
-
-// AVD 名只收 [A-Za-z0-9._-]：avdmanager 拒绝空格和中文，就地转掉而不是留给后端报错。
-const slug = (s: string) => s.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '')
 
 export function AvdCreateDrawer({ open, onClose, onCreated }: {
   open: boolean; onClose: () => void; onCreated: () => void
@@ -81,7 +58,7 @@ export function AvdCreateDrawer({ open, onClose, onCreated }: {
   // 名字跟着选择走，除非用户自己改过——改过就不再覆盖他。
   useEffect(() => {
     if (nameTouched || !picked) return
-    setName(slug([device || purpose, 'api' + picked.api].join('_')))
+    setName(slugAvdName([device || purpose, 'api' + picked.api].join('_')))
   }, [device, pkg, purpose])
 
   const variantText = (v: string) => {
@@ -118,7 +95,7 @@ export function AvdCreateDrawer({ open, onClose, onCreated }: {
 
   const create = async (start: boolean) => {
     if (!name || !pkg) { message.warning(t('phone.avd.needNamePkg')); return }
-    const tvSize = purpose === 'tv' ? { width: 1920, height: 1080, density: 320 } : {}
+    const tvSize = tvSizeOverride(purpose, device)
     try {
       const r = await api('POST', '/phone/avd', {
         name, pkg, device, start, acceptLicense: license,
@@ -180,7 +157,7 @@ export function AvdCreateDrawer({ open, onClose, onCreated }: {
 
         <div>
           <div className="tt-lbl">{t('phone.avd.name')}</div>
-          <Input value={name} onChange={(e) => { setNameTouched(true); setName(slug(e.target.value)) }} />
+          <Input value={name} onChange={(e) => { setNameTouched(true); setName(slugAvdName(e.target.value)) }} />
           <div className="tt-hint">{t('phone.avd.nameHelp')}</div>
         </div>
 

--- a/install.sh
+++ b/install.sh
@@ -167,52 +167,33 @@ ensure_adb() {
 }
 
 # ── KVM（本机 Android 模拟器要靠它跑起来）──────────────────────────
-# 没有 KVM，x86_64 系统镜像根本起不来，界面上只会看到一句「无权访问 /dev/kvm」。
 #
-# 权限有两条来路，都要，因为它们管的时间段不一样：
-#   setfacl  立刻生效（ACL 按 uid 匹配，连正在跑的 roam 都能开），但它是 logind 挂的，
-#            换个座位会话就会被重挂掉，也不过重启
-#   kvm 组   持久、重启后照样在，代价是附加组在进程创建时定死 —— 要新登录才带得上
-# 于是：ACL 管「现在」，组管「以后」。中间那段（加了组还没重新登录）由后端套 sg 兜住。
-#
-# 机器上没有 /dev/kvm 就直接跳过：云主机大多如此，不该为一个用不上的功能弹口令框。
-# ROAM_NO_KVM=1 可显式跳过。
+# 唯一实现在 scripts/install/kvm-access.sh —— 这里按「本地仓库 → 远端同源 → 只打印命令」
+# 三级取用，**不留第二份副本**：抄两份必然走散，改一条规则要改两处，最后两个入口
+# 按不同版本的规则给同一台机器授权。远端和 install.sh 自己是同一个 raw 源，不多一层信任。
 ensure_kvm() {
-  [ "$OS" = linux ] || return 0                    # macOS 用 HVF，不碰 /dev/kvm
-  [ "${ROAM_NO_KVM:-0}" = 1 ] && { step "ROAM_NO_KVM=1：跳过 KVM 授权（本机模拟器将起不来）"; return 0; }
-  [ -e /dev/kvm ] || { info "本机没有 /dev/kvm，跳过（本机模拟器需要虚拟化；虚拟机里要先开嵌套虚拟化）"; return 0; }
-  if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then info "KVM 已就绪（本机模拟器可用）"; return 0; fi
-
-  local sudo=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null && sudo=sudo
-  if [ "$(id -u)" -ne 0 ] && [ -z "$sudo" ]; then
-    warn "无权访问 /dev/kvm 且没有 sudo：本机模拟器起不来。请由管理员执行：gpasswd -a $USER kvm"
+  [ "$OS" = linux ] || return 0                     # macOS 用 HVF，不碰 /dev/kvm
+  [ -e /dev/kvm ] || return 0                       # 云主机大多没有，别为用不上的功能弹口令框
+  local here lib=""
+  here="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "")"
+  if [ -n "$here" ] && [ -f "$here/scripts/install/kvm-access.sh" ]; then
+    lib="$here/scripts/install/kvm-access.sh"
+  else
+    lib="$(mktemp)" || lib=""
+    # 限时：网络不通时安装器不能卡在这儿 —— 拿不到就退回打印命令，几秒内给出结论。
+    if [ -n "$lib" ] && ! curl -fsSL --connect-timeout 5 --max-time 20 \
+         "https://raw.githubusercontent.com/${REPO}/main/scripts/install/kvm-access.sh" -o "$lib" 2>/dev/null; then
+      rm -f "$lib"; lib=""
+    fi
+  fi
+  if [ -z "$lib" ]; then
+    warn "取不到 KVM 授权脚本。若要用本机模拟器，在终端里跑一次： sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
     return 0
   fi
-  step "无权访问 /dev/kvm，申请授权（需要 sudo 口令）..."
-
-  getent group kvm >/dev/null 2>&1 || $sudo groupadd -r kvm 2>/dev/null || true
-  $sudo gpasswd -a "$USER" kvm >/dev/null 2>&1 || $sudo usermod -aG kvm "$USER" 2>/dev/null || \
-    warn "加入 kvm 组失败：重启后模拟器仍会起不来"
-
-  # setfacl 来自 acl 包，不是每台机器都有；缺了就补一个，补不上也只是少了「立刻生效」这半。
-  command -v setfacl >/dev/null 2>&1 || {
-    if   command -v apt-get >/dev/null; then $sudo apt-get install -y -qq acl 2>/dev/null
-    elif command -v dnf     >/dev/null; then $sudo dnf install -y acl 2>/dev/null
-    elif command -v pacman  >/dev/null; then $sudo pacman -Sy --noconfirm acl 2>/dev/null
-    elif command -v zypper  >/dev/null; then $sudo zypper -n install acl 2>/dev/null
-    elif command -v apk     >/dev/null; then $sudo apk add acl 2>/dev/null
-    fi
-  }
-  command -v setfacl >/dev/null 2>&1 && $sudo setfacl -m "u:$USER:rw" /dev/kvm 2>/dev/null
-
-  # 判据是回读设备，不是命令返回码：装上一个不生效的授权比没有更糟 —— 以为有，于是不再管它。
-  if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
-    info "KVM 已授权（本机模拟器可用；已加入 kvm 组，重启后依然有效）"
-  elif id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx kvm || getent group kvm | grep -q "[:,]$USER\(,\|$\)"; then
-    info "已加入 kvm 组（重新登录后生效；在那之前 roam 会自动借 sg 起模拟器）"
-  else
-    warn "KVM 授权未成功，本机模拟器起不来。手动执行： sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
-  fi
+  # shellcheck source=scripts/install/kvm-access.sh
+  source "$lib"
+  kvm_ensure step
+  [ "$lib" = "$here/scripts/install/kvm-access.sh" ] || rm -f "$lib"
 }
 
 # ── systemd 常驻服务 ─────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@
 #   ROAM_BIN_DIR=DIR      安装目录（默认 ~/.local/bin）
 #   ROAM_NO_SERVICE=1     只装二进制，不注册 systemd 服务
 #   ROAM_SYSTEM=1         注册系统级 systemd 服务（/etc/systemd/system，需 root/sudo）
+#   ROAM_NO_KVM=1         跳过 /dev/kvm 授权（则本机 Android 模拟器起不来）
 #   ROAM_FROM_SOURCE=1    在仓库 clone 内从源码构建（需 go+node），而非下载 release
 #
 # 开发/源码构建请用 start.sh --dev（会从源码构建 CLI/chrome/skills + 前后端）。
@@ -165,6 +166,55 @@ ensure_adb() {
     || warn "未能自动安装 adb：手机镜像页不可用，装好后重启：systemctl --user restart roam"
 }
 
+# ── KVM（本机 Android 模拟器要靠它跑起来）──────────────────────────
+# 没有 KVM，x86_64 系统镜像根本起不来，界面上只会看到一句「无权访问 /dev/kvm」。
+#
+# 权限有两条来路，都要，因为它们管的时间段不一样：
+#   setfacl  立刻生效（ACL 按 uid 匹配，连正在跑的 roam 都能开），但它是 logind 挂的，
+#            换个座位会话就会被重挂掉，也不过重启
+#   kvm 组   持久、重启后照样在，代价是附加组在进程创建时定死 —— 要新登录才带得上
+# 于是：ACL 管「现在」，组管「以后」。中间那段（加了组还没重新登录）由后端套 sg 兜住。
+#
+# 机器上没有 /dev/kvm 就直接跳过：云主机大多如此，不该为一个用不上的功能弹口令框。
+# ROAM_NO_KVM=1 可显式跳过。
+ensure_kvm() {
+  [ "$OS" = linux ] || return 0                    # macOS 用 HVF，不碰 /dev/kvm
+  [ "${ROAM_NO_KVM:-0}" = 1 ] && { step "ROAM_NO_KVM=1：跳过 KVM 授权（本机模拟器将起不来）"; return 0; }
+  [ -e /dev/kvm ] || { info "本机没有 /dev/kvm，跳过（本机模拟器需要虚拟化；虚拟机里要先开嵌套虚拟化）"; return 0; }
+  if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then info "KVM 已就绪（本机模拟器可用）"; return 0; fi
+
+  local sudo=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null && sudo=sudo
+  if [ "$(id -u)" -ne 0 ] && [ -z "$sudo" ]; then
+    warn "无权访问 /dev/kvm 且没有 sudo：本机模拟器起不来。请由管理员执行：gpasswd -a $USER kvm"
+    return 0
+  fi
+  step "无权访问 /dev/kvm，申请授权（需要 sudo 口令）..."
+
+  getent group kvm >/dev/null 2>&1 || $sudo groupadd -r kvm 2>/dev/null || true
+  $sudo gpasswd -a "$USER" kvm >/dev/null 2>&1 || $sudo usermod -aG kvm "$USER" 2>/dev/null || \
+    warn "加入 kvm 组失败：重启后模拟器仍会起不来"
+
+  # setfacl 来自 acl 包，不是每台机器都有；缺了就补一个，补不上也只是少了「立刻生效」这半。
+  command -v setfacl >/dev/null 2>&1 || {
+    if   command -v apt-get >/dev/null; then $sudo apt-get install -y -qq acl 2>/dev/null
+    elif command -v dnf     >/dev/null; then $sudo dnf install -y acl 2>/dev/null
+    elif command -v pacman  >/dev/null; then $sudo pacman -Sy --noconfirm acl 2>/dev/null
+    elif command -v zypper  >/dev/null; then $sudo zypper -n install acl 2>/dev/null
+    elif command -v apk     >/dev/null; then $sudo apk add acl 2>/dev/null
+    fi
+  }
+  command -v setfacl >/dev/null 2>&1 && $sudo setfacl -m "u:$USER:rw" /dev/kvm 2>/dev/null
+
+  # 判据是回读设备，不是命令返回码：装上一个不生效的授权比没有更糟 —— 以为有，于是不再管它。
+  if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+    info "KVM 已授权（本机模拟器可用；已加入 kvm 组，重启后依然有效）"
+  elif id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx kvm || getent group kvm | grep -q "[:,]$USER\(,\|$\)"; then
+    info "已加入 kvm 组（重新登录后生效；在那之前 roam 会自动借 sg 起模拟器）"
+  else
+    warn "KVM 授权未成功，本机模拟器起不来。手动执行： sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
+  fi
+}
+
 # ── systemd 常驻服务 ─────────────────────────────────────────────
 install_service_user() {
   command -v systemctl >/dev/null || { warn "无 systemd，跳过服务注册；手动运行：${BIN_DIR}/roam"; return 0; }
@@ -257,6 +307,7 @@ install_binary
 ensure_tmux
 ensure_chrome
 ensure_adb
+ensure_kvm
 
 if [ "${ROAM_NO_SERVICE:-0}" = 1 ]; then
   step "ROAM_NO_SERVICE=1：跳过服务注册"

--- a/scripts/install/kvm-access.sh
+++ b/scripts/install/kvm-access.sh
@@ -1,0 +1,80 @@
+# scripts/install/kvm-access.sh — /dev/kvm 的访问权：能拿就拿，拿不了就把命令说清楚。
+#
+# 没有 KVM，本机 Android 模拟器（QEMU+KVM）根本起不来，界面上只剩一句「无权访问 /dev/kvm」。
+#
+# 权限有两条来路，两条都要，因为它们管的时间段不一样：
+#   setfacl  立刻生效（ACL 按 uid 匹配，连正在跑的 roam 都能开），但它是 logind 挂的，
+#            换个座位会话就被重挂掉，也不过重启
+#   kvm 组   持久、重启后照样在，代价是附加组在进程创建时定死 —— 要新登录才带得上
+# ACL 管「现在」，组管「以后」。中间那段（加了组还没重新登录）由后端套 sg 兜住，
+# 见 backend/phone/kvm.go。
+#
+# **提权按仓库既有的规矩**（lib/platform.sh 的 can_autoinstall）：root / 免密 sudo /
+# 交互式终端才动手，否则只打印命令。curl|bash 和 systemd 下 stdin 不是终端，
+# 这时候去 sudo 只会卡在密码输入上 —— 一个装到一半卡死的安装器比不装更难查。
+# shellcheck shell=bash
+
+# kvm_can_elevate 现在动 sudo 会不会卡住。
+kvm_can_elevate() {
+    [ "$(id -u)" -eq 0 ] && return 0
+    command -v sudo >/dev/null 2>&1 || return 1
+    sudo -n true 2>/dev/null && return 0   # 免密 sudo
+    [ -t 0 ]                               # 交互式终端：允许弹密码
+}
+
+kvm_usable() { [ -r /dev/kvm ] && [ -w /dev/kvm ]; }
+
+# kvm_in_group 组数据库里有没有这个用户（不是「本进程带没带上」——那是后端管的事）。
+kvm_in_group() {
+    getent group kvm 2>/dev/null | grep -q "[:,]${USER}\(,\|$\)"
+}
+
+kvm_manual_hint() {
+    echo "    sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
+}
+
+# kvm_ensure [say] — say 是一个接收单行消息的函数名，默认 echo。
+#
+# 拿不到就说清楚，绝不假装成功：装上一个不生效的授权比没有更糟 —— 以为有闸，于是不再管它。
+# 所以判据一律是**回读设备/组数据库**，不是命令返回码。
+kvm_ensure() {
+    local say="${1:-echo}"
+    [ "$(uname -s)" = Linux ] || return 0                 # macOS 用 HVF，不碰 /dev/kvm
+    if [ "${ROAM_NO_KVM:-0}" = 1 ]; then
+        $say "ROAM_NO_KVM=1：跳过 /dev/kvm 授权（本机模拟器将起不来）"; return 0
+    fi
+    # 机器上没有这个设备就整段跳过：云主机大多如此，不该为一个用不上的功能弹口令框。
+    [ -e /dev/kvm ] || return 0
+    kvm_usable && { $say "KVM 已就绪（本机模拟器可用）"; return 0; }
+
+    if ! kvm_can_elevate; then
+        $say "无权访问 /dev/kvm，本机模拟器起不来。在终端里跑一次即可（只需一次）："
+        kvm_manual_hint
+        return 0
+    fi
+
+    local sudo=""; [ "$(id -u)" -ne 0 ] && sudo=sudo
+    $say "无权访问 /dev/kvm，申请授权（可能需要 sudo 口令）..."
+    getent group kvm >/dev/null 2>&1 || $sudo groupadd -r kvm 2>/dev/null || true
+    $sudo gpasswd -a "$USER" kvm >/dev/null 2>&1 || $sudo usermod -aG kvm "$USER" 2>/dev/null || true
+
+    # setfacl 来自 acl 包，不是每台机器都有；缺了就补，补不上也只是少了「立刻生效」这半。
+    if ! command -v setfacl >/dev/null 2>&1; then
+        if   command -v apt-get >/dev/null; then $sudo apt-get install -y -qq acl 2>/dev/null
+        elif command -v dnf     >/dev/null; then $sudo dnf install -y acl 2>/dev/null
+        elif command -v pacman  >/dev/null; then $sudo pacman -Sy --noconfirm acl 2>/dev/null
+        elif command -v zypper  >/dev/null; then $sudo zypper -n install acl 2>/dev/null
+        elif command -v apk     >/dev/null; then $sudo apk add acl 2>/dev/null
+        fi
+    fi
+    command -v setfacl >/dev/null 2>&1 && $sudo setfacl -m "u:$USER:rw" /dev/kvm 2>/dev/null
+
+    if kvm_usable; then
+        $say "KVM 已授权（已加入 kvm 组，重启后依然有效）"
+    elif kvm_in_group; then
+        $say "已加入 kvm 组（重新登录后生效；在那之前 roam 会自动借 sg 起模拟器）"
+    else
+        $say "KVM 授权未成功，本机模拟器起不来。手动执行："
+        kvm_manual_hint
+    fi
+}

--- a/start.sh
+++ b/start.sh
@@ -208,6 +208,24 @@ elif [ ! -x "$BIN" ]; then
   echo "✘ 未找到 $BIN —— 先构建：bash install.sh   或   bash start.sh --dev"; exit 1
 fi
 
+# ── KVM 提醒：只对「装了 Android SDK 却开不了 /dev/kvm」的机器说 ──
+#
+# 这里**不**动 sudo：start.sh 常在后台/systemd 下跑，弹口令框只会把它挂死。
+# 授权归 install.sh（那时有终端），这里只负责别让人对着「启动超时」猜。
+# 「加了组还没重新登录」那一格后端会自己套 sg 起，所以这条只在真没授权时出现。
+kvm_hint() {
+  [ "$OS" = Linux ] || return 0
+  [ -e /dev/kvm ] || return 0
+  [ -r /dev/kvm ] && [ -w /dev/kvm ] && return 0
+  id -nG 2>/dev/null | tr ' ' '\n' | grep -qx kvm && return 0
+  getent group kvm 2>/dev/null | grep -q "[:,]${USER}\(,\|$\)" && return 0
+  local sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}"
+  [ -d "$sdk" ] || return 0   # 没装 SDK 的机器不关心模拟器，别多嘴
+  echo "==> 提示：无权访问 /dev/kvm，本机 Android 模拟器起不来。跑一次即可（只需一次）："
+  echo "    sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
+}
+kvm_hint
+
 # ── 启动 ─────────────────────────────────────────────────────────
 echo "==> 启动 Roam  $SCHEME://$BIND"
 echo "    登录口令：首次打开网页时在界面上设置；或编辑 ~/.roam/config.yaml 的 web.password。"

--- a/start.sh
+++ b/start.sh
@@ -208,23 +208,31 @@ elif [ ! -x "$BIN" ]; then
   echo "✘ 未找到 $BIN —— 先构建：bash install.sh   或   bash start.sh --dev"; exit 1
 fi
 
-# ── KVM 提醒：只对「装了 Android SDK 却开不了 /dev/kvm」的机器说 ──
+# ── KVM：--dev 才动手拿权限，平时只提醒 ──────────────────────────
 #
-# 这里**不**动 sudo：start.sh 常在后台/systemd 下跑，弹口令框只会把它挂死。
-# 授权归 install.sh（那时有终端），这里只负责别让人对着「启动超时」猜。
-# 「加了组还没重新登录」那一格后端会自己套 sg 起，所以这条只在真没授权时出现。
-kvm_hint() {
+# 为什么分开：systemd 的 ExecStart 就是 `start.sh fg`，普通启动也常在后台跑，
+# 那里弹 sudo 口令框会把启动挂死（kvm_ensure 里的 can_elevate 也会挡住，
+# 但「启动服务」这件事本来就不该顺手要 root）。--dev 是源码档的安装+构建模式，
+# 装依赖、编 CLI、拉 chrome 都在那儿，拿 KVM 权限是同一类事。
+#
+# 只对「装了 Android SDK 却开不了 /dev/kvm」的机器说：没装 SDK 的机器不关心模拟器。
+kvm_step() {
   [ "$OS" = Linux ] || return 0
   [ -e /dev/kvm ] || return 0
   [ -r /dev/kvm ] && [ -w /dev/kvm ] && return 0
-  id -nG 2>/dev/null | tr ' ' '\n' | grep -qx kvm && return 0
-  getent group kvm 2>/dev/null | grep -q "[:,]${USER}\(,\|$\)" && return 0
   local sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Android/Sdk}}"
-  [ -d "$sdk" ] || return 0   # 没装 SDK 的机器不关心模拟器，别多嘴
+  [ -d "$sdk" ] || return 0
+  if [ "$DEV" = 1 ] && [ -f scripts/install/kvm-access.sh ]; then
+    # shellcheck source=scripts/install/kvm-access.sh
+    source scripts/install/kvm-access.sh
+    kvm_ensure 'echo "==>"'
+    return 0
+  fi
   echo "==> 提示：无权访问 /dev/kvm，本机 Android 模拟器起不来。跑一次即可（只需一次）："
   echo "    sudo gpasswd -a \$USER kvm && sudo setfacl -m u:\$USER:rw /dev/kvm"
+  echo "    或 bash start.sh --dev 让它替你办（需要在终端里跑）"
 }
-kvm_hint
+kvm_step
 
 # ── 启动 ─────────────────────────────────────────────────────────
 echo "==> 启动 Roam  $SCHEME://$BIND"


### PR DESCRIPTION
两处都让「本机模拟器」这个功能在别人机器上跑不起来，一处建错机器，一处根本起不来。

---

## 一、选「电视(4K)」建出来却是 1080p

新建向导只要用途选了「电视」，前端就无条件带上 `1920x1080@320`。但 `avdmanager -d <档>` 已经按机型档把分辨率写进 `config.ini` 了 —— `tv_4k` 是 `3840x2160@640`。我们这一层盖上去，用户选的「Television (4K)」就被按回 1080p，而且 `config.ini` 里看不出是谁按的。

```ts
- const tvSize = purpose === 'tv' ? { width: 1920, height: 1080, density: 320 } : {}
+ const tvSize = tvSizeOverride(purpose, device)
```

改成只在**没选机型档**时才兜底：那时 avdmanager 会落到手机默认档，一台竖屏手机尺寸的「电视」，那才需要 1080p（960x540dp 的电视设计画布）。

顺手把 `purposeFilter` / `slug` 挪进 `frontend/src/avd-profile.ts`：这几条规则错了不会报错，只会安静地建出一台不是你要的机器，而那要等模拟器起来才看得见 —— 得能测。

## 二、`/dev/kvm` 开不了的三种，从前混成同一句话

| 处境 | 判据 | 现在的做法 |
| --- | --- | --- |
| 没有设备 | `ENOENT` | 机器没开虚拟化，救不了，说清楚 |
| 组里没名字 | `EACCES` + 组数据库里没有 | 给出那条 sudo |
| 组里有名字、进程没带上 | `EACCES` + 组数据库里有 | **我们自己兜住**：套 `sg kvm -c` 起 |

第三格最坑：附加组在进程创建时定死，systemd 的**用户实例**也是登录时定死的，`systemctl --user restart roam` 换不来新组。用户明明照着我们说的跑了那条 sudo，模拟器还是起不来，只会觉得那条命令没生效。

`sg` 照组数据库重算整套组再执行，不需要口令（本来就是成员）；副作用只有「这条命令新建的文件属组变成 kvm」，落在 AVD 自己的镜像文件上，无碍。找不到 `sg` 就原样起 —— 报错仍然说得清该干什么。

授权本身归 `install.sh` 的 `ensure_kvm`：`gpasswd`（持久，要新登录）+ `setfacl`（立刻生效，但会被 logind 重挂、也不过重启）两条都办，缺 `acl` 包就顺手装。**机器上没有 `/dev/kvm` 就整段跳过** —— 云主机不该为一个用不上的功能弹口令框（`ROAM_NO_KVM=1` 可显式跳过）。判据是**回读设备**而不是命令返回码：装上一个不生效的授权比没有更糟。

`start.sh` 只提示不 sudo：它常在后台/systemd 下跑，弹口令框会把它挂死；而且只对「装了 Android SDK 却开不了 kvm」的机器说。

---

## 验证

**4K** —— 本机 Web UI 走完整条链（设置 → 手机/Android → 新建模拟器 → 电视 → Television (4K) → Android 36 · Android TV → 创建），抓到的 POST 体不再带尺寸：

```json
{"name":"xh_tv4k","pkg":"system-images;android-36;android-tv;x86_64","device":"tv_4k","start":false,"ram":0,"disk":""}
```

落地 `config.ini`：`hw.lcd.width=3840` / `height=2160` / `density=640` / `hw.dPad=yes` / `hw.gpu.mode=host`。

**KVM** —— `backend/phone/kvm_test.go` 覆盖三态判定、`sg -c` 的 shell 引号（SDK 路径带空格会拦腰截断）、没有 `sg` 时的回落；`ensure_kvm` 用 sudo 打桩跑过三个分支。

单测 `frontend/src/avd-profile.test.ts` 9 条 + `phone` 包全绿；`scripts/dev/quality/check.sh quick` 通过。

---

## 三、KVM 通了之后，仍然起不来：`-gpu host` 要一块能画的屏

```
GlxEnginegetDefaultDisplay: Failed to open display 0. DISPLAY: [(null)]
Failed to get EGL display / Could not start renderer
```

`gpuMode()` 从前只看有没有 Intel/AMD 渲染节点就回 `host`。但 `-gpu host` 走 GLX/EGL，要一个 X/Wayland 显示才拿得到 EGL display，而 roam 后端常年是 systemd 用户服务，`DISPLAY` 是空的。**有独显也一样：显卡在，能画的那块屏不在。** 无头就只能 `swiftshader_indirect` —— 慢，但起得来。

顺带收掉起失败留下的壳子：渲染器初始化失败会留下一个永远不会开机的 qemu，一直握着 AVD 的 `multiinstance.lock`，下一次点「启动」只换来 `AVD is already running` —— 一次失败毒死后面每一次。判据是「连 adb 都没登记过」：登记过但还没开完机的那台在正常往前走，不能杀。

### 真机验收（本机，全程走 Web UI 的按钮）

| | |
| --- | --- |
| 冷启动 | `Boot completed in 36702 ms` |
| 停止 → 再启动 | 走 quickboot 快照，约 10s |
| `wm size` / `wm density` | `3840x2160` / `640` |
| 特性 | `android.software.leanback`（真是电视，不是拉大的手机） |
| 「手机」页镜像 | 出画，页头显示 `3840×2160` |

---

## 四、提权这件事：按仓库既有的规矩，且只留一份实现

`lib/platform.sh` 的 `can_autoinstall` 早就写好了这条规矩，理由也写在那儿 —— **root / 免密 sudo / 交互式终端才动手，否则打印精确命令**，因为 `curl … | bash` 的 stdin 是管道、systemd 下根本没有终端，那里去 sudo 只会卡在密码输入上。第一版 `ensure_kvm` 绕过了它，直接 `$sudo` 上，现在照办。

于是 `start.sh` 能分档：

| 入口 | 提权吗 |
| --- | --- |
| `install.sh` | 会（安装时刻，和 tmux/chromium/adb 同一类） |
| `start.sh --dev` | 会（源码档的安装+构建模式） |
| `bash start.sh` / systemd 的 `start.sh fg` | **不会**，只提醒 —— 「启动服务」不该顺手要 root |

授权逻辑抽成 `scripts/install/kvm-access.sh` 一份：`start.sh` 直接 source，`install.sh` 按「本地仓库 → 远端同源 raw（限时 20s）→ 只打印命令」三级取用。从前那份是抄进 `install.sh` 的完整副本 —— 按 AGENTS.md 开篇那句，抄两份必然走散。

五档都跑过：已就绪 / 没权限提不了权 / 没权限能提权（sudo 打桩）/ `ROAM_NO_KVM=1` / 机器上没有 `/dev/kvm`（一个字不说）。
