### PR TITLE
fix(shell): 选中底改中性；外壳三条与侧栏同底；树里不再画分支；_ttmux-* 滤干净

### DIFF
--- a/frontend/src/components/plugins/PluginsPanel.tsx
+++ b/frontend/src/components/plugins/PluginsPanel.tsx
@@ -145,7 +145,7 @@ export default function PluginsPanel({ initialId }: { initialId?: string } = {})
               // 直角、通栏：一列 8px 圆角的小块贴在一整块底上，读起来像卡片里又摞了一叠卡片
               style={{
                 cursor: 'pointer', borderRadius: 0, padding: '8px 10px',
-                background: !isMobile && p.manifest.id === selected ? 'var(--list-hover)' : undefined,
+                background: !isMobile && p.manifest.id === selected ? 'var(--sel-bg)' : undefined,
                 boxShadow: !isMobile && p.manifest.id === selected ? 'inset 2px 0 0 var(--accent)' : undefined,
               }}
               actions={[<Switch key="sw" size="small" checked={p.enabled}

--- a/frontend/src/components/shell/ProjectTree.tsx
+++ b/frontend/src/components/shell/ProjectTree.tsx
@@ -13,7 +13,6 @@ import { Dropdown, Tooltip } from 'antd'
 import { useI18n } from '../../i18n'
 
 import { AgentLogo, ArchiveIcon, ChevronDown, CloseIcon, HomeIcon, MoreIcon, OpenInIcon, PencilIcon, PlusIcon, TerminalIcon, TrashIcon, WorktreeIcon } from '../../icons'
-import { WtStatusIcon } from '../git/parts'
 import { icoOf } from '../projects/project-list/project-model'
 import { isLooseTask, taskKeyOf, type TaskKey } from '../sessions/task-key'
 import type { TaskTree, TreeSession, TreeTask } from './task-tree'
@@ -114,11 +113,11 @@ export function ProjectTree({ tree, activeTask, activeSession, onProject, onTask
     </Dropdown>
   )
 
-  // 头行右端一枚分支状态图标（照 Orca 卡片右上角那枚 PR 标）：分支名不再单独占一行——底部状态条已经有；
-  // 颜色说状态：已合入 = 绿，有未合入提交 = 蓝，有未提交改动 = 黄，干净 = 灰；悬停看分支和数字，点开是 PR 卡
-  const wtStatus = (task: TreeTask) => task.branch
-    ? <WtStatusIcon branch={task.branch} dir={task.path} merged={task.merged} dirty={task.dirty} ahead={task.ahead} behind={task.behind} pushed={task.pushed} />
-    : null
+  // 分支不在这棵树里出现。
+  //
+  // 这一栏回答的是「我有哪些活、开在哪」，分支是那件活的实现细节：一枚谁也说不清含义的
+  // ⑂ 挂在每个任务后面，只是把本来就窄的行再挤掉 20px。真要看分支状态，底部状态条上有一格，
+  // 右栏的 Git 面板里更全。
 
   // 任务卡的头行：状态点 + 任务名 + 徽标 + 分支状态图标。活着的任务和空闲 worktree 共用，只差徽标写什么
   const taskHead = (task: TreeTask, badge: ReactNode, on: boolean) => (
@@ -129,7 +128,6 @@ export function ProjectTree({ tree, activeTask, activeSession, onProject, onTask
         <span className="ic">{dot({ running: task.sessions.some((s) => s.running), waiting: task.sessions.some((s) => s.waiting), unfinished: task.unfinished }, true)}</span>
         <span className="nm">{task.name}</span>
         {badge}
-        {wtStatus(task)}
       </button>
     </Dropdown>
   )
@@ -161,7 +159,6 @@ export function ProjectTree({ tree, activeTask, activeSession, onProject, onTask
         <span className="nm">{s.label}</span>
         {task.unfinished && taskBadge(task)}
         {s.dormant ? <span className="bd">{t('tree.dormant')}</span> : dot(s, false)}
-        {wtStatus(task)}
         {!s.dormant && s.at ? <span className="tm">{ago(s.at, t)}</span> : null}
       </button>
     </Dropdown>

--- a/frontend/src/components/shell/task-tree.ts
+++ b/frontend/src/components/shell/task-tree.ts
@@ -5,6 +5,7 @@
 //   /git/worktrees?dir=  每个 git 项目的 worktree 与挂在上面的会话
 //   /sessions            全部会话（散会话从这里来：不在任何 worktree 上的）
 // 纯函数：App 把三份数据拿到手后 useMemo 一次，数据没变就不重算。
+import { isInfraSession } from '../sessions/infra-session'
 import { taskKeyOf, type TaskKey } from '../sessions/task-key'
 
 export type TreeSession = {
@@ -92,12 +93,14 @@ export function buildTaskTree(o: {
   const projects: TreeProject[] = o.projects.map((p) => {
     const tasks: TreeTask[] = []
     for (const wt of o.worktrees[p.key] || []) {
-      const names = (wt.sessions || []).map((s) => s.session).filter(Boolean)
+      // worktree 带来的会话列表是**另一条来源**（不是 /sessions），基础设施会话得在这里
+      // 再滤一遍——上一版只滤了 /sessions，于是 _ttmux-plugind 照样从这条路挂进任务里。
+      const names = (wt.sessions || []).map((s) => s.session).filter((n) => n && !isInfraSession(n))
       // 主仓库检出：有会话才立卡（在仓库根目录开的 claude 也得归到项目下，不能丢进散会话）；
       // 没会话不立——它不是一个可收尾的任务位，每个项目都挂一张空的「main」只会碍事
       if (wt.isMain && names.length === 0) continue
       names.forEach((n) => placed.add(n))
-      for (const s of wt.sessions || []) if (s.dormant) put({ name: s.session, dormant: true })
+      for (const s of wt.sessions || []) if (s.dormant && !isInfraSession(s.session)) put({ name: s.session, dormant: true })
       const sessions = names.map(sess)
       const ahead = wt.committedAhead || 0
       tasks.push({

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,9 @@
   --accent-solid: #1f6feb;
   --accent-soft: rgba(31, 111, 235, .14);
   --accent-border: rgba(88, 166, 255, .45);
+  /* 选中行的底：中性提亮，不带色相（见 theme.tsx 的注释）。
+     --accent-soft 留给强调件（芯片/徽标/聚焦光晕），两者不再混用。 */
+  --sel-bg: rgba(255, 255, 255, .065);
   /* 成功/运行绿：全站也只有这一组（见 theme.tsx） */
   --ok: #3fb950;
   --ok-solid: #238636;
@@ -454,11 +457,14 @@ html[data-pointer="coarse"] .tt-devrow.acts > .tt-mode { padding-bottom: 58px; }
 .tt-nodemark.off { color: var(--text-dimmer); border-style: dashed; background: transparent; }
 /* 机器切换器：摆在底部这一组的第一位。底下几样都是「上下文与账户」，
    而它是其中作用域最大的一个——切它，上面整列页面看的都换一台机器。 */
+/* 切机器这一枚是**导航行**，不是一张卡片：它上面是项目树、下面是「设置 / 收起」，
+   一色扁平的行里夹一枚带底、比别人矮 4px、左右缩进也不一样的方框，看着就是没对齐。
+   现在跟 .tt-nav-item 同高（38）、同缩进（10）、同图标槽（11px gap）、同 hover 底。 */
 .tt-nav-node {
-  position: relative; display: flex; align-items: center; gap: 8px; width: 100%;
-  height: 34px; padding: 0 8px; margin-bottom: 4px;
-  border: 0; border-radius: var(--r-sm); background: var(--bg-elevated); color: var(--text-dim);
-  font-size: var(--fs-meta); text-align: left;
+  position: relative; display: flex; align-items: center; gap: 11px; width: 100%;
+  min-height: 38px; padding: 0 10px; margin-bottom: 4px;
+  border: 0; border-radius: var(--r-sm); background: none; color: var(--text-dim);
+  font-size: var(--fs-body); text-align: left;
 }
 .tt-nav-node .av { flex: 0 0 auto; display: grid; place-items: center; }
 .tt-nav-node .nm { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
@@ -466,14 +472,15 @@ html[data-pointer="coarse"] .tt-devrow.acts > .tt-mode { padding-bottom: 58px; }
 .tt-nav-node .dots { flex: 0 0 auto; display: grid; place-items: center; color: var(--text-dimmer); }
 :where(html[data-pointer="fine"]) .tt-nav-node:hover { background: var(--list-hover); color: var(--text-bright); }
 /* 轨态：只剩方章，状态点叠在右下角（外描底色免得糊在方章边上） */
-.tt-nav.rail .tt-nav-node { width: 34px; justify-content: center; padding: 0; margin: 0 auto 4px; }
+.tt-nav.rail .tt-nav-node { width: 36px; justify-content: center; padding: 0; margin: 0 auto 4px; }
 .tt-nav.rail .tt-nav-node .nd { position: absolute; right: 1px; bottom: 1px; box-shadow: 0 0 0 2px var(--bg-base); }
 /* 它和下面的设置/账户是一组，但作用域不同：给一条分隔线把它单独拎出来 */
 .tt-nav-node { margin-bottom: 6px; padding-bottom: 6px; }
 .tt-nav-foot .tt-nav-node { border-bottom: 1px solid var(--border-subtle); border-radius: var(--r-sm); }
 
-/* 选中态：3px 左强调线 + 低饱和蓝底。整块高亮会把注意力从内容上夺走（14 §4.4） */
-.tt-nav-item.on { background: var(--accent-soft); color: var(--text-bright); }
+/* 选中态：3px 左强调线 + 中性淡底。整块高亮会把注意力从内容上夺走（14 §4.4）；
+   底色也不该带色相——深底上 14% 的蓝糊成一块脏 navy，而「就是这一条」那条线已经说清了。 */
+.tt-nav-item.on { background: var(--sel-bg); color: var(--text-bright); }
 .tt-nav-item.on::before {
   content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%);
   width: 3px; height: 20px; border-radius: 0 3px 3px 0; background: var(--accent);
@@ -729,7 +736,7 @@ html[data-size="compact"] .tt-palette {
   border: 0; border-radius: var(--r-sm); background: transparent;
   color: var(--text-bright); cursor: pointer;
 }
-.tt-palette-row.on { background: var(--accent-soft); }
+.tt-palette-row.on { background: var(--sel-bg); }
 .tt-palette-row .ic { flex: 0 0 18px; display: grid; place-items: center; color: var(--text-dim); }
 .tt-palette-row.on .ic { color: var(--accent); }
 .tt-palette-row .tx { min-width: 0; flex: 1; }
@@ -839,7 +846,7 @@ html[data-size="compact"] .tt-pagedivider { display: none; }
    排下来高低错半档，比单个控件丑得多。 */
 .mc {
   flex: 0 0 auto;
-  background: var(--bg-container);
+  background: var(--bg-base);
   border-bottom: 1px solid var(--border);
   --ctl-h: 32px;
 }
@@ -1452,7 +1459,7 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
 }
 .tt-tabs::-webkit-scrollbar, .tt-tbar::-webkit-scrollbar { height: 0; width: 0; }
 .tt-tabs > *, .tt-tbar > * { flex: 0 0 auto; }
-.tt-tabs { gap: 0; padding: 0; background: var(--bg-container); border-bottom: 1px solid var(--border-subtle); }
+.tt-tabs { gap: 0; padding: 0; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle); }
 .tt-tbar { gap: 3px; padding: 5px 8px; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle); }
 
 /* 竖线断句：把「状态 / 会话动作 / 面板开关」隔开 */
@@ -1462,7 +1469,7 @@ html[data-size="compact"] .ant-form-item-control-input-content > .ant-picker { w
 /* 标签条外壳：左侧「收起」固定，标签区独立横滚，两侧溢出给渐隐（14 §7.1） */
 .tt-tabs-wrap {
   position: relative; display: flex; align-items: center; min-width: 0;
-  background: var(--bg-container); border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-base); border-bottom: 1px solid var(--border-subtle);
 }
 .tt-tabs-wrap > .tt-tabs { flex: 1 1 auto; min-width: 0; border-bottom: 0; }
 .tt-tabs-lead { flex: 0 0 auto; display: flex; align-items: center; padding: 0 0 0 8px; }
@@ -1501,7 +1508,9 @@ html[data-pointer="coarse"] .tt-tabs-nav::after { content: ''; position: absolut
   transition: background .12s, color .12s;
 }
 :where(html[data-pointer="fine"]) .tt-tab:hover { background: var(--list-hover); color: var(--text-bright); }
-.tt-tab.on { background: var(--bg-base); color: var(--text-bright); font-weight: 600;
+/* 外壳统一成一张底之后，选中的标签不能再靠「和下面内容同底」显形了——那时它和整条一样黑。
+   改成选中底 + 顶上那条 accent 线：跟侧栏选中行是同一套语言（中性底 + 一条强调线）。 */
+.tt-tab.on { background: var(--sel-bg); color: var(--text-bright); font-weight: 600;
   box-shadow: inset 0 2px 0 var(--accent); }
 .tt-tab .tt-wait { flex: 0 0 auto; color: var(--warn); font-weight: 600; }
 /* 会话拖到标签上（21 设计）：落点亮成实心强调边。跟标签重排那条 .dropL
@@ -1784,7 +1793,7 @@ html[data-pointer="coarse"] .tt-send::after { content: ''; position: absolute; l
 .cc-filerow { border-radius: 6px; margin: 1px 4px; }
 :where(html[data-pointer="fine"]) .cc-filerow:hover { background: rgba(88, 166, 255, .08); }
 /* 右键菜单打开期间保持目标行高亮；状态留在菜单组件内，避免重渲染整棵文件列表。 */
-.tt-file-context-open > .cc-filerow { background: var(--accent-soft); }
+.tt-file-context-open > .cc-filerow { background: var(--sel-bg); }
 /* 手动控制的右键菜单不要被整行触发器拉伸到文件抽屉宽度。 */
 .tt-file-context-menu { width: max-content !important; min-width: 130px !important; }
 /* Git 分组标题上的操作按钮：平时半透明，hover 分组时变实 */
@@ -3115,7 +3124,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
 }
 .tt-set-tree .row.kid, .tt-set-tree .row.solo { padding-left: 28px; }
 :where(html[data-pointer="fine"]) .tt-set-tree .row:hover { background: var(--list-hover); color: var(--text-bright); }
-.tt-set-tree .row.on { background: var(--accent-soft); color: var(--accent); font-weight: 500; }
+.tt-set-tree .row.on { background: var(--sel-bg); color: var(--accent); font-weight: 500; }
 .tt-set-tree .row.dim { opacity: .35; }
 .tt-set-tree .row .cv { flex: 0 0 12px; color: var(--text-dimmer); transition: transform .12s; }
 .tt-set-tree .row .n {
@@ -3201,7 +3210,7 @@ html[data-size="compact"] .cc-run-slot { width: auto; }
   flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   color: var(--text-dim);
 }
-.tt-nodemenu.on { background: var(--accent-soft); }
+.tt-nodemenu.on { background: var(--sel-bg); }
 .tt-nodemenu.on .nm { color: var(--text-bright); font-weight: 500; }
 .tt-nodemenu .lat {
   flex: 0 0 auto; font-family: var(--mono); font-size: var(--fs-micro); color: var(--text-dimmer);
@@ -3365,7 +3374,7 @@ html[data-size="compact"] .tt-histname { flex: 1 1 auto; max-width: none; }
   display: flex; align-items: stretch;
   height: calc(var(--status-h) + var(--safe-b));
   padding-bottom: var(--safe-b);
-  background: var(--bg-container);
+  background: var(--bg-base);
   border-top: 1px solid var(--border-subtle);
   font-size: var(--fs-meta); color: var(--text-dim);
   overflow: hidden; user-select: none;

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -41,11 +41,14 @@ export const THEME_TOKENS: Record<ThemeMode, ThemeTokens> = {
       // 强调色只有这一组，别再往组件里写死蓝色十六进制（见下面 buildTheme 的注释）：
       //   --accent       线 / 图标 / 链接（浅蓝，压在深底上够亮）
       //   --accent-solid 实心块：主按钮、Segmented 选中、徽标（深蓝，白字够对比）
-      //   --accent-soft  淡底：选中行、当前导航项
+      //   --accent-soft  淡底：强调件（芯片、徽标、聚焦光晕）——**不是**选中行
+      // 选中行走 --sel-bg：中性提亮，不带色相。深底上一层 14% 的蓝糊成一块脏navy，
+      // 而选中这件事本来就不该靠颜色喊——左边那条 3px accent 线已经说清了「就是这一条」。
       '--accent': '#58a6ff',
       '--accent-solid': '#1f6feb',
       '--accent-soft': 'rgba(31, 111, 235, .14)',
       '--accent-border': 'rgba(88, 166, 255, .45)',
+      '--sel-bg': 'rgba(255, 255, 255, .065)',
       // 成功/运行绿也只有这一组，同理别写死：--ok 线/文字（含 diff 的 +），
       // --ok-solid 实心块，--ok-soft 淡底，--ok-border 描边
       '--ok': '#3fb950',
@@ -102,6 +105,7 @@ export const THEME_TOKENS: Record<ThemeMode, ThemeTokens> = {
       '--accent': '#0969da',
       '--accent-solid': '#1f6feb',
       '--accent-soft': 'rgba(31, 111, 235, .10)',
+      '--sel-bg': 'rgba(27, 31, 36, .055)',
       '--accent-border': 'rgba(31, 111, 235, .40)',
       '--ok': '#1a7f37',
       '--ok-solid': '#1f883d',


### PR DESCRIPTION
## 选中底不再是一块脏 navy

新开一档 `--sel-bg`（中性提亮：深色 6.5% 白 / 浅色 5.5% 黑）。导航项、⌘K 结果行、设置树、
机器菜单、插件列表都换过去。原来一律用 `--accent-soft` —— 深底上一层 14% 的蓝糊成一块脏 navy，
而「就是这一条」本来就该由左边那条 3px accent 线说，不该靠底色喊。
`--accent-soft` 从此只留给强调件（芯片、徽标、聚焦光晕），两件事不再共用一个令牌。

## 外壳三条与侧栏同底

标签条、状态条、镜像工具行原来是 `--bg-container` (#161b22)，侧栏是 `--bg-base` (#0d1117)，
两者挨着就是一道说不清的分界。三条全换成 `--bg-base`，靠 1px 线断句。

选中的标签因此不能再靠「和下面内容同底」显形（那时它跟整条一样黑），改成 `--sel-bg` +
顶上那条 accent 线 —— 跟侧栏选中行同一套语言。

实测：侧栏 / 标签条 / 状态条现在都是 `rgb(13,17,23)`，选中底 `rgba(255,255,255,.067)`。

## 树里不再画分支

这一栏回答的是「我有哪些活、开在哪」，分支是那件活的实现细节。一枚谁也说不清含义的 ⑂
挂在每个任务后面，只是把本就窄的行再挤掉 20px。分支状态底部状态条有一格，右栏 Git 面板里更全。

## _ttmux-plugind 还在树里

上一版（#238）只滤了 `/sessions`，而 worktree 那份会话列表是**另一条来源**，基础设施会话
照样从那条路挂进任务。两处都滤了，真机确认树里已经没有它。

## 切机器那一枚

它是导航行不是卡片——上面是项目树、下面是「设置 / 收起」，一色扁平的行里夹一枚带底、
矮 4px、缩进也不同的方框，看着就是没对齐。现在跟 `.tt-nav-item` 同高（38）、同缩进（10）、
同 hover 底。

> 这一条没能在真机上验：本机是单机，机器切换器只有接了中心/多节点才出现。CSS 改的是同一枚
> `.tt-nav-node`，但「看起来对齐了」还得等有多机的环境。

`scripts/dev/quality/check.sh full` 通过，412 项前端测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPWNAispKbdHuzKrn8MibW