### PR TITLE
feat(mirror): 镜像能「在新页面打开」，Chrome 自己的界面页不再赖在标签条上

### DIFF
--- a/backend/browser/browser.go
+++ b/backend/browser/browser.go
@@ -10,6 +10,7 @@ package browser
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -351,8 +352,30 @@ func browserUA() string {
 	return strings.Replace(v.UserAgent, "HeadlessChrome", "Chrome", 1)
 }
 
-// listPages 返回所有 page 类型的标签页（过滤掉 service worker / iframe 等其它 target）。
-func listPages() []target {
+// isUserTab 判断一个 page target 是不是「用户的标签页」。
+//
+// Chrome 把自己那套界面也报成 type=page：地址栏下拉（chrome://omnibox-popup.top-chrome/）、
+// 标签搜索、各种侧边栏，都是 chrome://<something>.top-chrome/ 的 WebUI。它们混在 /json 里，
+// 于是标签条上多出一条关不掉的标签——/json/close 对浏览器界面无效，它还会随下一次输入再冒出来；
+// 更糟的是它常常排在首位，而首位标签的变化被前台跟随当成「用户切了标签」，镜像会跟着跳过去。
+// DevTools 前端（devtools://）同理：它是我们另开的调试窗口，不是被镜像的标签。
+func isUserTab(t target) bool {
+	u := strings.ToLower(t.URL)
+	if strings.HasPrefix(u, "devtools://") || strings.HasPrefix(u, "chrome-untrusted://") {
+		return false
+	}
+	if rest, ok := strings.CutPrefix(u, "chrome://"); ok {
+		host, _, _ := strings.Cut(rest, "/")
+		if strings.Contains(host, "top-chrome") { // chrome://settings 这类真页面照常留下
+			return false
+		}
+	}
+	return true
+}
+
+// rawTargets 是 /json 的原样结果：什么都不过滤。
+// 「这个 id 还在不在」必须问它——问 listPages 的话，被过滤掉的目标看起来永远是「已经关了」。
+func rawTargets() []target {
 	resp, err := cdpHTTP.Get(CDPBase + "/json")
 	if err != nil {
 		return nil
@@ -363,9 +386,16 @@ func listPages() []target {
 	if json.Unmarshal(b, &ts) != nil {
 		return nil
 	}
+	return ts
+}
+
+// listPages 返回所有 page 类型的标签页（过滤掉 service worker / iframe 等其它 target，
+// 以及 Chrome 自己的界面——见 isUserTab）。
+func listPages() []target {
+	ts := rawTargets()
 	pages := ts[:0]
 	for _, t := range ts {
-		if t.Type == "page" {
+		if t.Type == "page" && isUserTab(t) {
 			pages = append(pages, t)
 		}
 	}
@@ -419,14 +449,39 @@ func newTab(rawURL string) (string, error) {
 	return t.ID, nil
 }
 
-// closeTab 关闭指定标签页。
+// ErrNotClosable：Chrome 收下了关闭请求，但那一页还在。
+// 浏览器界面页就是这样（chrome://omnibox-popup.top-chrome/ 之类）：/json/close 照样回
+// "Target is closing"，列表里却一直在——它是浏览器窗口的一部分，不是标签，关不掉。
+// 实测：/json/close 回 "Target is closing"、CDP Target.closeTarget 回 {success:true}，
+// 两条路都是嘴上答应，那一页原封不动还在列表里。
+var ErrNotClosable = errors.New("这一页是 Chrome 的浏览器界面（不是标签页），Chrome 不允许关闭")
+
+// closeTab 关闭指定标签页，并确认它真的没了。
+//
+// 不能只看 /json/close 的回复：它对关不掉的目标也回 200 "Target is closing"，
+// 于是前端以为关成功，下一次 3 秒轮询那一行又回来了——用户看到的就是「这标签关不掉」。
 func closeTab(id string) error {
 	resp, err := cdpHTTP.Get(CDPBase + "/json/close/" + id)
 	if err != nil {
 		return err
 	}
 	resp.Body.Close()
-	return nil
+	for i := 0; i < 6; i++ { // 关闭是异步的，给它 ~900ms 消失
+		time.Sleep(150 * time.Millisecond)
+		if !targetExists(id) {
+			return nil
+		}
+	}
+	return ErrNotClosable
+}
+
+func targetExists(id string) bool {
+	for _, t := range rawTargets() {
+		if t.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // 最近被「前置」的标签追踪（用户在镜像面板点标签、或经 REST 激活）。watcher 据此广播

--- a/backend/browser/instance_test.go
+++ b/backend/browser/instance_test.go
@@ -26,3 +26,25 @@ func TestParseProfilePort(t *testing.T) {
 		t.Errorf("空 profile 不该匹配任何东西: got %d", got)
 	}
 }
+
+// 标签条上那条关不掉的「chrome://omnibox-popup.top-chrome/」：Chrome 自己的界面也报成 page。
+func TestIsUserTab(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://example.com/", true},
+		{"about:blank", true},
+		{"chrome://settings/", true}, // 真页面，用户开的就该看得见、关得掉
+		{"chrome://version/", true},
+		{"chrome://omnibox-popup.top-chrome/omnibox_popup_aim.html", false},
+		{"chrome://tab-search.top-chrome/tab_search.html", false},
+		{"devtools://devtools/bundled/devtools_app.html", false},
+		{"chrome-untrusted://feed/", false},
+	}
+	for _, c := range cases {
+		if got := isUserTab(target{URL: c.url}); got != c.want {
+			t.Errorf("isUserTab(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}

--- a/backend/browser/tabs.go
+++ b/backend/browser/tabs.go
@@ -6,6 +6,7 @@
 package browser
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -46,8 +47,15 @@ func NewTab(c *gin.Context) {
 }
 
 // CloseTab 关闭指定标签页。
+// 关不掉的（Chrome 自己的界面页）单独给一个 code，前端据此把这一行从标签条上抹掉——
+// 用户按了「关闭」就该看见它消失，哪怕 Chrome 那边根本不肯放手。
 func CloseTab(c *gin.Context) {
-	if err := closeTab(c.Param("id")); err != nil {
+	err := closeTab(c.Param("id"))
+	if errors.Is(err, ErrNotClosable) {
+		c.JSON(http.StatusConflict, gin.H{"error": gin.H{"code": "not_closable", "message": err.Error()}})
+		return
+	}
+	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": gin.H{"message": err.Error()}})
 		return
 	}

--- a/backend/browser/tabs_test.go
+++ b/backend/browser/tabs_test.go
@@ -1,0 +1,61 @@
+package browser
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// 假 Chrome：/json 列出 targets，/json/close 一律回 "Target is closing"（真 Chrome 对
+// 关不掉的浏览器界面页也是这么回的），关掉与否由 gone 决定。
+func fakeChrome(t *testing.T, id string, gone *atomic.Bool) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/json":
+			if gone.Load() {
+				fmt.Fprint(w, `[]`)
+				return
+			}
+			fmt.Fprintf(w, `[{"id":%q,"type":"page","url":"chrome://omnibox-popup.top-chrome/","webSocketDebuggerUrl":"ws://x"}]`, id)
+		default:
+			fmt.Fprint(w, "Target is closing")
+		}
+	}))
+	t.Cleanup(srv.Close)
+	old := CDPBase
+	CDPBase = srv.URL
+	t.Cleanup(func() { CDPBase = old })
+}
+
+func TestCloseTabReportsWhenTargetSurvives(t *testing.T) {
+	var gone atomic.Bool
+	fakeChrome(t, "abc", &gone)
+	if err := closeTab("abc"); !errors.Is(err, ErrNotClosable) {
+		t.Fatalf("关不掉的页应报 ErrNotClosable，得到 %v", err)
+	}
+}
+
+func TestCloseTabOKWhenTargetGone(t *testing.T) {
+	var gone atomic.Bool
+	gone.Store(true)
+	fakeChrome(t, "abc", &gone)
+	if err := closeTab("abc"); err != nil {
+		t.Fatalf("目标已消失应视为关闭成功，得到 %v", err)
+	}
+}
+
+// 关不掉的那一页也不该出现在标签条上——两道防线各测各的。
+func TestListPagesDropsBrowserUI(t *testing.T) {
+	var gone atomic.Bool
+	fakeChrome(t, "abc", &gone)
+	if pages := listPages(); len(pages) != 0 {
+		t.Fatalf("chrome://*.top-chrome/ 不该进标签列表，得到 %+v", pages)
+	}
+	if !targetExists("abc") {
+		t.Fatal("targetExists 必须问未过滤的原始列表，否则关闭确认永远以为已经关掉了")
+	}
+}

--- a/cli/chrome-cli/driver.mjs
+++ b/cli/chrome-cli/driver.mjs
@@ -97,6 +97,18 @@ const effectiveTimeoutMs = (verb, timeoutMs) => verb === 'record' ? Math.max(tim
 // 「前台标签跟随」（见 backend/browser/screencast.go 的 /json 顺序兜底）靠的正是标签被前置
 // 这件事本身，agent 操作到哪，面板就跟到哪。前置失败（标签刚好被关掉等）不影响后续真正的
 // 操作，吞掉即可。
+// Chrome 自己的界面也是一个 page：地址栏下拉 chrome://omnibox-popup.top-chrome/、
+// 标签搜索、侧边栏。它们混在 ctx.pages() 里，chrome tabs 会多列几行，更要命的是
+// pages[0] 可能就是其中一个——那 chrome goto/text 就操作到浏览器界面上去了。
+// 与后端 isUserTab（backend/browser/browser.go）同一条规矩。
+function userPages(pages) {
+  return pages.filter((p) => {
+    const u = (p.url() || '').toLowerCase()
+    if (u.startsWith('devtools://') || u.startsWith('chrome-untrusted://')) return false
+    return !(u.startsWith('chrome://') && u.slice('chrome://'.length).split('/')[0].includes('top-chrome'))
+  })
+}
+
 async function pick(pages, flags, fail) {
   const p = pickPage(pages, flags, fail)
   await p.bringToFront().catch(() => {})
@@ -162,7 +174,7 @@ async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
   const to = timeoutMs
   const settle = () => settleMs(flags)
   const ctx = browser.contexts()[0] || (await browser.newContext())
-  const pages = ctx.pages()
+  const pages = userPages(ctx.pages())
   const pickHere = () => pick(pages, flags, fail)
 
   switch (verb) {
@@ -243,7 +255,7 @@ async function executeVerb(browser, verb, flags, pos, timeoutMs, io) {
     }
     case 'pdf': { const f = pos[0] || 'page.pdf'; await (await pickHere()).pdf({ path: f }); io.log(f); break }
     case 'tabs': io.log(await Promise.all(pages.map(async (pg, i) => ({ i, title: await pg.title().catch(() => ''), url: pg.url() })))); break
-    case 'new': { const np = await ctx.newPage(); if (pos[0]) { await allowInsecureTLS(ctx, np); await np.goto(pos[0], { waitUntil: 'load', timeout: to }) } await np.bringToFront().catch(() => {}); io.log({ i: ctx.pages().indexOf(np), url: np.url() }); break }
+    case 'new': { const np = await ctx.newPage(); if (pos[0]) { await allowInsecureTLS(ctx, np); await np.goto(pos[0], { waitUntil: 'load', timeout: to }) } await np.bringToFront().catch(() => {}); io.log({ i: userPages(ctx.pages()).indexOf(np), url: np.url() }); break }
     case 'close': await (await pickHere()).close(); io.log('ok'); break
     default: fail('未知命令: ' + verb)
   }
@@ -313,7 +325,7 @@ class Recorder {
       if (this.active) fail('已经在录制：' + this.outPath + '（先 record stop）')
       const outPath = resolveRecordPath(pos[1], fail)
       const ctx = browser.contexts()[0] || (await browser.newContext())
-      const page = await pick(ctx.pages(), flags, fail)
+      const page = await pick(userPages(ctx.pages()), flags, fail)
       await this._start(ctx, page, outPath, fail)
       io.log({ recording: true, path: outPath })
       return

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ import Tasks from './components/tasks/Tasks'
 import TerminalPane from './components/terminal/TerminalPane'
 import SoloTerminal from './components/terminal/SoloTerminal'
 import { ICONS } from './components/nav-icons'
-import { normalizeRoute, setHashParams, readTermTokens } from './route-hash'
+import { normalizeRoute, setHashParams, readTermTokens, NO_TERMS } from './route-hash'
 import type { ClaudeInfo } from './components/terminal/claude-info'
 import { dropDeadTokens, loadTabs, saveTabs } from './components/terminal/term-tabs-store'
 import { CloudIcon, ExitFullscreenIcon, FullscreenIcon, LogoutIcon, MoonIcon, MoreIcon, SearchIcon, SunIcon } from './icons'
@@ -160,6 +160,9 @@ export default function App() {
   // URL 上待还原的 id/名字（还没拿到 id 映射前先原样存着）
   const urlTerms = useRef<string[]>(readTermTokens().terms)
   const urlActive = useRef<string>(readTermTokens().active)
+  // 「在新页面打开」开出来的页（terms=none）：这一页不继承任何会话，也不许拿空集回写——
+  // 回写就把主页面记着的那串标签抹了。用户在这页真开了会话之后，它就是普通页面。
+  const noTabs = useRef(readTermTokens().none)
   const restored = useRef(false) // 还原完成前不许回写 URL，否则会把待还原的参数抹掉
   const [overlay, setOverlay] = useState(false) // 手机/平板全屏终端
   const [moreOpen, setMoreOpen] = useState(false) // 手机「更多」sheet
@@ -368,7 +371,7 @@ export default function App() {
     restored.current = true
     const toName = (tok: string) => sessIds.byId[tok] || tok
     const fromUrl = urlTerms.current
-    const saved = fromUrl.length ? null : loadTabs(curNodeId)
+    const saved = fromUrl.length || noTabs.current ? null : loadTabs(curNodeId)
     if (saved && !urlActive.current) urlActive.current = saved.active
     // 查无此会话的 id 直接丢：切机器、会话在别处被关掉，都会在这里长出打不开的空标签
     const names = Array.from(new Set(dropDeadTokens(saved ? saved.terms : fromUrl, sessIds.byId).map(toName)))
@@ -385,6 +388,10 @@ export default function App() {
   // 终端状态同步到 URL，刷新后可恢复。写 id；还没有 id 的（刚建、列表未刷新）先退回写名字。
   useEffect(() => {
     if (!restored.current) return
+    if (noTabs.current) {
+      if (!terms.length) return   // 还是那页干净的镜像页：URL 保持 terms=none，本机记忆不动
+      noTabs.current = false      // 这页开了会话 → 回到普通页面的存续规则
+    }
     const toTok = (n: string) => sessIds?.byName[n] || n
     const toks = terms.map(toTok)
     const activeTok = active ? toTok(active) : ''
@@ -620,8 +627,9 @@ export default function App() {
     const back = loadTabs(id)
     setCurrentNode(id)
     setHashParams({
-      terms: back.terms.map(encodeURIComponent).join(','),
-      active: back.active ? encodeURIComponent(back.active) : '',
+      // 干净页（terms=none）换台机器还是干净页——那台的标签不该在这里长出来
+      terms: noTabs.current ? NO_TERMS : back.terms.map(encodeURIComponent).join(','),
+      active: noTabs.current || !back.active ? '' : encodeURIComponent(back.active),
     })
     location.reload()
   }

--- a/frontend/src/components/mirror/BrowserView.tsx
+++ b/frontend/src/components/mirror/BrowserView.tsx
@@ -11,7 +11,7 @@ import { useI18n } from '../../i18n'
 import { usePreferences, savePreferences } from '../../preferences'
 import { connect, type DuplexTransport } from '../../p2p/transport'
 import {
-  BotIcon, ChevronLeft, ChevronRight, CodeIcon, DeviceIcon, HomeIcon, OpenInIcon,
+  BotIcon, ChevronLeft, ChevronRight, CodeIcon, DeviceIcon, GlobeIcon, HomeIcon, OpenInIcon,
   PlusIcon, RefreshIcon, RotateScreenIcon, TabsIcon, UserIcon,
 } from '../../icons'
 import {
@@ -163,11 +163,17 @@ export default function BrowserView() {
     api('GET', '/me').then((r) => { if (r?.data?.browserHome) setHome(r.data.browserHome) }).catch(() => {})
   }, [])
 
+  // Chrome 有些「页」压根关不掉——它自己的界面（chrome://*.top-chrome/）就是这样：
+  // /json/close 照收不误，那一行下一次轮询又回来。后端已经把认得出来的挡在外面，
+  // 万一还是漏进来一条，用户按下关闭时就记在这里：关不掉，至少让它从这条标签条上消失。
+  const dismissedRef = useRef<Set<string>>(new Set())
+  const visibleTabs = (list: TabInfo[]) => list.filter((x) => !dismissedRef.current.has(x.id))
+
   // 拉取标签页列表（每 3s 刷新，反映 agent 自己开的标签页/标题变化）
   const loadTabs = async () => {
     try {
       const r = await api('GET', '/browser/tabs')
-      const list: TabInfo[] = r?.data || []
+      const list: TabInfo[] = visibleTabs(r?.data || [])
       setTabs((prev) => mergeTabs(prev, list)) // 稳定顺序，避免后端重排导致 tab 乱跳
       // 当前 target 已不存在 → 切到第一个
       setTarget((t) => (list.some((x) => x.id === t) ? t : (list[0]?.id || '')))
@@ -184,15 +190,24 @@ export default function BrowserView() {
       const known = new Set(tabs.map((t) => t.id)) // 记下创建前的 id，用于定位新开的那个
       await api('POST', '/browser/tabs', { url: home }) // 新标签默认开导航起始页
       const r = await api('GET', '/browser/tabs')
-      const list: TabInfo[] = r?.data || []
+      const list: TabInfo[] = visibleTabs(r?.data || [])
       setTabs((prev) => mergeTabs(prev, list))
       const fresh = list.find((t) => !known.has(t.id)) // 真正新增的(在右侧)，而非后端顺序的末位
       setTarget(fresh?.id || list[list.length - 1]?.id || '')
     } catch (e: any) { message.error(e.message) }
   }
   const closeTab = async (id: string) => {
-    try { await api('DELETE', `/browser/tabs/${id}`); await loadTabs() }
-    catch (e: any) { message.error(e.message) }
+    try {
+      await api('DELETE', `/browser/tabs/${id}`)
+    } catch (e: any) {
+      // not_closable = Chrome 收下了关闭请求但那一页还在（后端确认过，见 ErrNotClosable）
+      if (e?.apiError?.code !== 'not_closable') { message.error(e.message); return }
+      dismissedRef.current.add(id)
+      setTabs((prev) => prev.filter((x) => x.id !== id))
+      setTarget((cur) => (cur === id ? '' : cur))
+      message.info(t('browser.tabHidden'))
+    }
+    await loadTabs()
   }
 
   // 地址栏跟随当前标签页真实 URL（聚焦编辑时不覆盖；about:blank 显示为空）
@@ -227,7 +242,7 @@ export default function BrowserView() {
     for (let i = 0; i < 8; i++) {
       try {
         const r = await api('GET', '/browser/tabs')
-        const list: TabInfo[] = r?.data || []
+        const list: TabInfo[] = visibleTabs(r?.data || [])
         const fresh = list.find((t) => !known.has(t.id))
         if (fresh) {
           setTabs((prev) => mergeTabs(prev, list))
@@ -335,7 +350,7 @@ export default function BrowserView() {
       // 后端广播的当前前台标签（agent 经 chrome-cli 操作、或别处经 REST 前置）：
       // 未暂停跟随时自动切过去；顺手拿它带的标签列表刷新标题/地址，比 3s 轮询更及时。
       if (msg.type === 'active') {
-        if (Array.isArray(msg.tabs)) setTabs((prev) => mergeTabs(prev, msg.tabs))
+        if (Array.isArray(msg.tabs)) setTabs((prev) => mergeTabs(prev, visibleTabs(msg.tabs)))
         if (!followPausedRef.current && msg.id && msg.id !== target) setTarget(msg.id)
         return
       }
@@ -623,7 +638,10 @@ export default function BrowserView() {
     ] : []),
     { key: 'rotate', icon: <RotateScreenIcon />, label: rotation ? `${t('browser.rotateTitle')} ${rotation}°` : t('browser.rotateTitle'), onClick: rotate },
     { key: 'devtools', icon: <CodeIcon />, label: t('browser.devtoolsTitle'), onClick: openDevtools },
-    { key: 'external', icon: <OpenInIcon size={15} />, label: t('browser.openExternalTitle'), onClick: openExternal },
+    { key: 'external', icon: <GlobeIcon size={15} />, label: t('browser.openExternalTitle'), onClick: openExternal },
+    // terms=none：新开的这页只有镜像，不把当前开着的会话标签一并拽过去（见 route-hash）
+    { key: 'newpage', icon: <OpenInIcon size={15} />, label: t('mirror.openInNewPage'),
+      onClick: () => window.open('/#/browser?terms=none', '_blank') },
     { type: 'divider' as const, key: 'd2' },
     { key: 'newtab', icon: <PlusIcon />, label: t('browser.newTab'), onClick: newTab },
   ]

--- a/frontend/src/components/mirror/PhoneView.tsx
+++ b/frontend/src/components/mirror/PhoneView.tsx
@@ -10,7 +10,7 @@ import { api } from '../../api'
 import { useI18n } from '../../i18n'
 import { connect, type DuplexTransport } from '../../p2p/transport'
 import { devKindText, devStateText, listPhoneDevices, selectPhoneDevice, type PhoneDevice } from '../../phone-devices'
-import { AppsIcon, ChevronDown, DeviceIcon, PhoneAssistIcon, PhoneBackIcon, PhoneHomeIcon, PhoneRecentsIcon, PowerIcon, RefreshIcon, SearchIcon } from '../../icons'
+import { AppsIcon, ChevronDown, DeviceIcon, OpenInIcon, PhoneAssistIcon, PhoneBackIcon, PhoneHomeIcon, PhoneRecentsIcon, PowerIcon, RefreshIcon, SearchIcon } from '../../icons'
 import { fmtRate, IconBtn, MirrorChrome, MirrorMenu, Omnibox, StreamControl, useShelf, type Quality } from './mirror'
 
 interface PhoneApp { id: string; name?: string }
@@ -229,6 +229,9 @@ export default function PhoneView() {
       { key: 'lock', icon: <PowerIcon size={14} />, label: t('phone.lock'), onClick: () => pressKey('lock') },
     ]),
     { key: 'reconnect', icon: <RefreshIcon size={14} />, label: t('phone.reconnect'), onClick: () => setReconnectKey((n) => n + 1) },
+    // terms=none：新开的这页只有镜像，不继承当前的会话标签（见 route-hash）
+    { key: 'newpage', icon: <OpenInIcon size={14} />, label: t('mirror.openInNewPage'),
+      onClick: () => window.open('/#/phone?terms=none', '_blank') },
   ]
 
   // 设备身份：名字 + 它是什么（本机模拟器/真机/远程），点开换一台。

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -816,6 +816,7 @@ const enUS = {
   'browser.subtitle': 'Live mirror of the backend Chrome — take over input, switch tabs, emulate mobile devices',
   'browser.tabs': 'Tabs',
   'browser.newTab': 'New tab',
+  'browser.tabHidden': "Chrome won't close this page (it's browser UI, not a tab) — removed it from the tab strip",
   'browser.quality.auto': 'Auto',
   'browser.quality.standard': 'SD',
   'browser.quality.high': 'HD',
@@ -970,6 +971,8 @@ const enUS = {
   'phone.save': 'Save & connect',
   'phone.test': 'Test connection',
   'phone.saved': 'Saved',
+  // 镜像页共用（浏览器 / 手机）
+  'mirror.openInNewPage': 'Open in new page',
   'overview.welcome': 'Welcome back 👋',
   'overview.subtitle': 'Drive your machine and its AI agents — anywhere, anytime',
   'overview.enterSessions': 'Open sessions',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -818,6 +818,7 @@ const zhCN = {
   'browser.subtitle': '把后端那台 Chrome 的画面实时镜像到这里：可接管键鼠、切标签、模拟移动设备',
   'browser.tabs': '标签页',
   'browser.newTab': '新建标签',
+  'browser.tabHidden': 'Chrome 不允许关闭这一页（它是浏览器界面，不是标签页），已从标签条移除',
   'browser.quality.auto': '自动',
   'browser.quality.standard': '标清',
   'browser.quality.high': '高清',
@@ -972,6 +973,8 @@ const zhCN = {
   'phone.save': '保存并连接',
   'phone.test': '测试连接',
   'phone.saved': '已保存',
+  // 镜像页共用（浏览器 / 手机）
+  'mirror.openInNewPage': '在新页面打开',
   'overview.welcome': '欢迎回来 👋',
   'overview.subtitle': '随时随地，遥控你的电脑和 AI 干活',
   'overview.enterSessions': '进入会话',

--- a/frontend/src/route-hash.test.ts
+++ b/frontend/src/route-hash.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readTermTokens } from './route-hash'
+
+const at = (hash: string) => { location.hash = hash }
+
+describe('readTermTokens：terms 的三态', () => {
+  beforeEach(() => at('#/projects'))
+
+  it('没写 terms = 这条链接对标签没意见（交给本机记忆）', () => {
+    expect(readTermTokens()).toEqual({ terms: [], active: '', none: false })
+  })
+  it('terms=none = 明说这页不要标签', () => {
+    at('#/browser?terms=none')
+    expect(readTermTokens()).toEqual({ terms: [], active: '', none: true })
+  })
+  it('有值就还原那几个，none 不再成立', () => {
+    at('#/projects?terms=a,b&active=b')
+    expect(readTermTokens()).toEqual({ terms: ['a', 'b'], active: 'b', none: false })
+  })
+})

--- a/frontend/src/route-hash.ts
+++ b/frontend/src/route-hash.ts
@@ -27,14 +27,22 @@ export function setHashParams(params: Record<string, string>) {
   if (h !== next) history.replaceState(history.state, '', next)
 }
 
+export const NO_TERMS = 'none'
+
 // URL 上的终端标签参数（terms=打开的标签、active=当前标签）。
 // 现在写进去的是会话 id；老链接里存的是会话名，两者都能读——还原时按 id 表判别（见 resolveToken）。
-export function readTermTokens(): { terms: string[]; active: string } {
+//
+// terms 有三态，别把后两个当成一回事：**没写** = 这条链接对标签没意见，回落到本机记的那份；
+// **terms=none** = 明说「这页不要标签」（「在新页面打开」开出来的镜像页就带这个）；
+// 有值 = 就开这几个。少了 none 这一态，新开的页会把上一次的会话全部拽过来。
+export function readTermTokens(): { terms: string[]; active: string; none: boolean } {
   const p = getHashParams()
   const t = p.get('terms')
   const a = p.get('active')
   return {
-    terms: t ? t.split(',').map(decodeURIComponent).filter(Boolean) : [],
+    terms: t && t !== NO_TERMS ? t.split(',').map(decodeURIComponent).filter(Boolean) : [],
     active: a ? decodeURIComponent(a) : '',
+    none: t === NO_TERMS,
   }
 }
+


### PR DESCRIPTION
## 一、镜像能「在新页面打开」

浏览器/手机镜像的 ⋯ 菜单各加一条「在新页面打开」。开出来是**同一个壳子换瓤**——左边栏、上边栏、下边栏照旧，只是里面那块换成镜像，不是另做一张没有导航的独立页。

新页 URL 带 `terms=none`，这一页不继承当前开着的会话标签。`terms` 因此有了三态：

| 值 | 含义 |
| --- | --- |
| 没写 | 这条链接对标签没意见 → 回落到本机记的那份（书签打开裸域名照旧还原） |
| `none` | 明说「这页不要标签」 |
| 有值 | 就开这几个 |

空集不许回写：否则这页一开，主窗口记着的那串标签就被抹了（`term-tabs-store` 里那条注释警告的正是这件事）。用户真在这页开了会话，它就退回普通页面的存续规则。切机器也保持干净。

顺带：浏览器 ⋯ 菜单里「在系统浏览器打开」原本和终端「新标签」共用同一枚 `OpenInIcon`，同一个菜单里两行一模一样的箭头分不清，改成 `GlobeIcon`（它唤起的是宿主机的浏览器）。

## 二、那条关不掉的 `chrome://omnibox-popup.top-chrome/`

Chrome 把自己的界面也报成 `type: "page"`：地址栏下拉、标签搜索、侧边栏。它们混进 `/json`，于是标签条上多出关不掉的一行。实测这台 Chrome：

```
GET /json/close/<id>    → "Target is closing"    …3s 后：还在
Target.closeTarget      → {"success":true}       …1.5s 后：还在
```

两条路都是嘴上答应。前端以为关掉了，3 秒轮询那一行又回来——用户看到的就是「关不掉」。

三道处理：

1. `isUserTab`：浏览器界面页 / DevTools 前端不算标签。顺带治了另一个毛病——`screencast.go` 拿列表首位当「用户切了标签」，而这些 target 常排在最前，镜像会自己跳过去。
2. `closeTab`：不信 Chrome 的回复，关完去**未过滤的**原始列表确认它真没了（~900ms），没消失就返回 `ErrNotClosable` → `409 not_closable`。
3. 前端收到这个 code，就把这一行从标签条抹掉并记进 dismissed 集（列表的四条来源都过滤）。Chrome 不放手，至少不再碍眼。

`chrome` CLI 走同一份 `ctx.pages()`，同样过滤。那边其实更要命：`pick()` 默认取 `pages[0]`，浏览器界面排在前面就会把 `goto`/`text` 打到它身上。

## 验证

- `backend/browser/tabs_test.go`：假 Chrome 回 "Target is closing" 但目标不消失 → 断言 `ErrNotClosable`；另测成功路径，以及 `targetExists` 必须问原始列表（问过滤后的会永远以为已经关掉）。
- `frontend/src/route-hash.test.ts`：`terms` 三态。
- 机器上实测：重启后端后 `chrome tabs` 从「about:blank + 两条 omnibox-popup」变成只剩 `about:blank`。
- `scripts/dev/quality/check.sh full` 通过；前端 404 项测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW