### PR TITLE
fix(shell): 文件页/插件页也满幅；文件栏默认收窄；侧栏搜索不再是个方框

### DIFF
--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -336,7 +336,7 @@ function FileTree({
 
 // dock 布局的两层折叠（文件树 ｜ 预览）交给 <InspectorLayers>——Git 的「改动列表 ｜ diff」
 // 用的是同一份机制，契约写在那个文件顶上。这里只给这两层的尺寸。
-const TREE: LayerSize = { key: 'ttmux.fileTreeW', min: 180, max: 480, def: 360 } // 再窄就只剩省略号
+const TREE: LayerSize = { key: 'ttmux.fileTreeW', min: 180, max: 480, def: 300 } // 再窄就只剩省略号；300 够放两级缩进 + 20 个字
 const PREVIEW: LayerSize = { key: 'ttmux.filePreviewW', min: 280, max: 1200, def: 560 } // 280 以下读不了代码；560 = 80 列等宽正文 + 留白
 
 export default function FileBrowser({

--- a/frontend/src/components/files/FileWorkspace.tsx
+++ b/frontend/src/components/files/FileWorkspace.tsx
@@ -18,7 +18,7 @@ const TAB_MIME = 'application/x-ttmux-tab'
 const PATH_MIME = 'application/x-ttmux-path'
 const LEAD_MIME = 'application/x-ttmux-lead' // 拖会话(首)tab → 左右易位
 const PREVIEW_PREFIX = 'preview://' // 侧栏预览 tab 的标识前缀（区别于同文件的源码 tab）
-const DOCK_MIN = 160, DOCK_MAX = 640, DOCK_DEFAULT = 280
+const DOCK_MIN = 160, DOCK_MAX = 640, DOCK_DEFAULT = 240 // 240：文件名够看，正文那栏多出 40
 
 function baseName(p: string): string {
   return p.split('/').pop() || p

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -510,14 +510,17 @@ html[data-pointer="coarse"] .tt-nav-collapse::after {
 
 /* ── 侧栏搜索行（22 设计 §3.5）：顶栏 Command Center 撤了，⌘K 的可见入口回到品牌下面 ──
    实底 + 32 高的假输入框：与底同色只描一圈边的话没人看得出这里能搜（有人用了半年不知道有 ⌘K） */
+/* 搜索这一行是**导航行**，不是输入框：它下面紧跟着「项目 / 文件 / 浏览器…」一列扁平的行，
+   中间夹一枚带边框、带填充底的方框，读起来像另一个控件掉进了导航里（实测第一眼就是它最扎眼）。
+   现在跟 .tt-nav-item 同一副长相：同高、同图标槽、同 hover 底，只有右端多一枚 ⌘K 标。 */
 .tt-nav-search {
-  display: flex; align-items: center; gap: var(--sp-2); width: 100%; height: 32px;
-  margin: 0 0 var(--sp-2); padding: 0 10px;
-  border: 1px solid var(--border-subtle); border-radius: var(--r-sm);
-  background: var(--bg-elevated); color: var(--text-dim); font-size: var(--fs-sm);
-  text-align: left; cursor: pointer; transition: border-color .12s, color .12s;
+  display: flex; align-items: center; gap: 11px; width: 100%; min-height: 38px;
+  margin: 0 0 var(--sp-1); padding: 0 10px;
+  border: 0; border-radius: var(--r-sm);
+  background: none; color: var(--text-dim); font-size: var(--fs-body);
+  text-align: left; cursor: pointer; transition: background .14s, color .14s;
 }
-:where(html[data-pointer="fine"]) .tt-nav-search:hover { border-color: var(--accent-border); color: var(--text-bright); }
+:where(html[data-pointer="fine"]) .tt-nav-search:hover { background: var(--list-hover); color: var(--text-bright); }
 .tt-nav-search .ph { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tt-nav-search kbd {
   flex: 0 0 auto; padding: 1px 5px; border: 1px solid var(--border); border-radius: 5px;
@@ -1327,11 +1330,17 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
    品牌行矮一截、错开 16px，顶上那道横线接不上。
    底部例外——手机上要给底栏/会话坞让位，否则画面被压在它们下面。 */
 .tt-page-phone,
-.tt-page-browser { padding: 0; }
+.tt-page-browser,
+.tt-page-files,
+.tt-page-plugins { padding: 0; }
 .tt-page-phone.tt-page-mobile,
-.tt-page-browser.tt-page-mobile { padding-bottom: calc(76px + env(safe-area-inset-bottom)); }
+.tt-page-browser.tt-page-mobile,
+.tt-page-files.tt-page-mobile,
+.tt-page-plugins.tt-page-mobile { padding-bottom: calc(76px + env(safe-area-inset-bottom)); }
 .tt-page-phone.tt-page-mobile.has-dock,
-.tt-page-browser.tt-page-mobile.has-dock { padding-bottom: calc(126px + env(safe-area-inset-bottom)); }
+.tt-page-browser.tt-page-mobile.has-dock,
+.tt-page-files.tt-page-mobile.has-dock,
+.tt-page-plugins.tt-page-mobile.has-dock { padding-bottom: calc(126px + env(safe-area-inset-bottom)); }
 .tt-page-files > *,
 .tt-page-phone > *,
 .tt-page-browser > *,


### PR DESCRIPTION
## 满幅

文件页、插件页跟浏览器/手机页一样去掉 16px 页边距。五页里三页贴边、两页留白，切换时顶上
那道线来回跳 16px。

## 文件栏默认收窄

树 `360 → 300`，停靠栏 `280 → 240`。这一栏是「找文件」的，不是读文件的，正文那栏多出来的
宽度更值钱。已经自己拖过的不受影响（宽度记在本机 localStorage），双击分隔条回默认值。

## 侧栏搜索不再是个方框

它下面紧跟着「项目 / 文件 / 浏览器…」一列扁平的导航行，中间夹一枚带边框、带填充底的方框——
读起来像另一个控件掉进了导航里。现在跟 `.tt-nav-item` 同一副长相：同高（38）、同图标槽（11px gap）、
同 hover 底，只有右端多一枚 ⌘K 标。

## 验证

真 Chrome 里看的：文件页/插件页的 `padding-top` 都是 `0`、第一个子元素 `top=0`；
文件栏在清掉本机记录后是 240 宽；侧栏搜索与下面的导航行同高同缩进。
`scripts/dev/quality/check.sh full` 通过。

> 还留着的：插件页里那两张卡自己带圆角和间距，页面边距虽然没了，卡跟卡之间仍有缝。
> 要连卡片一起拆平说一声。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW