### PR TITLE
fix(revive): tmux server 整个没了时休眠会话立刻出现，不用等新建一个会话

### DIFF
--- a/cli/ttmux-cli-go/internal/command/session/collect.go
+++ b/cli/ttmux-cli-go/internal/command/session/collect.go
@@ -37,6 +37,9 @@ func Collect(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool) 
 	if err == nil {
 		live = parseSessionLines(out, exclude)
 	}
+	// server 确定不在（socket 连不上）≠ 盲态：前者台账里所有活行一起进历史，
+	// 后者一行不动。分不开这两种，重启后休眠会话就要等下一次建会话才出现。
+	serverGone := err != nil && runtime.NoServer(out)
 	// 内存画像：会话列表上那条内存条的数据源。cgroup 按 pane 分好了，
 	// 一次读两个文件，比轮询 ps 聚合整棵进程树便宜也准（含子进程全部后代）。
 	samples := make([]memalert.Sample, 0, len(live))
@@ -56,17 +59,21 @@ func Collect(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool) 
 			PIDs: m.PIDs, Cur: m.Cur, High: m.High, Max: m.Limit,
 		})
 	}
-	// tmux 盲态（server 没起）时 alive 为空，Reconcile 内部会一行不动——
-	// 「看不见的时候不下判断」。这里照常调用，让它自己决定。
+	// tmux 盲态（list-sessions 出错但不是「server 不在」）时 alive 为空，
+	// Reconcile 内部会一行不动——「看不见的时候不下判断」。这里照常调用，让它自己决定。
 	if meta != nil {
-		alive := make(map[string]bool, len(live))
-		for _, s := range live {
-			alive[s.Name] = true
+		if serverGone {
+			meta.ReconcileServerGone()
+		} else {
+			alive := make(map[string]bool, len(live))
+			for _, s := range live {
+				alive[s.Name] = true
+			}
+			// 把「这个会话吃了多少内存」接给台账。cgroup 按 pane 分好了，
+			// 一次读两个文件，比轮询 ps 聚合整棵进程树便宜也准。
+			meta.MemStat = func(sess string) (int64, int64, bool) { return sessionMem(rt, sess) }
+			meta.Reconcile(alive)
 		}
-		// 把「这个会话吃了多少内存」接给台账。cgroup 按 pane 分好了，
-		// 一次读两个文件，比轮询 ps 聚合整棵进程树便宜也准。
-		meta.MemStat = func(sess string) (int64, int64, bool) { return sessionMem(rt, sess) }
-		meta.Reconcile(alive)
 		// 看门狗：逼近上限 / 撞顶被杀各说一次。列会话本来就在采内存，顺手判一下，
 		// 不必再养一个采集器（这也是它没做成 hostmonitor 插件的原因——
 		// 数据跟着会话列表走，插件那条路要再建一条通路）。

--- a/cli/ttmux-cli-go/internal/runtime/runtime.go
+++ b/cli/ttmux-cli-go/internal/runtime/runtime.go
@@ -120,6 +120,20 @@ func (r Runtime) HasSession(name string) bool {
 	return cmd.Run() == nil
 }
 
+// NoServer 判断 tmux 的一次报错是不是「server 根本不在」。
+//
+// 客户端连不上 socket 只有两种措辞：socket 文件在但没人听是
+// "no server running on <path>"，连 socket 文件都没有是
+// "error connecting to <path> (No such file or directory)"。这两种都是确定的
+// 「一个会话都没有」，和权限不对、二进制缺失那种「看不见」是两回事——
+// 前者该让台账把所有活行收进历史，后者才是一行不许动的盲态。
+func NoServer(out string) bool {
+	if strings.Contains(out, "no server running on") {
+		return true
+	}
+	return strings.Contains(out, "error connecting to") && strings.Contains(out, "No such file or directory")
+}
+
 // Sessions returns all tmux session names (unfiltered).
 func (r Runtime) Sessions() []string {
 	out, err := r.TmuxOutput("list-sessions", "-F", "#{session_name}")

--- a/cli/ttmux-cli-go/internal/runtime/session_test.go
+++ b/cli/ttmux-cli-go/internal/runtime/session_test.go
@@ -118,3 +118,26 @@ func TestSanitizeLabelKeepsHumanText(t *testing.T) {
 		t.Fatalf("制表/换行会破坏 list-sessions -F 的分隔，必须替掉: %q", got)
 	}
 }
+
+// 只有 tmux 那两句「连不上 socket」算 server 不在；权限不对、别的报错都不算——
+// 认错了就会把一整表活会话误收进历史。
+func TestNoServer(t *testing.T) {
+	for _, out := range []string{
+		"no server running on /tmp/tmux-1000/default\n",
+		"error connecting to /tmp/tmux-1000/default (No such file or directory)\n",
+	} {
+		if !NoServer(out) {
+			t.Errorf("应判为 server 不在: %q", out)
+		}
+	}
+	for _, out := range []string{
+		"",
+		"error connecting to /tmp/tmux-1000/default (Permission denied)\n",
+		"can't find session: dev\n",
+		"dev\t1\t1700000000\n",
+	} {
+		if NoServer(out) {
+			t.Errorf("不该判为 server 不在: %q", out)
+		}
+	}
+}

--- a/cli/ttmux-cli-go/internal/sessmeta/sessmeta.go
+++ b/cli/ttmux-cli-go/internal/sessmeta/sessmeta.go
@@ -588,6 +588,7 @@ func (s *Store) OnKill(session string) error {
 
 // Reconcile 对齐 tmux 实况，**双向**自愈：活着的置 live 并刷新运行时句柄，不在了
 // 的置 dead（不删）。alive 为空（tmux 盲态）时一行不动——看不见的时候不下判断。
+// server 确定不在的情况不走这里，走 ReconcileServerGone。
 //
 // died_reason 分两种：tmux_epoch 还是这一代 server ⇒ 是被杀的；对不上 ⇒ server
 // 换代了（机器重启把它带走的）。这是「重启后一整批会话集体消失」和「你刚 kill 了
@@ -682,6 +683,27 @@ func (s *Store) Reconcile(alive map[string]bool) {
 		_, _ = db.Exec(`UPDATE sessions SET status='dead', died_at=?, died_reason=?, tmux_id=NULL
 			WHERE id=?`, g.at, g.reason, g.id)
 	}
+	s.prune(db, deadKeep)
+}
+
+// ReconcileServerGone 处理 tmux server **确定不在**的情况（socket 连不上，见 runtime.NoServer）。
+//
+// 这不是盲态。盲态是「看不见」，这里是「看清楚了，一个都不在」——机器重启、
+// tmux 被整个带走之后就是这样。Reconcile 在 alive 为空时一行不动，于是重启后
+// 所有行卡在 live：Dormant() 只认 dead 行，列表里一个休眠会话都不出现，
+// 要等用户随手新建一个会话、alive 非空了才被收敛（实测就是「点了新建命令行
+// 旧会话才冒出来」）。这里把所有 live 行一次收进历史，记 host-restart（整批一起
+// 没的，不是谁被 kill），died_at 取最后一次看见它。tmux_epoch 原样留着，
+// Dormant() 靠它认「上一代 server 带走的那批」。
+func (s *Store) ReconcileServerGone() {
+	db, err := s.db()
+	if err != nil {
+		return
+	}
+	now := s.Now().Format(time.RFC3339)
+	_, _ = db.Exec(`UPDATE sessions SET status='dead', died_reason='host-restart', tmux_id=NULL,
+		died_at=CASE WHEN IFNULL(last_seen,'')<>'' THEN last_seen ELSE ? END
+		WHERE status='live'`, now)
 	s.prune(db, deadKeep)
 }
 

--- a/cli/ttmux-cli-go/internal/sessmeta/sessmeta_test.go
+++ b/cli/ttmux-cli-go/internal/sessmeta/sessmeta_test.go
@@ -286,3 +286,47 @@ func TestSetHomeOverwritesButBlankKeeps(t *testing.T) {
 		t.Fatalf("传空不该清掉已有的 repo_root: %q", repo)
 	}
 }
+
+// tmux server 整个不在（重启 / kill-server）：这不是盲态，所有 live 行一次收进历史，
+// 记 host-restart、died_at 取最后一次看见它，并且**当场**就出现在 Dormant() 里——
+// 不用等用户新建一个会话让 alive 非空才被收敛。
+func TestServerGoneMarksLiveRowsDormant(t *testing.T) {
+	s, _ := newTestStore(t, map[string]string{"a": "$1", "b": "$2"})
+	s.Epoch = func() string { return "1000" }
+	dir := t.TempDir()
+	for _, n := range []string{"a", "b"} {
+		if err := s.Put(Row{Session: n, InitialCwd: dir}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 活着时看见过一次：died_at 应取这一刻，不是之后收敛的时刻
+	s.Reconcile(map[string]bool{"a": true, "b": true})
+	seen := s.Now().Format(time.RFC3339)
+	s.Now = func() time.Time { return time.Date(2026, 7, 29, 9, 0, 0, 0, time.UTC) }
+
+	s.ReconcileServerGone()
+
+	if live := s.All(); len(live) != 0 {
+		t.Fatalf("server 没了不该还有活行: %+v", live)
+	}
+	hist := s.History(0)
+	if len(hist) != 2 {
+		t.Fatalf("两行都该进历史，got %+v", hist)
+	}
+	for _, r := range hist {
+		if r.DiedReason != "host-restart" {
+			t.Fatalf("%s died_reason = %q, want host-restart", r.Session, r.DiedReason)
+		}
+		if r.DiedAt != seen {
+			t.Fatalf("%s died_at = %q, want 最后一次看见 %q", r.Session, r.DiedAt, seen)
+		}
+	}
+	if got := s.Dormant(); len(got) != 2 {
+		t.Fatalf("server 没了之后休眠列表就该有它们，got %+v", got)
+	}
+	// 没有活行时再来一次什么都不变
+	s.ReconcileServerGone()
+	if len(s.History(0)) != 2 || len(s.Dormant()) != 2 {
+		t.Fatalf("重复收敛不该改变结果: %+v", s.History(0))
+	}
+}


### PR DESCRIPTION
## 问题

机器重启或 tmux 被整个带走后，打开项目页一个休眠会话都不显示；随手点一次「新建命令行」，旧会话才以休眠卡片冒出来。

## 根因

`Collect` 调 `list-sessions` 时 tmux 报 `no server running`，拿到的存活集合为空，`Reconcile` 按「tmux 盲态」一行不动，台账里所有会话卡在 `live`；而 `Dormant()` 只认 `dead` 行，于是列表里没有它们。直到用户建出一个活会话、存活集合非空，收敛才跑起来把旧会话标成 `host-restart`。

台账实录：会话 `2026-0902-1817-0001` 的 tmux 在 18:32 没了，直到 18:42 用户新建命令行才被标记为 host-restart。

## 改法

- `runtime.NoServer`：只认 tmux 那两句「连不上 socket」的报错（`no server running on` / `error connecting to … (No such file or directory)`），权限错误等仍算盲态。
- `sessmeta.ReconcileServerGone`：把所有 `live` 行一次收进历史，记 `host-restart`，`died_at` 取 `last_seen`，`tmux_epoch` 原样保留供 `Dormant()` 认批次。
- `Collect` 按「server 确定不在」与「盲态」分流；真正的盲态行为不变。

## 验证

- 新增 `TestServerGoneMarksLiveRowsDormant`、`TestNoServer`；`go test ./internal/sessmeta/ ./internal/runtime/` 通过。
- `scripts/dev/quality/check.sh quick` 通过。
- 隔离环境端到端（独立 tmux socket + 临时 `ROAM_HOME`）：建会话 → `kill-server` → `ls --json` 立刻列出 `dormant`，`db revive` 能接回；旧二进制同场景列表为空、台账仍 `live`。
- 本机 130.55 已用叠加了 #230 的构建替换 `~/.local/bin/ttmux` 实测。

## 本 PR 不做什么

- 不改后端和前端：它们已经消费 `ttmux ls` 的 dormant 结果，台账一收敛即显示。
- 不处理 `fork` 路径里的 `Reconcile(aliveSet(rt))`：那两处在 server 不在时是空操作，随后的 `ls` 会补上收敛。
- 与 #230 无文件重叠，互不依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
