### PR TITLE
fix(browser): 远端浏览器钉成固定视口 —— 拖窗格只改缩放，不再让页面重排

### DIFF
--- a/frontend/src/components/mirror/BrowserView.tsx
+++ b/frontend/src/components/mirror/BrowserView.tsx
@@ -108,7 +108,11 @@ export default function BrowserView() {
   // 画面旋转：0/90/180/270，持久化。手机竖屏看横屏浏览器时转 90°
   const [rotation, setRotation] = useState<number>(() => Number(prefs.browserRotate || localStorage.getItem(RKEY)) || 0)
   const [stage, setStage] = useState({ w: 0, h: 0 }) // 舞台尺寸，旋转时需据此对调 <img> 盒子宽高
-  const [vp, setVp] = useState({ w: 1280, h: 800 })  // 当前生效的渲染视口(mw×mh)：显示盒的高按它的比×舞台宽算出，与舞台高解耦
+  const [frame, setFrame] = useState({ w: 0, h: 0 }) // 远端画面尺寸（帧自带），只用于告诉用户「现在传的是多大一张图」
+  // 桌面档的固定视口：设置页「浏览器 · 窗口大小」那一格。远端就按这个尺寸渲染，
+  // 与观看区多宽无关。默认 1920×1080。
+  const [deskVp, setDeskVp] = useState({ w: 1920, h: 1080 })
+  const deskVpRef = useRef(deskVp)
   // 实时指标
   const [latency, setLatency] = useState<number | null>(null)
   const [bw, setBw] = useState(0)   // 字节/秒
@@ -161,6 +165,18 @@ export default function BrowserView() {
   // 取导航起始页地址（后端按 TTMUX_HOME_BIND 算出）
   useEffect(() => {
     api('GET', '/me').then((r) => { if (r?.data?.browserHome) setHome(r.data.browserHome) }).catch(() => {})
+  }, [])
+
+  // 桌面视口取自 Chrome 启动配置的「窗口大小」("1920,1080")：设置页改了那一格，这里跟着变。
+  useEffect(() => {
+    api('GET', '/browser/config').then((r) => {
+      const m = /^\s*(\d{3,5})\s*[,x×]\s*(\d{3,5})\s*$/.exec(r?.data?.windowSize || '')
+      if (!m) return
+      const vp = { w: Number(m[1]), h: Number(m[2]) }
+      deskVpRef.current = vp
+      setDeskVp(vp)
+      if (!deviceRef.current) sendEmulate() // 桌面档才需要现场改视口
+    }).catch(() => {})
   }, [])
 
   // Chrome 有些「页」压根关不掉——它自己的界面（chrome://*.top-chrome/）就是这样：
@@ -271,26 +287,23 @@ export default function BrowserView() {
     catch (e: any) { message.error(e.message) }
   }
 
-  // 桌面视口按 ≥2x 采样出图（哪怕显示器是 1x），JPEG 压缩本身会糊字，超采样后再压缩，
-  // 文字边缘留下的细节更多，肉眼看起来清晰得多；观看端本来就用 object-fit 缩放显示，
-  // 采样倍数与显示器实际 dpr 无需一致。
-  const desktopDpr = () => Math.max(window.devicePixelRatio || 1, 2)
-
-  // 当前设备 → emulate 消息载荷。桌面把远端渲染成「和观看区同比、但宽≥1280 的桌面视口」，整帧
-  // 铺满组件。视口只在观看区【宽】变化时重算(见 emulate effect)；高度抖动(移动端工具栏/滚动)不重算，
-  // 显示盒的高也只按【宽】算(见 <img>) → 铺满且高度抖动时内容缩放比恒定、不忽大忽小。
+  // 当前设备 → emulate 消息载荷。
+  //
+  // 桌面档是【固定视口】(设置页「浏览器 · 窗口大小」，默认 1920×1080)，与观看区多大无关。
+  // 从前这里按观看区宽高比算视口下发，于是拖动分隔条 = 给远端换分辨率：页面当场重排，
+  // 响应式站点的栏数、折行、菜单收纳全跟着变——想看的是同一个页面，看到的却是另一个版式。
+  // 现在拖动只改本地怎么把这一帧塞进观看区（object-fit: contain，装不满的那一维留黑边）。
+  //
+  // 为什么不干脆不覆盖、用 Chrome 窗口自己的尺寸？实测这台无头 Chrome 的原生视口是
+  // 1280×1775（竖的）——--force-device-scale-factor=2 叠上 --start-fullscreen 与 ozone
+  // 的屏幕尺寸覆盖，一台「全屏浏览器」就长成了竖屏。所以显式钉一个横屏尺寸。
+  // dpr 用 1：传输分辨率由画质档的 maxWidth/maxHeight 管（见后端 ladder），1920 的画面
+  // 落到窄窗格里本身就是超采样，不必再让远端多渲一倍像素。
   const emulatePayload = () => {
     const dev = DEVICES.find((d) => d.key === deviceRef.current)
     if (dev) return { type: 'emulate', mobile: true, mw: dev.w, mh: dev.h, dpr: dev.dpr, ua: dev.ua }
-    const el = stageRef.current
-    const pw = el ? el.clientWidth : 0
-    const ph = el ? el.clientHeight : 0
-    if (pw <= 0 || ph <= 0) return { type: 'emulate', mobile: false, mw: 0, mh: 0, dpr: desktopDpr() }
-    // 宽 = max(观看区宽, 桌面下限 1280)：窄窗格(iPad 分屏/手机)也按桌面宽出图、不掉手机版；宽屏用原生宽。
-    // 高 = 宽 × 观看区当前宽高比 → 视口与观看区同比、铺满不留白。
-    const mw = Math.max(Math.round(pw), 1280)
-    const mh = Math.max(1, Math.round((mw * ph) / pw))
-    return { type: 'emulate', mobile: false, mw, mh, dpr: desktopDpr() }
+    const { w, h } = deskVpRef.current
+    return { type: 'emulate', mobile: false, mw: w, mh: h, dpr: 1 }
   }
 
   // 发 emulate 但【去重】：载荷和上次一样就不发。重设 device metrics 会让后端产一个「视口尚未稳」
@@ -302,7 +315,6 @@ export default function BrowserView() {
     const key = JSON.stringify(p)
     if (!newSession && key === lastEmuRef.current) return
     lastEmuRef.current = key
-    if (p.mw && p.mh) setVp({ w: p.mw, h: p.mh }) // 记生效视口 → 显示盒高按它算，与舞台高解耦
     send(p)
   }
 
@@ -333,6 +345,8 @@ export default function BrowserView() {
         const dv = new DataView(buf)
         const w = dv.getUint16(0, true), h = dv.getUint16(2, true), seq = dv.getUint16(4, true)
         sizeRef.current = { w: w || 1280, h: h || 800 }
+        // 尺寸变了才 setState（每帧都设会把整棵树重渲染成一秒几十次）
+        setFrame((f) => (f.w === sizeRef.current.w && f.h === sizeRef.current.h ? f : { ...sizeRef.current }))
         bytesRef.current += buf.byteLength
         framesRef.current++
         if (objURL) URL.revokeObjectURL(objURL)
@@ -384,14 +398,9 @@ export default function BrowserView() {
     }
   }, [control, target]) // 画质/device 切换都不重连，靠 quality / emulate 消息现场切换
 
-  // 设备切换 / 观看区尺寸变化：在现有连接上发 emulate（同一 CDP 会话 set/clear），不重连。
-  // 防抖 300ms 合并连续抖动（移动端工具栏显隐/顶栏换行会让 stage 尺寸高频抖动），settle 后经
-  // sendEmulate 去重：净值没变就完全不发 → 不重设视口 → 不跳。桌面仍随窗口大小自适应。
-  useEffect(() => {
-    clearTimeout(emuTimerRef.current)
-    emuTimerRef.current = setTimeout(() => sendEmulate(), 300)
-    return () => clearTimeout(emuTimerRef.current)
-  }, [device, stage.w]) // 只在观看区【宽】变时重设视口；高度抖动(移动端工具栏显隐)不重设 → 不跳
+  // 设备切换：在现有连接上发 emulate（同一 CDP 会话 set/clear），不重连。
+  // 观看区尺寸【不在依赖里】——远端视口不跟着窗格走，拖分隔条不该动远端一根汗毛。
+  useEffect(() => { sendEmulate() }, [device])
 
   const navigate = () => {
     if (!url) return
@@ -656,6 +665,7 @@ export default function BrowserView() {
       quality={quality} onQuality={changeQuality}
       level={quality === 'auto' ? levelName : undefined}
       latency={latency} bytesPerSec={bw} fps={fps}
+      size={frame.w ? `${frame.w}×${frame.h}` : undefined}
       variant="badge" showLabel={shelf !== 'narrow'} />
   )
 
@@ -663,7 +673,8 @@ export default function BrowserView() {
     <Dropdown trigger={['click']} placement="bottomRight" menu={{
       selectedKeys: [device],
       items: [
-        { key: '', label: t('browser.device.desktop'), onClick: () => changeDevice('') },
+        { key: '', onClick: () => changeDevice(''),
+          label: <span>{t('browser.device.desktop')}<span style={{ color: 'var(--text-dimmer)' }}>{` · ${deskVp.w}×${deskVp.h}`}</span></span> },
         ...DEVICES.map((d) => ({ key: d.key, label: t(d.nameKey), onClick: () => changeDevice(d.key) })),
       ],
     }}>
@@ -748,12 +759,11 @@ export default function BrowserView() {
           onMouseUp={onMouse('up')}
           onMouseMove={onMove}
           style={{
-            // 绝对居中 + 旋转。关键：显示盒的【高】= 舞台宽 × 视口比(vp.h/vp.w)，只跟舞台【宽】走、
-            // 与舞台【高】无关 → 移动端工具栏显隐令观看区高度抖动时，画面缩放比恒定、不忽大忽小；
-            // 高度富余则上下留边、不足则被 overflow:hidden 裁切，都不缩放。旋转(90/270)维持原逻辑。
+            // 显示盒 = 整个舞台（旋转 90/270 时宽高对调），画面按 object-fit: contain 等比塞进去：
+            // 装不满的那一维留黑边。远端视口是固定的，所以拖窗格只改这一步的缩放比，画面内容不动。
             position: 'absolute', left: '50%', top: '50%',
             width: rotated ? stage.h : stage.w,
-            height: rotated ? stage.w : Math.round((stage.w * vp.h) / vp.w),
+            height: rotated ? stage.w : stage.h,
             objectFit: 'contain',
             transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
           }}

--- a/frontend/src/components/mirror/BrowserView.tsx
+++ b/frontend/src/components/mirror/BrowserView.tsx
@@ -4,18 +4,18 @@
 //   发 {type:'nav', url} | {type:'ping', t} | {type:'mouse'|'wheel'|'key', ...}（输入仅 control=1 生效）
 import { useEffect, useRef, useState } from 'react'
 import { nodeWs, nodeWsHostPath } from '../cluster/node-url'
-import { Dropdown, App as AntApp } from 'antd'
+import { ConfigProvider, Dropdown, App as AntApp } from 'antd'
 import type { MenuProps } from 'antd'
 import { api } from '../../api'
 import { useI18n } from '../../i18n'
 import { usePreferences, savePreferences } from '../../preferences'
 import { connect, type DuplexTransport } from '../../p2p/transport'
 import {
-  BotIcon, ChevronLeft, ChevronRight, CodeIcon, DeviceIcon, GlobeIcon, HomeIcon, OpenInIcon,
-  PlusIcon, RefreshIcon, RotateScreenIcon, TabsIcon, UserIcon,
+  BotIcon, ChevronLeft, ChevronRight, CodeIcon, DeviceIcon, ExitFullscreenIcon, FullscreenIcon,
+  GlobeIcon, HomeIcon, OpenInIcon, PlusIcon, RefreshIcon, RotateScreenIcon, TabsIcon, UserIcon,
 } from '../../icons'
 import {
-  fmtRate, IconBtn, MirrorChrome, MirrorMenu, Omnibox, StatusChip, StreamControl, useShelf, type Quality,
+  fmtRate, IconBtn, MirrorChrome, MirrorMenu, Omnibox, StatusChip, StreamControl, useFullscreen, useShelf, type Quality,
 } from './mirror'
 import { TabSheet, TabStrip, type TabInfo } from './browser-tabs'
 
@@ -78,6 +78,7 @@ export default function BrowserView() {
   const [prefs] = usePreferences()
   const imgRef = useRef<HTMLImageElement>(null)
   const stageRef = useRef<HTMLDivElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   // 镜像收发底层：p2p 时是 media PC 上的不可靠 DataChannel，回退时是 /api/browser/stream 的 WS。
   // 二进制帧解析/ack/ping/自适应逻辑不感知底层（DuplexTransport ≈ WebSocket）。
   const tpRef = useRef<DuplexTransport | null>(null)
@@ -141,6 +142,8 @@ export default function BrowserView() {
   // 模式要长期保持，不能自己漂移回去（人正盯着一个 agent 没打算离开的页面时尤其如此）。
   const [followPaused, setFollowPaused] = useState(false)
   const followPausedRef = useRef(false)
+
+  const fs = useFullscreen(rootRef)
 
   // control 开关用 ref 同步，供事件回调读取最新值
   useEffect(() => { controlRef.current = control }, [control])
@@ -447,7 +450,9 @@ export default function BrowserView() {
     const boxH = img?.clientHeight || (rotated ? r.width : r.height)
     const scale = Math.min(boxW / nw, boxH / nh) // contain 缩放比
     const dispW = nw * scale, dispH = nh * scale // 画面实际显示尺寸
-    const padX = (boxW - dispW) / 2, padY = (boxH - dispH) / 2 // 黑边
+    // 黑边：横向居中（左右各一半），纵向贴上沿（全在下面）——必须跟 <img> 的 object-position 一致，
+    // 否则点击落点会整体偏上/偏下半条黑边。
+    const padX = (boxW - dispW) / 2, padY = 0
     // 屏幕点 → 舞台中心相对
     const dx = clientX - (r.left + r.width / 2)
     const dy = clientY - (r.top + r.height / 2)
@@ -640,6 +645,12 @@ export default function BrowserView() {
   // ⋯ 菜单：低频动作一律进这里，主行永远只有四个目标（设计 17 §3）。
   // 窄档下把「前进 / 主页」也收进来——它们是次高频，后退才是必须留在外面的那一枚。
   const menuItems: MenuProps['items'] = [
+    // 全屏摆在最前：远端视口固定之后，「黑边多厚」只取决于观看区多大，铺满显示器就是把黑边挤没
+    ...(fs.supported ? [
+      { key: 'fs', icon: fs.on ? <ExitFullscreenIcon size={15} /> : <FullscreenIcon size={15} />,
+        label: fs.on ? t('common.exitFullscreen') : t('common.fullscreen'), onClick: fs.toggle },
+      { type: 'divider' as const, key: 'd0' },
+    ] : []),
     ...(shelf === 'narrow' ? [
       { key: 'forward', icon: <ChevronRight />, label: t('file.forward'), onClick: () => act('forward') },
       { key: 'home', icon: <HomeIcon size={15} />, label: t('browser.home'), onClick: () => act('navigate', { url: home }) },
@@ -683,135 +694,146 @@ export default function BrowserView() {
   )
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {/* 页头（设计 17）：桌面＝标签条 + 工具行；窄档＝一条主行 + 状态芯片条。
-          从前是五行散装控件——「前往」实心按钮比地址栏还抢戏、四档清晰度常驻一整行、
-          「外部打开」被挤成第五行的孤儿。现在只有一个主角：omnibox。 */}
-      {shelf !== 'narrow' && (
-        <TabStrip tabs={tabs} active={target} onSelect={switchTab} onClose={closeTab} onAdd={newTab}
-          extra={<StatusChip icon={followPaused ? <UserIcon size={12} /> : <BotIcon size={12} />}
-            strong={followPaused ? t('browser.followModeHuman') : t('browser.followModeAgent')}
-            active={!followPaused} onClick={() => (followPaused ? resumeFollow() : pauseFollow())} />} />
-      )}
-      <MirrorChrome
-        chromeRef={shelfRef}
-        main={<>
-          <IconBtn icon={<ChevronLeft size={17} />} label={t('file.back')} onClick={() => act('back')} />
-          {shelf !== 'narrow' && <>
-            <IconBtn icon={<ChevronRight size={17} />} label={t('file.forward')} onClick={() => act('forward')} />
-            <IconBtn icon={<RefreshIcon size={16} />} label={t('common.refresh')} onClick={() => act('reload')} />
-            <IconBtn icon={<HomeIcon size={16} />} label={t('browser.home')} onClick={() => act('navigate', { url: home })} />
-          </>}
-          <Omnibox
-            value={url}
-            onChange={setUrl}
-            onSubmit={navigate}
-            onFocusChange={(f) => { addrFocused.current = f }}
-            placeholder={t('browser.urlPlaceholder')}
-            goLabel={t('browser.go')}
-            lead={streamBadge}
-            trailing={shelf === 'narrow'
-              ? <IconBtn icon={<RefreshIcon size={15} />} label={t('common.refresh')} onClick={() => act('reload')} />
-              : shelf === 'wide'
-                ? <span className="mc-omni-num">{`${latency == null ? '—' : latency + 'ms'} · ${fmtRate(bw)} · ${fps}fps`}</span>
-                : undefined}
-          />
-          {shelf === 'narrow' && (
-            <IconBtn icon={<TabsIcon />} label={t('browser.tabs')} badge={tabs.length} onClick={() => setTabsOpen(true)} />
-          )}
-          {shelf !== 'narrow' && deviceChip}
-          <MirrorMenu items={menuItems} label={t('common.more')} />
-        </>}
-        chips={shelf === 'narrow' ? <>
-          <StatusChip icon={followPaused ? <UserIcon size={12} /> : <BotIcon size={12} />}
-            strong={followPaused ? t('browser.followModeHuman') : t('browser.followModeAgent')}
-            active={!followPaused} onClick={() => (followPaused ? resumeFollow() : pauseFollow())} />
-          {deviceChip}
-        </> : undefined}
-      />
-      {/* 手机标签：横条在 360 上放不下第三枚，换成「⧉N + 抽屉」（设计 17 §4） */}
-      <TabSheet open={tabsOpen} tabs={tabs} active={target} onClose={() => setTabsOpen(false)}
-        onSelect={(id) => { switchTab(id); setTabsOpen(false) }}
-        onCloseTab={closeTab} onAdd={() => { newTab(); setTabsOpen(false) }} />
-      <style>{`
-        .bv-ripple{position:absolute;width:14px;height:14px;margin:-7px 0 0 -7px;border-radius:50%;
-          border:2px solid var(--accent);pointer-events:none;animation:bvRip .45s ease-out forwards;}
-        @keyframes bvRip{from{transform:scale(.3);opacity:.9}to{transform:scale(2.6);opacity:0}}
-      `}</style>
-      <div
-        ref={stageRef}
-        tabIndex={0}
-        onKeyDown={onKey}
-        onWheel={onWheel}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-        style={{
-          flex: 1, minHeight: 0, background: '#000', overflow: 'hidden', position: 'relative',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          cursor: control ? 'default' : 'not-allowed', outline: 'none', touchAction: 'none',
-        }}
-      >
-        <img
-          ref={imgRef}
-          draggable={false}
-          onMouseDown={onMouse('down')}
-          onMouseUp={onMouse('up')}
-          onMouseMove={onMove}
-          style={{
-            // 显示盒 = 整个舞台（旋转 90/270 时宽高对调），画面按 object-fit: contain 等比塞进去：
-            // 装不满的那一维留黑边。远端视口是固定的，所以拖窗格只改这一步的缩放比，画面内容不动。
-            position: 'absolute', left: '50%', top: '50%',
-            width: rotated ? stage.h : stage.w,
-            height: rotated ? stage.w : stage.h,
-            objectFit: 'contain',
-            transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
-          }}
-        />
-        <textarea
-          ref={imeRef}
-          aria-label={t('browser.imeProxyLabel')}
-          tabIndex={-1}
-          autoCapitalize="off"
-          autoCorrect="off"
-          spellCheck={false}
-          onCompositionStart={() => { composingRef.current = true }}
-          onCompositionEnd={() => { composingRef.current = false; flushIme() }}
-          onInput={() => {
-            // 组合中的中间态（isComposing 的 input 事件）不发；只有非组合插入
-            //（如 macOS 长按选音标）才在这里落地。
-            if (!composingRef.current) flushIme()
-          }}
-          onBlur={() => {
-            // 失焦时丢弃半截组合，避免残留拼音在下次聚焦时被误发到远端。
-            composingRef.current = false
-            if (imeRef.current) imeRef.current.value = ''
-          }}
-          style={{
-            position: 'absolute', left: imePos.x, top: imePos.y, width: 2, height: 2,
-            opacity: 0, padding: 0, border: 'none', outline: 'none', resize: 'none',
-            overflow: 'hidden', background: 'transparent', caretColor: 'transparent',
-            pointerEvents: 'none',
-          }}
-        />
-        {ripples.map((p) => (
-          <span key={p.id} className="bv-ripple" style={{ left: p.x, top: p.y }} />
-        ))}
-        {/* 连不上且后端报了原因：覆盖一层提示，省得用户对着黑屏猜 */}
-        {!connected && healthMsg && (
-          <div style={{
-            position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
-            padding: 24, pointerEvents: 'none',
-          }}>
-            <div style={{
-              maxWidth: 520, padding: 'var(--sp-3) var(--sp-4)', borderRadius: 'var(--r-sm)', background: 'rgba(0,0,0,.72)',
-              border: '1px solid var(--danger-border)', color: 'var(--danger)', fontSize: 'var(--fs-sm)', lineHeight: 1.6, textAlign: 'center',
-            }}>
-              {t('browser.launchFailed')}<br />{healthMsg}
-            </div>
-          </div>
+    // 背景色写在根上：全屏时这一块就是整块屏幕，缺省背景会在工具行外露出一圈白。
+    // position: relative 给下面 getPopupContainer 当定位基准。
+    <div ref={rootRef} style={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100%', background: 'var(--bg)' }}>
+      {/* 浮层（⋯ 菜单/标签/设备下拉/画质气泡）挂进这一块，而不是 document.body：全屏时只有
+          全屏元素的子树会被画出来，挂 body 上的浮层在全屏下**看不见也点不着**——实测点了
+          「全屏」再开 ⋯ 菜单，菜单在 DOM 里、屏幕上没有，连「退出全屏」都够不着。 */}
+      <ConfigProvider getPopupContainer={() => rootRef.current || document.body}>
+        {/* 页头（设计 17）：桌面＝标签条 + 工具行；窄档＝一条主行 + 状态芯片条。
+            从前是五行散装控件——「前往」实心按钮比地址栏还抢戏、四档清晰度常驻一整行、
+            「外部打开」被挤成第五行的孤儿。现在只有一个主角：omnibox。 */}
+        {shelf !== 'narrow' && (
+          <TabStrip tabs={tabs} active={target} onSelect={switchTab} onClose={closeTab} onAdd={newTab}
+            extra={<StatusChip icon={followPaused ? <UserIcon size={12} /> : <BotIcon size={12} />}
+              strong={followPaused ? t('browser.followModeHuman') : t('browser.followModeAgent')}
+              active={!followPaused} onClick={() => (followPaused ? resumeFollow() : pauseFollow())} />} />
         )}
-      </div>
+        <MirrorChrome
+          chromeRef={shelfRef}
+          main={<>
+            <IconBtn icon={<ChevronLeft size={17} />} label={t('file.back')} onClick={() => act('back')} />
+            {shelf !== 'narrow' && <>
+              <IconBtn icon={<ChevronRight size={17} />} label={t('file.forward')} onClick={() => act('forward')} />
+              <IconBtn icon={<RefreshIcon size={16} />} label={t('common.refresh')} onClick={() => act('reload')} />
+              <IconBtn icon={<HomeIcon size={16} />} label={t('browser.home')} onClick={() => act('navigate', { url: home })} />
+            </>}
+            <Omnibox
+              value={url}
+              onChange={setUrl}
+              onSubmit={navigate}
+              onFocusChange={(f) => { addrFocused.current = f }}
+              placeholder={t('browser.urlPlaceholder')}
+              goLabel={t('browser.go')}
+              lead={streamBadge}
+              trailing={shelf === 'narrow'
+                ? <IconBtn icon={<RefreshIcon size={15} />} label={t('common.refresh')} onClick={() => act('reload')} />
+                : shelf === 'wide'
+                  ? <span className="mc-omni-num">{`${latency == null ? '—' : latency + 'ms'} · ${fmtRate(bw)} · ${fps}fps`}</span>
+                  : undefined}
+            />
+            {shelf === 'narrow' && (
+              <IconBtn icon={<TabsIcon />} label={t('browser.tabs')} badge={tabs.length} onClick={() => setTabsOpen(true)} />
+            )}
+            {shelf !== 'narrow' && deviceChip}
+            <MirrorMenu items={menuItems} label={t('common.more')} />
+          </>}
+          chips={shelf === 'narrow' ? <>
+            <StatusChip icon={followPaused ? <UserIcon size={12} /> : <BotIcon size={12} />}
+              strong={followPaused ? t('browser.followModeHuman') : t('browser.followModeAgent')}
+              active={!followPaused} onClick={() => (followPaused ? resumeFollow() : pauseFollow())} />
+            {deviceChip}
+          </> : undefined}
+        />
+        {/* 手机标签：横条在 360 上放不下第三枚，换成「⧉N + 抽屉」（设计 17 §4） */}
+        <TabSheet open={tabsOpen} tabs={tabs} active={target} onClose={() => setTabsOpen(false)}
+          onSelect={(id) => { switchTab(id); setTabsOpen(false) }}
+          onCloseTab={closeTab} onAdd={() => { newTab(); setTabsOpen(false) }} />
+        <style>{`
+          .bv-ripple{position:absolute;width:14px;height:14px;margin:-7px 0 0 -7px;border-radius:50%;
+            border:2px solid var(--accent);pointer-events:none;animation:bvRip .45s ease-out forwards;}
+          @keyframes bvRip{from{transform:scale(.3);opacity:.9}to{transform:scale(2.6);opacity:0}}
+        `}</style>
+        <div
+          ref={stageRef}
+          tabIndex={0}
+          onKeyDown={onKey}
+          onWheel={onWheel}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          style={{
+            flex: 1, minHeight: 0, background: '#000', overflow: 'hidden', position: 'relative',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            cursor: control ? 'default' : 'not-allowed', outline: 'none', touchAction: 'none',
+          }}
+        >
+          <img
+            ref={imgRef}
+            draggable={false}
+            onMouseDown={onMouse('down')}
+            onMouseUp={onMouse('up')}
+            onMouseMove={onMove}
+            style={{
+              // 显示盒 = 整个舞台（旋转 90/270 时宽高对调），画面按 object-fit: contain 等比塞进去：
+              // 装不满的那一维留黑边。远端视口是固定的，所以拖窗格只改这一步的缩放比，画面内容不动。
+              position: 'absolute', left: '50%', top: '50%',
+              width: rotated ? stage.h : stage.w,
+              height: rotated ? stage.w : stage.h,
+              objectFit: 'contain',
+              // 贴着上沿放，不是居中：黑边全留在下面。居中的话，拖窄一点画面就往中间缩一次，
+              // 页面顶边跟着往下走——手上在拖分隔条，眼睛看到的却是「它自己滚了一下」。
+              // 贴上沿之后，缩放只让下面那条黑边变厚，页面顶边一直钉在原处。
+              objectPosition: '50% 0%',
+              transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+            }}
+          />
+          <textarea
+            ref={imeRef}
+            aria-label={t('browser.imeProxyLabel')}
+            tabIndex={-1}
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            onCompositionStart={() => { composingRef.current = true }}
+            onCompositionEnd={() => { composingRef.current = false; flushIme() }}
+            onInput={() => {
+              // 组合中的中间态（isComposing 的 input 事件）不发；只有非组合插入
+              //（如 macOS 长按选音标）才在这里落地。
+              if (!composingRef.current) flushIme()
+            }}
+            onBlur={() => {
+              // 失焦时丢弃半截组合，避免残留拼音在下次聚焦时被误发到远端。
+              composingRef.current = false
+              if (imeRef.current) imeRef.current.value = ''
+            }}
+            style={{
+              position: 'absolute', left: imePos.x, top: imePos.y, width: 2, height: 2,
+              opacity: 0, padding: 0, border: 'none', outline: 'none', resize: 'none',
+              overflow: 'hidden', background: 'transparent', caretColor: 'transparent',
+              pointerEvents: 'none',
+            }}
+          />
+          {ripples.map((p) => (
+            <span key={p.id} className="bv-ripple" style={{ left: p.x, top: p.y }} />
+          ))}
+          {/* 连不上且后端报了原因：覆盖一层提示，省得用户对着黑屏猜 */}
+          {!connected && healthMsg && (
+            <div style={{
+              position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              padding: 24, pointerEvents: 'none',
+            }}>
+              <div style={{
+                maxWidth: 520, padding: 'var(--sp-3) var(--sp-4)', borderRadius: 'var(--r-sm)', background: 'rgba(0,0,0,.72)',
+                border: '1px solid var(--danger-border)', color: 'var(--danger)', fontSize: 'var(--fs-sm)', lineHeight: 1.6, textAlign: 'center',
+              }}>
+                {t('browser.launchFailed')}<br />{healthMsg}
+              </div>
+            </div>
+          )}
+        </div>
+      </ConfigProvider>
     </div>
   )
 }

--- a/frontend/src/components/mirror/mirror.tsx
+++ b/frontend/src/components/mirror/mirror.tsx
@@ -8,7 +8,7 @@
 //   主行  = [左钮] [主角（Omnibox / devbox）] [右钮…]   —— 永远只有四个左右的可点目标
 //   芯片条 = 智能体 / 连接与画质 / 设备 …               —— 状态只读一眼，点开才是面板
 // 主角是唯一被强调的东西：胶囊、撑满剩余宽度、左徽标（连接与画质）+ 右就地操作。
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react'
 import { Dropdown, Popover, Segmented } from 'antd'
 import type { MenuProps } from 'antd'
 import { useI18n } from '../../i18n'
@@ -121,6 +121,40 @@ export function MirrorMenu({ items, label }: { items: MenuProps['items']; label:
       </button>
     </Dropdown>
   )
+}
+
+// ── 全屏 ────────────────────────────────────────────────────────────────
+
+/**
+ * 元素级全屏：把镜像这一块（工具行 + 画面）铺满显示器。
+ *
+ * 用元素级而不是整页全屏，是因为远端视口固定之后，观看区的宽高比决定黑边有多厚——
+ * 铺满一块 16:9 的显示器，黑边正好归零。iOS Safari 只允许 <video> 全屏，那里
+ * supported=false，调用方直接不摆这个入口（摆了也点不动）。
+ */
+export function useFullscreen(ref: RefObject<HTMLElement | null>) {
+  const [on, setOn] = useState(false)
+  useEffect(() => {
+    const sync = () => setOn(!!(document.fullscreenElement || (document as any).webkitFullscreenElement))
+    document.addEventListener('fullscreenchange', sync)
+    document.addEventListener('webkitfullscreenchange', sync)
+    return () => {
+      document.removeEventListener('fullscreenchange', sync)
+      document.removeEventListener('webkitfullscreenchange', sync)
+    }
+  }, [])
+  const root: any = typeof document === 'undefined' ? null : document.documentElement
+  const supported = !!(root?.requestFullscreen || root?.webkitRequestFullscreen)
+  const toggle = () => {
+    const doc: any = document
+    if (doc.fullscreenElement || doc.webkitFullscreenElement) {
+      (doc.exitFullscreen || doc.webkitExitFullscreen)?.call(doc)
+      return
+    }
+    const node: any = ref.current
+    ;(node?.requestFullscreen || node?.webkitRequestFullscreen)?.call(node)
+  }
+  return { on, supported, toggle }
 }
 
 // ── 主角 ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/mirror/mirror.tsx
+++ b/frontend/src/components/mirror/mirror.tsx
@@ -230,7 +230,7 @@ export function Omnibox({ value, onChange, onSubmit, onFocusChange, lead, traili
 // 状态与档位从来是同一件事（现在多清楚 / 连没连上 / 能不能换），拆成两处必然出现
 // 「超清」在屏幕上出现两次、谁也说不清哪个是状态哪个是开关。
 
-export function StreamControl({ connected, label, quality, onQuality, level, latency, bytesPerSec, fps, variant = 'badge', showLabel }: {
+export function StreamControl({ connected, label, quality, onQuality, level, latency, bytesPerSec, fps, size, variant = 'badge', showLabel }: {
   connected: boolean
   label: string
   quality: Quality
@@ -239,6 +239,8 @@ export function StreamControl({ connected, label, quality, onQuality, level, lat
   latency: number | null
   bytesPerSec: number
   fps: number
+  /** 画面分辨率（如 1280×720）：远端视口固定之后，「现在传的是多大一张图」是链路信息，和延迟/码率同属这里 */
+  size?: string
   /** badge = omnibox 左徽标；chip = 状态芯片条上的一枚 */
   variant?: 'badge' | 'chip'
   /** 徽标里带不带「已连接」四个字（桌面带，手机只留档位名） */
@@ -257,6 +259,7 @@ export function StreamControl({ connected, label, quality, onQuality, level, lat
         <span className="num">{latency == null ? '—' : latency + 'ms'}</span>
         <span className="num">{fmtRate(bytesPerSec)}</span>
         <span className="num">{fps}fps</span>
+        {size && <span className="num">{size}</span>}
       </div>
       <Segmented
         size="small"


### PR DESCRIPTION
## 问题

浏览器镜像的桌面档，从前把**观看区的宽高比**当成远端视口下发（`emulate` 挂在 `stage.w` 上）。
于是拖一下分隔条 = 给远端换一次分辨率：响应式站点当场重排，栏数、折行、菜单收纳全跟着变。
想看的是同一个页面，拖一下却成了另一个版式。

**改前**：同一个页面，宽窗格 vs 窄窗格 —— 画面铺满窗格不留黑边，代价是**内容重排**（注意正文折行、右栏位置全变了）

| 宽窗格 | 窄窗格 |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/before-wide.png" width="420"> | <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/before-narrow.png" width="420"> |

## 改后

桌面档是**固定视口**，取设置页「浏览器 · 窗口大小」（默认 1920×1080），与观看区多大无关。
观看区只负责把这一帧 `object-fit: contain` 塞进去，装不满的那一维留黑边。

**改后**：同一个页面，宽窗格 vs 窄窗格 —— **版式一模一样**，只是整体缩小，多出来的地方留黑边

| 宽窗格（左右留边） | 窄窗格（上下留边） |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/after-wide.png" width="420"> | <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/after-narrow.png" width="420"> |

## 几个决定

**为什么不干脆不覆盖视口、用 Chrome 窗口自己的尺寸？** 先这么试过，结果远端是**竖屏**的：
实测这台无头 Chrome 的原生视口是 `1280×1775`（`chrome eval "[innerWidth,innerHeight,devicePixelRatio,screen.width,screen.height]"`
→ `[1280,1775,2,400,300]`）——`--force-device-scale-factor=2` 叠上 `--start-fullscreen` 与 ozone 的
屏幕尺寸覆盖，一台「全屏浏览器」就长成了这样。所以显式钉一个横屏尺寸，并让它跟着设置页那一格走：
想换分辨率，就去改「浏览器 · 窗口大小」，一个地方说了算。

**dpr 从 ≥2 改回 1。** 传输分辨率本来就由画质档的 `maxWidth/maxHeight` 管（后端 `ladder`），
1920 的画面落进窄窗格本身就是超采样，不必再让远端多渲一倍像素。

**固定之后，「远端到底多大」得看得见。** 画质气泡里补了一格画面分辨率（挨着延迟/码率/帧率），
设备下拉的「桌面」那一项标出当前视口尺寸。

## 验证

- 上面四张图都是真机跑出来的：登录本机实例 → 镜像页 → 1600 宽截一张 → 拖到 980 宽再截一张。
- **点击落点**：窄窗格 + 上下黑边的状态下点镜像里目录的「Function」，远端确实跳到了
  `en.wikipedia.org/wiki/Web_browser#Function`（地址栏与 `chrome url` 两处对得上）——
  `mapClientXY` 的 contain 换算在显示盒改成整块舞台之后依然正确。
- `scripts/dev/quality/check.sh full` 通过；前端 404 项测试通过。

## 已知取舍

手机上看**桌面**镜像会比从前更小：以前视口跟着窗格走（最小 1280 宽），现在恒定 1920 宽，
在 390pt 的屏上是 ~5× 缩小。要在手机上读网页，走设备档（iPhone/Pixel）或用旋转按钮更合适。

> 正文引用的四张图放在 `pr-shots/browser-fixed-viewport` 分支（不进 main），合完可删。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW

---

## 追加：拖动时「感觉它自己滚了一下」

画面本来是**居中**放的：拖窄一点就往中间缩一次，上下黑边同时变厚，页面顶边跟着往下走。
手上在拖分隔条，眼睛看到的却是内容上下窜——不是滚动，但看着就是。
（先量过一遍确认远端是稳的：连着改四次窗格宽度，远端 `[scrollY, innerWidth, innerHeight]`
一直是 `[1200, 1920, 1080]`，一动没动。所以问题在本地怎么摆这一帧。）

改成贴着上沿放（`object-position: 50% 0%`）：缩放只让**下面**那条黑边变厚，页面顶边一直
钉在原处，和真浏览器缩窗口的手感一致（内容从左上角长出来，不整体位移）。

| 宽窗格 | 窄窗格（顶边同一位置，黑边全在下面） |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/anchor-wide.png" width="420"> | <img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/anchor-narrow.png" width="420"> |

`mapClientXY` 的黑边换算跟着改（纵向 `padY` 归零）——显示和命中是同一套几何，改一头必须
改另一头，否则点击落点整体差半条黑边。

## 追加：全屏

⋯ 菜单第一项。远端视口固定之后「黑边多厚」只取决于观看区多大，铺满一块 16:9 的显示器
黑边正好归零。全屏的是「工具行 + 画面」这一整块，不是整页——地址栏和标签还得能用。

<img src="https://raw.githubusercontent.com/ybz21/Roam/pr-shots/browser-fixed-viewport/shots/fullscreen.png" width="720">

**做全屏时踩到的一个坑，顺手一起修了**：全屏状态下只有全屏元素的子树会被画出来，而 antd
默认把浮层挂在 `document.body` 上。于是点了全屏再开 ⋯ 菜单，菜单在 DOM 里、屏幕上没有，
连「退出全屏」都够不着（自动化点它直接超时，就是这么发现的）。整块用 ConfigProvider 的
`getPopupContainer` 把浮层收进根节点，标签菜单/设备下拉/画质气泡一并解决。

验证：点「全屏」→ `document.fullscreenElement` 是镜像根节点 → 全屏里再开 ⋯ 菜单，首项已变成
「退出全屏」→ 点它，退出成功。