### PR TITLE
fix(shell): 右栏第一次进来真的收着了 —— 上一版被 mount 顺序掰开

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -434,7 +434,7 @@ export default function App() {
       if (mod && e.shiftKey && taskView && e.key.toLowerCase() === 'f') {
         e.preventDefault()
         setPanel('files')
-        if (space.inspectorCollapsed) space.toggleInspectorCollapsed()
+        space.setInspectorCollapsed(false)
         setSearchNonce((n) => n + 1)
         return
       }
@@ -442,7 +442,7 @@ export default function App() {
       if (mod && e.shiftKey && taskView && (e.key.toLowerCase() === 'e' || e.key.toLowerCase() === 'g')) {
         e.preventDefault()
         setPanel(e.key.toLowerCase() === 'e' ? 'files' : 'git')
-        if (space.inspectorCollapsed) space.toggleInspectorCollapsed()
+        space.setInspectorCollapsed(false)
         return
       }
       // Esc 收一层：覆盖态先收面板，聚焦态退回分栏。两者都不关终端、不离开页面。
@@ -777,7 +777,7 @@ export default function App() {
       onNew={taskView ? { terminal: () => { void newTerminalInTask('shell') }, claude: () => { void newTerminalInTask('claude') }, codex: () => { void newTerminalInTask('codex') }, taskLabel: activeTaskLabel } : undefined}
       // 任务视图里对话点路径 / Git 都落到右栏三面板；手机与 Page 态退回 TerminalPane 自己的二级页
       onOpenFile={taskView ? (path, line) => openFileTab(path, line) : undefined}
-      onOpenGit={taskView ? () => { setPanel('git'); if (space.inspectorCollapsed) space.toggleInspectorCollapsed() } : undefined}
+      onOpenGit={taskView ? () => { setPanel('git'); space.setInspectorCollapsed(false) } : undefined}
       inspector={taskView ? { open: !space.inspectorCollapsed, toggle: () => space.toggleInspectorCollapsed() } : undefined}
       fileTabs={taskView ? fileTabs : undefined} activeFile={taskView ? curFile : undefined}
       taskDir={activeTask && !isLooseTask(activeTask) ? activeTask : (activeProject?.dir || '')}

--- a/frontend/src/components/shell/useWorkspaceLayout.ts
+++ b/frontend/src/components/shell/useWorkspaceLayout.ts
@@ -89,6 +89,8 @@ export type WorkspaceLayout = {
   canvasFitsInspector: boolean
   /** Inspector 折起（面板仍挂着，只是这一列宽度归零）；把手上那枚握把切它 */
   inspectorCollapsed: boolean
+  /** 展开右栏。只有人的动作该调它（开关钮 / ⌘⇧E·G·F / 对话工具行的 Git） */
+  setInspectorCollapsed: (collapsed: boolean) => void
   toggleInspectorCollapsed: () => void
 }
 
@@ -210,15 +212,12 @@ export function useWorkspaceLayout(hasTerms: boolean, taskView = false): Workspa
 
   // Inspector 折起进偏好：第一次进来收着（WORKSPACE_DEFAULTS），自己拉开过就一直开着。
   //
-  // 「面板下次打开时理应看得见自己」这条约束还在，但只在**从没有面板到有面板**的那一刻
-  // 生效：任务页上 InspectorPanels 是常驻 claim 的（open 恒为真），拿 open 当条件的话，
-  // 每次进任务页都会把收起态强行掰开——那就等于这格偏好不存在。
-  const prevInspectorOpen = useRef(inspectorOpen)
-  useEffect(() => {
-    const rose = !prevInspectorOpen.current && inspectorOpen
-    prevInspectorOpen.current = inspectorOpen
-    if (rose) setInspectorCollapsed(false)
-  }, [inspectorOpen])
+  // 这里**不再**根据「有没有面板占着槽位」自动展开。原来那条（open 为真就展开）等于让这格
+  // 偏好不存在——任务页上 InspectorPanels 是常驻 claim 的。改成只看「从无到有」也不行：
+  // 槽位是在 mount 之后的 effect 里 claim 的，于是每次进任务页都恰好是一次 false→true，
+  // 照样把收起态掰开（实测：点会话进来右栏还是开着）。
+  // 展开只由**人**触发：标签条右端那枚开关、⌘⇧E/G/F、对话工具行里的「Git」——
+  // 那几处各自调 setInspectorCollapsed(false)，见 App.tsx。
 
   return {
     mode,
@@ -233,6 +232,7 @@ export function useWorkspaceLayout(hasTerms: boolean, taskView = false): Workspa
     resetInspectorWidth: () => { hydrated.current = true; setInsWidthLocal(0); saveWorkspace({ inspectorWidth: 0 }) },
     canvasFitsInspector: canvasFitsWith({ workspaceWidth, inspectorWidth }),
     inspectorCollapsed,
+    setInspectorCollapsed,
     toggleInspectorCollapsed: () => setInspectorCollapsed(!inspectorCollapsed),
     toggleDock: () => setDockOpen(!dockOpen),
     setDockOpen,


### PR DESCRIPTION
上一版（#235）加了 `workspace.inspectorCollapsed` 默认收起，但**点会话进来右栏还是开着**。

原因是 mount 顺序：自动展开那条本来判的是「有没有面板占着槽位」，我把它收紧成
「从没有面板到有面板的那一刻」——可槽位正是在 mount 之后的 effect 里 claim 的，于是每次进
任务页都恰好是一次 `false → true`，照样把收起态掰开。等于那格偏好写了个寂寞。

自动展开整条去掉。**展开只由人触发**，各自显式调 `setInspectorCollapsed(false)`：
标签条右端那枚开关、`⌘⇧E` / `⌘⇧G` / `⌘⇧F`、对话工具行里的「Git」。

## 验证（真 Chrome 里点的，不是看代码想的）

清掉本机镜像和服务端偏好里的这一格，模拟第一次进来：

| | rail | 面板宽 | 存下来的偏好 |
| --- | --- | --- | --- |
| 第一次进来点会话 | `collapsed` | **0** | `true` |
| 人点右栏开关 | 展开 | 320 | `false` |
| 刷新之后 | 展开 | 320 | `false` |

`scripts/dev/quality/check.sh full` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW