### PR TITLE
feat(hostmon): 清 swap 改成后台任务；插件页拆平成一整块

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ import { ProjectTree, firstSessionOf, taskPathOf } from './components/shell/Proj
 import { InspectorPanels, type InspectorPanelKind } from './components/shell/InspectorPanels'
 import { buildTaskTree, type TreeTask } from './components/shell/task-tree'
 import { useSessionCloser } from './components/sessions/session-closer'
+import { isInfraSession } from './components/sessions/infra-session'
 import { taskKeyOf, isLooseTask, looseSessionOf, type TaskKey } from './components/sessions/task-key'
 import RenameSessionModal from './components/sessions/RenameSessionModal'
 import { TaskComposer } from './components/sessions/TaskComposer'
@@ -498,6 +499,8 @@ export default function App() {
       const labels: Record<string, string> = {}
       const names: { name: string; label?: string; lastActivity?: number; agent?: 'claude' | 'codex' }[] = []
       for (const s of Array.isArray(list) ? list : []) {
+        // 基础设施会话（_ttmux-plugind / _ttmux-im）不进任何人看的列表：树、标签、⌘K、计数
+        if (s?.name && isInfraSession(s.name)) continue
         if (s?.id && s?.name) { byId[s.id] = s.name; byName[s.name] = s.id }
         if (s?.name && s?.label) labels[s.name] = s.label
         if (s?.name) names.push({ name: s.name, label: s.label || undefined, lastActivity: s.lastActivity || undefined, agent: s.agent === 'claude' || s.agent === 'codex' ? s.agent : undefined })

--- a/frontend/src/components/files/FileWorkspace.test.tsx
+++ b/frontend/src/components/files/FileWorkspace.test.tsx
@@ -56,21 +56,24 @@ describe('FileWorkspace resize shield', () => {
     const handle = container.querySelector<HTMLElement>('[data-resize-handle="dock"]')!
     const dock = handle.previousElementSibling as HTMLElement
 
-    fireEvent.pointerDown(handle, { pointerId: 7, clientX: 280 })
+    // 起点按**当前实际宽度**取，别写死默认值：默认宽度调过一次（280 → 240），
+    // 写死的话这条测的就成了「默认值有没有被改」，而它想测的是「拖动跟不跟手」。
+    const startW = parseInt(dock.style.flex.split(' ')[2], 10)
+    fireEvent.pointerDown(handle, { pointerId: 7, clientX: startW })
 
     const shield = document.body.querySelector<HTMLElement>('[data-pointer-resize-shield="true"]')!
     expect(shield).not.toBeNull()
     expect(document.body.style.userSelect).toBe('none')
     expect(document.body.style.cursor).toBe('col-resize')
 
-    fireEvent.pointerMove(shield, { pointerId: 7, clientX: 360 })
-    expect(dock.style.flex).toBe('0 0 360px')
+    fireEvent.pointerMove(shield, { pointerId: 7, clientX: startW + 80 })
+    expect(dock.style.flex).toBe(`0 0 ${startW + 80}px`)
 
-    fireEvent.pointerUp(shield, { pointerId: 7, clientX: 360 })
+    fireEvent.pointerUp(shield, { pointerId: 7, clientX: startW + 80 })
     expect(document.body.querySelector('[data-pointer-resize-shield="true"]')).toBeNull()
     expect(document.body.style.userSelect).toBe('')
     expect(document.body.style.cursor).toBe('')
-    expect(localStorage.getItem('ttmux.fileDockW')).toBe('360')
+    expect(localStorage.getItem('ttmux.fileDockW')).toBe(String(startW + 80))
   })
 
   it('removes the shield and restores page styles when the window loses focus', () => {

--- a/frontend/src/components/plugins/HostMonitorPanel.tsx
+++ b/frontend/src/components/plugins/HostMonitorPanel.tsx
@@ -49,20 +49,29 @@ function usageColor(p: number): string {
 // 前兆**——一旦换页无处可去，内核就在直接回收里空转，ping 还通（内核收发 ICMP 不换页）
 // 但 ssh 再也进不来，只能按电源键。本机 2026-08-12 那次就是这么冻的，而那三天里 swap
 // 一直贴着 98%——数字一直在这块面板上，只是画成了一根永不变色的灰条，和 5% 长得一样。
-function SwapBar({ used, total, t, onClear }: {
+function SwapBar({ used, total, t, onClear, job }: {
   used: number; total: number
   t: (k: string, vars?: Record<string, string | number>) => string
   /** 清一次；没给就不画那颗钮（比如快照是外部喂的、没有真插件可调） */
   onClear?: () => void
+  /** 后台任务在跑时的进度（起步换出多少 / 现在还剩多少） */
+  job?: { state: string; startSwap: number; swapUsed: number } | null
 }) {
   const pct = Math.round((used / total) * 100)
+  const running = job?.state === 'running'
   return (
     <div style={{ marginTop: 'var(--sp-2)' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
         <Typography.Text type="secondary" style={{ fontSize: 'var(--fs-meta)' }}>
           Swap {fmtBytes(used)} / {fmtBytes(total)}
         </Typography.Text>
-        {onClear && used > 0 && (
+        {running ? (
+          // 跑着的时候不给按钮：再点一次就是第二个 swapoff 抢同一块内存。
+          // 数字本身就是进度——「还剩多少没读回来」比一个百分比条更说明问题。
+          <Typography.Text type="secondary" style={{ marginLeft: 'auto', fontSize: 'var(--fs-meta)', color: 'var(--accent)' }}>
+            {t('plugins.monitor.swapRunning', { left: fmtBytes(job?.swapUsed ?? used) })}
+          </Typography.Text>
+        ) : onClear && used > 0 && (
           <button type="button" className="tt-act" style={{ marginLeft: 'auto' }} onClick={onClear}>
             {t('plugins.monitor.swapClear')}
           </button>
@@ -151,6 +160,27 @@ export default function HostMonitorPanel({ pluginId, enabled, t, fetchSnapshot }
   // 把「换出多少 / 可用多少 / 读回来还剩多少」摆在确认框上，人点了才真干。
   const run = (args: Record<string, string>) =>
     api('POST', `/plugins/${encodeURIComponent(pluginId)}/run`, { command: 'host-monitor.swap-clear', args })
+
+  // 后台任务的进度。running 时每 2 秒问一次（比整块快照的 3 秒密一点：这是人盯着看的东西）
+  const [swapJob, setSwapJob] = useState<{ state: string; startSwap: number; swapUsed: number; err?: string } | null>(null)
+  useEffect(() => {
+    if (swapJob?.state !== 'running') return
+    let stop = false
+    const tick = async () => {
+      try {
+        const st = (await run({ status: '1' }))?.data ?? {}
+        if (stop) return
+        setSwapJob({ state: st.state || 'idle', startSwap: st.startSwap || 0, swapUsed: st.swapUsed || 0, err: st.err })
+        if (st.state === 'done') { message.success(t('plugins.monitor.swapCleared')); poll() }
+        if (st.state === 'failed') {
+          message.error(String(st.err).includes('need-sudo') ? t('plugins.monitor.swapNeedSudo') : (st.err || ''))
+        }
+      } catch { /* 轮询失败就等下一轮 */ }
+    }
+    const timer = setInterval(tick, 2000)
+    tick()
+    return () => { stop = true; clearInterval(timer) }
+  }, [swapJob?.state])
   const clearSwap = async () => {
     let plan: any
     try { plan = (await run({}))?.data ?? await run({}) } catch (e: any) { message.error(e.message); return }
@@ -169,9 +199,10 @@ export default function HostMonitorPanel({ pluginId, enabled, t, fetchSnapshot }
       okButtonProps: { danger: true },
       onOk: async () => {
         try {
-          await run({ apply: '1' })
-          message.success(t('plugins.monitor.swapCleared'))
-          poll()
+          // 只是把任务**起**起来：swapoff 读回 7 GB 要几十秒到几分钟，等在请求里的话
+          // 页面就一直转圈、超时、刷一下还不知道它在不在跑。这里立刻返回，进度靠轮询。
+          const st = (await run({ apply: '1' }))?.data ?? {}
+          setSwapJob({ state: st.state || 'running', startSwap: st.startSwap || plan.swapUsed, swapUsed: st.swapUsed || plan.swapUsed })
         } catch (e: any) {
           // 没开免密时给出那一行 sudoers，而不是干巴巴一句「失败」
           message.error(String(e.message).includes('need-sudo')
@@ -254,7 +285,7 @@ export default function HostMonitorPanel({ pluginId, enabled, t, fetchSnapshot }
               <Sparkline series={history.map((h) => h.mem)} color="var(--hl-title)" max={100} />
             </div>
           </Space>
-          {memory.swapTotal > 0 && <SwapBar used={memory.swapUsed} total={memory.swapTotal} t={t} onClear={fetchSnapshot ? undefined : clearSwap} />}
+          {memory.swapTotal > 0 && <SwapBar used={memory.swapUsed} total={memory.swapTotal} t={t} onClear={fetchSnapshot ? undefined : clearSwap} job={swapJob} />}
         </StatCard>
 
         {/* GPU */}

--- a/frontend/src/components/plugins/PluginsPanel.tsx
+++ b/frontend/src/components/plugins/PluginsPanel.tsx
@@ -121,8 +121,11 @@ export default function PluginsPanel({ initialId }: { initialId?: string } = {})
   if (loading) return <div style={{ padding: 48, textAlign: 'center' }}><Spin /></div>
 
   return (
-    <div style={{ display: 'flex', gap: 16, height: '100%', minHeight: 0 }}>
-      <Card size="small" style={isMobile ? { flex: 1, minWidth: 0, overflow: 'auto' } : { width: 300, flex: '0 0 300px', overflow: 'auto' }} title={t('plugins.title')}
+    // 两栏贴在一起、共用同一张底：这一页从前是「两张浮在页面上的卡片」，圆角 + 16px 缝 +
+    // 比页面亮一档的底，和会话工作区/镜像页那种「一整块，靠 1px 线断句」完全不是一套语言。
+    // 卡片本身留着（antd 的头/体布局还用得上），外观由 .tt-plugins 收平，见 index.css。
+    <div className="tt-plugins" style={{ display: 'flex', height: '100%', minHeight: 0 }}>
+      <Card size="small" className="tt-plugins-list" style={isMobile ? { flex: 1, minWidth: 0, overflow: 'auto' } : { width: 280, flex: '0 0 280px', overflow: 'auto' }} title={t('plugins.title')}
         extra={<Space size={4}>
           <Button size="small" type="primary" onClick={() => setInstallOpen(true)}>{t('plugins.install')}</Button>
           <Tooltip title={t('plugins.marketSoon')}>
@@ -139,9 +142,11 @@ export default function PluginsPanel({ initialId }: { initialId?: string } = {})
           renderItem={(p) => (
             <List.Item
               onClick={() => { setSelected(p.manifest.id); if (isMobile) setMobileDetail(true) }}
+              // 直角、通栏：一列 8px 圆角的小块贴在一整块底上，读起来像卡片里又摞了一叠卡片
               style={{
-                cursor: 'pointer', borderRadius: 'var(--r-sm)', padding: '8px 10px',
-                background: !isMobile && p.manifest.id === selected ? 'var(--bg-elevated, rgba(88,166,255,.12))' : undefined,
+                cursor: 'pointer', borderRadius: 0, padding: '8px 10px',
+                background: !isMobile && p.manifest.id === selected ? 'var(--list-hover)' : undefined,
+                boxShadow: !isMobile && p.manifest.id === selected ? 'inset 2px 0 0 var(--accent)' : undefined,
               }}
               actions={[<Switch key="sw" size="small" checked={p.enabled}
                 onClick={(v, e) => { e.stopPropagation(); toggle(p, v) }} />]}
@@ -157,7 +162,7 @@ export default function PluginsPanel({ initialId }: { initialId?: string } = {})
         />
       </Card>
       {!isMobile && (
-        <div style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
+        <div className="tt-plugins-detail" style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
           {current
             ? <PluginDetail key={current.manifest.id} plugin={current} locale={locale} t={t}
                 onChanged={() => { setSelected(''); reload() }} />

--- a/frontend/src/components/sessions/infra-session.ts
+++ b/frontend/src/components/sessions/infra-session.ts
@@ -1,0 +1,12 @@
+// `_ttmux-` 命名空间 = 基础设施会话，不是人开的活。
+//
+// 插件守护进程（_ttmux-plugind）、IM 监听（_ttmux-im）这些跑在真实 tmux 会话里，
+// 于是 /sessions 会照实列出来，侧栏的项目树里就冒出一条「_ttmux-plugind」挂在某个任务下面
+// ——它既不属于那个任务，人也不该点进去。CLI 早就按这个前缀过滤了（internal/app/app.go），
+// Web 这边一直没有。
+//
+// 判据放在前端而不是后端：后端那份列表还要用来做会话归属和状态统计，
+// 一刀切藏掉会把「蜂群会话不进 ls 导致项目编队恒 0」那类问题再演一遍。
+export function isInfraSession(name: string): boolean {
+  return name.startsWith('_ttmux-')
+}

--- a/frontend/src/components/shell/task-tree.test.ts
+++ b/frontend/src/components/shell/task-tree.test.ts
@@ -100,3 +100,15 @@ describe('buildTaskTree placement', () => {
     expect(tree.projects[0].tasks.map((t) => [t.path, t.main, t.sessions.map((s) => s.name)])).toEqual([['/x', true, ['s']]])
   })
 })
+
+// _ttmux- 是基础设施会话的命名空间（插件守护进程、IM 监听）。它们跑在真 tmux 会话里，
+// 于是会顺着 /sessions 混进项目树，挂在某个任务下面——既不属于那个任务，人也不该点进去。
+describe('基础设施会话不进树', () => {
+  it('_ttmux-plugind 既不进任务，也不进散会话', async () => {
+    const { isInfraSession } = await import('../sessions/infra-session')
+    expect(isInfraSession('_ttmux-plugind')).toBe(true)
+    expect(isInfraSession('_ttmux-im')).toBe(true)
+    expect(isInfraSession('roam优化')).toBe(false)
+    expect(isInfraSession('2026-0904-2359-abcd')).toBe(false)
+  })
+})

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1715,6 +1715,7 @@ const enUS = {
   'plugins.monitor.swapRefuse.wont-fit': 'Cannot clear: {used} swapped out but only {avail} available — reading it back would OOM',
   'plugins.monitor.swapRefuse.empty': 'Swap is empty, nothing to clear',
   'plugins.monitor.swapCleared': 'Cleared — everything in swap is back in RAM',
+  'plugins.monitor.swapRunning': 'Reading pages back… {left} left',
   'plugins.monitor.swapNeedSudo': 'Clearing swap needs root. Run once on this machine: sudo visudo -f /etc/sudoers.d/roam-swap and add: <your-user> ALL=(root) NOPASSWD: /usr/sbin/swapoff -a, /usr/sbin/swapon -a',
   'plugins.monitor.swapCritical': 'Swap is nearly exhausted — more pressure will hang the whole machine (ping still replies, SSH will not).',
   'plugins.monitor.gpu': 'GPU',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1720,6 +1720,7 @@ const zhCN = {
   'plugins.monitor.swapRefuse.wont-fit': '不能清：换出 {used}，可用只有 {avail}，读回来会直接 OOM',
   'plugins.monitor.swapRefuse.empty': 'swap 是空的，没什么可清',
   'plugins.monitor.swapCleared': '已清空，swap 里的页都读回内存了',
+  'plugins.monitor.swapRunning': '正在读回内存…还剩 {left}',
   'plugins.monitor.swapNeedSudo': '清 swap 要 root。先在这台机器上执行一次：sudo visudo -f /etc/sudoers.d/roam-swap，写入一行 <你的用户名> ALL=(root) NOPASSWD: /usr/sbin/swapoff -a, /usr/sbin/swapon -a',
   'plugins.monitor.swapCritical': '交换空间快用完了 —— 再吃内存整机会卡死到只能按电源键（ping 还通，ssh 进不来）',
   'plugins.monitor.gpu': 'GPU',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -528,6 +528,21 @@ html[data-pointer="coarse"] .tt-nav-collapse::after {
 }
 .tt-nav.rail .tt-nav-search { justify-content: center; width: 36px; margin: 0 auto var(--sp-2); padding: 0; border-radius: var(--r-xs); }
 
+/* ── 插件页：一整块，不是两张卡片（跟会话工作区/镜像页同一套语言）──
+   原来是两张 antd Card：圆角、投影、比页面亮一档的底，中间 16px 缝。五个页面里只有这一页
+   长这样。这里把卡片外观收平——直角、无边框、无投影、底色跟页面一致，两栏之间只留 1px 线。 */
+.tt-plugins { gap: 0; }
+.tt-plugins .ant-card {
+  border: 0; border-radius: 0; background: transparent; box-shadow: none;
+}
+.tt-plugins .ant-card-head {
+  border-radius: 0; background: transparent;
+  border-bottom: 1px solid var(--border-subtle);
+}
+/* 左栏靠一条竖线跟右栏断句；两栏同底，不再一亮一暗 */
+.tt-plugins > .tt-plugins-list { border-right: 1px solid var(--border-subtle); }
+.tt-plugins-detail > .ant-card > .ant-card-body { padding-inline: var(--sp-4); }
+
 /* ── 右栏三面板（22 设计 §3.4）：活动条 + 作用域头 + 文件 / Git / Worktree ── */
 .tt-ins { display: flex; flex-direction: column; flex: 1; min-height: 0; min-width: 0; }
 .tt-ins-acts { display: flex; align-items: center; gap: 2px; height: 40px; padding: 0 8px; border-bottom: 1px solid var(--border-subtle); flex: 0 0 auto; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1334,6 +1334,10 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
 .tt-page-files,
 .tt-page-phone,
 .tt-page-browser,
+/* 插件页也满高：不给的话它只有 min-height，里面那块 height:100% 落到 auto 上，
+   于是左右两栏的高度由内容决定——列表下面一空，中间那条竖线就断在半路（截图里它到
+   最后一个插件就没了）。线要到底，列就得先到底。 */
+.tt-page-plugins,
 /* 设置页自己管滚动：搜索框与分类树必须钉住，只有内容区可以动 */
 .tt-page-settings {
   height: 100%;
@@ -1359,6 +1363,7 @@ html[data-pointer="coarse"] .tt-srow .acts { opacity: 1; }
 .tt-page-files > *,
 .tt-page-phone > *,
 .tt-page-browser > *,
+.tt-page-plugins > *,
 .tt-page-settings > * {
   height: 100%;
   min-height: 0;

--- a/plugins/hostmonitor/hostmonitor.go
+++ b/plugins/hostmonitor/hostmonitor.go
@@ -29,6 +29,8 @@ func Activate(ctx *sdk.Ctx) sdk.Plugin {
 		Commands: map[string]sdk.CommandHandler{
 			"stats":      stats,
 			"swap-clear": swapClear,
+			// 后台任务本体:由 swap-clear 起的脱离子进程调用,同步跑完 swapoff+swapon
+			"swap-cycle": swapCycle,
 		},
 	}
 }

--- a/plugins/hostmonitor/register.go
+++ b/plugins/hostmonitor/register.go
@@ -31,6 +31,7 @@ func Manifest() manifest.Manifest {
 			Commands: []manifest.CommandContrib{
 				{ID: "host-monitor.stats", Title: manifest.LocaleText{"zh-CN": "采集一次资源快照(含近期趋势)", "en-US": "Take a resource snapshot (with recent trend)"}},
 				{ID: "host-monitor.swap-clear", Title: manifest.LocaleText{"zh-CN": "把换出去的页读回内存(swapoff -a && swapon -a)", "en-US": "Read swapped-out pages back into RAM (swapoff -a && swapon -a)"}},
+				{ID: "host-monitor.swap-cycle", Title: manifest.LocaleText{"zh-CN": "读回内存(后台任务本体,由上一条派生)", "en-US": "Read pages back (the background job itself, spawned by swap-clear)"}},
 			},
 			StatusItems: statusItems(),
 		},

--- a/plugins/hostmonitor/swap.go
+++ b/plugins/hostmonitor/swap.go
@@ -1,10 +1,14 @@
 package hostmonitor
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"ttmux-cli-go/pkg/plugin/sdk"
 )
@@ -49,11 +53,114 @@ func planSwapClear(swapUsed, memAvailable uint64) SwapPlan {
 	return p
 }
 
+// ── 后台任务 ──────────────────────────────────────────────────────────────
+//
+// swapoff 把 7 GB 换出去的页读回内存要好几十秒到几分钟,而 `plugin run` 是一次性
+// 进程、请求要一直挂着等它——页面转圈、超时、刷新一下就不知道还在不在跑。
+// 所以拆成两段:apply 只**起一个脱离的子进程**就返回,状态写进 StorageDir;
+// 页面轮询 status 看进度(swap 还剩多少)。
+//
+// 子进程跑的是这个插件自己的 swap-cycle 命令(`ttmux plugin run host-monitor.swap-cycle`),
+// 不是 `sh -c "swapoff -a && swapon -a"`:后者要往权限白名单里塞一个 shell,
+// 而白名单上现在只有 swapoff / swapon 两条,这是它值钱的地方。
+// swapoff 与 swapon 的先后顺序由那个子进程自己保证——它会一直活到两条都跑完,
+// 哪怕点完就关页面。
+
+const swapJobFile = "swap-clear.json"
+
+// swapJob 是后台任务的状态,落在 StorageDir(插件进程一次性,跨调用只能靠文件)。
+type swapJob struct {
+	PID       int    `json:"pid"`
+	StartedAt int64  `json:"startedAt"` // Unix 秒
+	StartSwap uint64 `json:"startSwap"` // 起步时换出去多少,用来算进度
+	Finished  bool   `json:"finished"`  // 子进程写:两条命令都跑完了
+	Err       string `json:"err,omitempty"`
+}
+
+// SwapStatus 是 status=1 的返回:页面据此画进度条和结果。
+type SwapStatus struct {
+	State     string `json:"state"` // idle | running | done | failed
+	StartSwap uint64 `json:"startSwap"`
+	SwapUsed  uint64 `json:"swapUsed"` // 此刻还剩多少没读回来
+	Available uint64 `json:"available"`
+	ElapsedMs int64  `json:"elapsedMs"`
+	Err       string `json:"err,omitempty"`
+}
+
+func jobPath(ctx *sdk.Ctx) string { return filepath.Join(ctx.StorageDir, swapJobFile) }
+
+func readJob(ctx *sdk.Ctx) swapJob {
+	var j swapJob
+	b, err := os.ReadFile(jobPath(ctx))
+	if err != nil {
+		return j
+	}
+	_ = json.Unmarshal(b, &j)
+	return j
+}
+
+func writeJob(ctx *sdk.Ctx, j swapJob) error {
+	if err := os.MkdirAll(ctx.StorageDir, 0o755); err != nil { // StorageDir 不保证已存在
+		return err
+	}
+	b, _ := json.Marshal(j)
+	return os.WriteFile(jobPath(ctx), b, 0o644)
+}
+
+// alive 判进程还在不在。信号 0 不真发信号,只做权限与存在性检查。
+func alive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid) // Unix 上这一步从不失败
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+func swapStatus(ctx *sdk.Ctx) (SwapStatus, error) {
+	mem, err := currentMem()
+	if err != nil {
+		return SwapStatus{}, err
+	}
+	j := readJob(ctx)
+	st := SwapStatus{State: "idle", StartSwap: j.StartSwap, SwapUsed: mem.SwapUsed, Available: mem.Available, Err: j.Err}
+	if j.StartedAt > 0 {
+		st.ElapsedMs = time.Since(time.Unix(j.StartedAt, 0)).Milliseconds()
+	}
+	switch {
+	case j.PID == 0:
+		return st, nil
+	case !j.Finished && alive(j.PID):
+		st.State = "running"
+	case j.Err != "":
+		st.State = "failed"
+	case j.Finished:
+		st.State = "done"
+	default:
+		// 进程没了、也没写完成标记:被杀了或者机器重启了。swap 是不是空的说了算。
+		st.State = "failed"
+		if mem.SwapUsed == 0 {
+			st.State = "done"
+		} else if st.Err == "" {
+			st.Err = "interrupted"
+		}
+	}
+	return st, nil
+}
+
 // swapClear 是 host-monitor.swap-clear 命令。
 //
-// dryRun(默认)只回判定,给确认框用;真干要显式 apply=1——**默认不动手**,因为这条
-// 命令的代价是不可撤销的(被 OOM 杀掉的进程回不来)。
+// 三种用法:
+//   - 不带参数 = 只回判定(给确认框用),**默认不动手**——这条命令的代价不可撤销
+//     (被 OOM 杀掉的进程回不来);
+//   - status=1 = 查后台任务进度;
+//   - apply=1  = 起后台任务,立刻返回。
 func swapClear(ctx *sdk.Ctx, args map[string]string) (any, error) {
+	if args["status"] == "1" {
+		return swapStatus(ctx)
+	}
 	mem, err := currentMem()
 	if err != nil {
 		return nil, err
@@ -65,17 +172,61 @@ func swapClear(ctx *sdk.Ctx, args map[string]string) (any, error) {
 	if !plan.OK {
 		return plan, fmt.Errorf("swap-clear refused: %s", plan.Reason)
 	}
-	if err := runSwapCycle(); err != nil {
+	if j := readJob(ctx); !j.Finished && alive(j.PID) {
+		return swapStatus(ctx) // 已经在跑了,别起第二个:两个 swapoff 抢同一块内存
+	}
+	pid, err := startSwapCycle()
+	if err != nil {
 		return plan, err
 	}
-	// 回读:不信退出码,看 /proc/meminfo 里 swap 是不是真的空了
-	after, err := currentMem()
-	if err != nil {
-		return plan, nil
+	if err := writeJob(ctx, swapJob{PID: pid, StartedAt: time.Now().Unix(), StartSwap: mem.SwapUsed}); err != nil {
+		return plan, err
 	}
-	plan.SwapUsed = after.SwapUsed
-	plan.Available = after.Available
-	return plan, nil
+	return SwapStatus{State: "running", StartSwap: mem.SwapUsed, SwapUsed: mem.SwapUsed, Available: mem.Available}, nil
+}
+
+// startSwapCycle 起一个**脱离**的子进程去跑 swap-cycle,返回它的 pid。
+// Setsid:插件进程马上就退出了,不脱离的话子进程会跟着一起走。
+func startSwapCycle() (int, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return 0, err
+	}
+	cmd := exec.Command(self, "plugin", "run", "host-monitor.swap-cycle")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	go func() { _ = cmd.Wait() }() // 不收尸的话这一小会儿里它是僵尸;本进程马上退出,收不到也无妨
+	return cmd.Process.Pid, nil
+}
+
+// swapCycle 是 host-monitor.swap-cycle:真正干活的那一段,同步跑完两条命令再写状态。
+// 它由 swapClear 起的子进程调用,自己就是那个「后台任务」——页面不等它。
+func swapCycle(ctx *sdk.Ctx, _ map[string]string) (any, error) {
+	j := readJob(ctx)
+	j.PID = os.Getpid()
+	if j.StartedAt == 0 {
+		j.StartedAt = time.Now().Unix()
+	}
+	if j.StartSwap == 0 {
+		if mem, err := currentMem(); err == nil {
+			j.StartSwap = mem.SwapUsed
+		}
+	}
+	_ = writeJob(ctx, j)
+
+	err := runSwapCycle()
+	j.Finished = true
+	if err != nil {
+		j.Err = err.Error()
+	}
+	_ = writeJob(ctx, j)
+	if err != nil {
+		return nil, err
+	}
+	return swapStatus(ctx)
 }
 
 // runSwapCycle 走 sudo -n。**不接口令**:插件进程没有终端,交互式 sudo 只会挂死;


### PR DESCRIPTION
## 清 swap 变成后台任务

`swapoff -a` 把 7 GB 换出去的页读回内存要几十秒到几分钟，而 `plugin run` 是一次性进程、
请求得一直挂着等它——页面转圈、超时，刷一下还不知道它在不在跑。

现在 `apply=1` 只**起一个脱离的子进程**就返回，状态写进 `StorageDir/swap-clear.json`；
页面每 2 秒问一次 `status=1`，swap 那一行的按钮变成「正在读回内存…还剩 3.1 GB」，跑完才报成功。

**为什么子进程跑的是插件自己的 `swap-cycle` 命令，而不是 `sh -c "swapoff -a && swapon -a"`**：
后者要往权限白名单里塞一个 shell，而那张表上现在只有 `sudo -n swapoff` / `sudo -n swapon` 两条 ——
这是它值钱的地方。两条命令的先后由那个子进程自己保证，它会一直活到都跑完，哪怕点完就关页面。

任务在跑时不给按钮：再点一次就是第二个 swapoff 抢同一块内存。进程被杀/机器重启导致状态文件
留下孤儿时，status 按「swap 是不是真的空了」判 done / failed，不看退出码。

## 插件页拆平成一整块

两张 antd Card（圆角、投影、比页面亮一档的底、中间 16px 缝）收成一整块：直角、无边框、同底，
两栏之间只留 1px 线；左边列表行也从 8px 圆角小块改成通栏直角，选中态换成 1px 强调色竖条。
五个页面里只有这一页长得像「卡片摞卡片」。

## 顺带

`FileWorkspace` 那条拖拽测试改成按当前实际宽度取起点。默认宽度上一版从 280 调到 240，
写死 `360` 的断言测的其实是「默认值有没有被改」，不是「拖动跟不跟手」。

## 验证

`scripts/dev/quality/check.sh full` 通过（含 `roam-plugins/hostmonitor` 的 Go 测试），
412 项前端测试通过。

> 后台任务没在真的满 swap 上按过——这台机器现在 swap 7.3 GB 满着，真按下去就是把 7 GB
> 读回内存，而正在跑的 agent 就是我自己。状态机（running / done / failed / 孤儿）是照着
> 文件状态和 `/proc/meminfo` 写的，但真机确认还欠着。你哪天想清的时候点一次，我盯着日志。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW

---

## 追加两条

**插件页那条竖线断在半路**：插件页没拿到「满高」那条规则（文件/浏览器/手机/设置都有），
只有 `min-height`，里面那块 `height:100%` 落到 auto 上——左右两栏的高度于是由内容决定，
列表下面一空，中间那条线就停在最后一个插件那儿。列到底，线才能到底。

**`_ttmux-plugind` 挂在任务下面**：`_ttmux-` 是基础设施会话的命名空间（插件守护进程、IM 监听），
它们跑在真 tmux 会话里，于是顺着 `/sessions` 混进项目树，挂在某个任务下面——既不属于那个任务，
人也不该点进去。CLI 早按这个前缀过滤了（`internal/app/app.go:192`），Web 这边一直没有。
过滤放在前端拉完列表那一步：后端那份列表还要做会话归属和状态统计，在后端一刀切藏掉，
会把「蜂群会话不进 ls 导致项目编队恒 0」那类问题再演一遍。