### PR TITLE
feat(terminal): 会话工具条加语音输入，终端视图也能按住说话

### DIFF
--- a/frontend/src/components/chat/VoiceInput.tsx
+++ b/frontend/src/components/chat/VoiceInput.tsx
@@ -13,7 +13,11 @@ const CANCEL_DY = 90
 // 录音时长下限：太短的误触不送去识别。
 const MIN_MS = 500
 
-export function VoiceInput({ accent, onResult, inline = false }: { accent: string; onResult: (text: string) => void; inline?: boolean }) {
+/**
+ * 三种形态：悬浮（默认，右下角圆钮，手机用）/ inline（composer 控制条上的 pill）/
+ * toolbar（会话工具条上的一枚扁平按钮，带「语音输入」字样——终端视图也能按住说话）。
+ */
+export function VoiceInput({ accent, onResult, inline = false, toolbar = false }: { accent: string; onResult: (text: string) => void; inline?: boolean; toolbar?: boolean }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
   // 录音能力探测：getUserMedia/MediaRecorder 仅在安全上下文(HTTPS / localhost)可用。
@@ -153,7 +157,7 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
       )}
       <button
         type="button"
-        className={inline ? `tt-pill ico tt-mic${active ? ' rec' : ''}` : undefined}
+        className={toolbar ? `tt-tbtn tt-mic${active ? ' rec' : ''}` : inline ? `tt-pill ico tt-mic${active ? ' rec' : ''}` : undefined}
         title={!micUsable ? micHint : configured ? t('voice.holdToTalk') : t('voice.notConfigured')}
         aria-label={t('voice.holdToTalk')}
         disabled={phase === 'transcribing'}
@@ -162,7 +166,7 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
         onPointerMove={(e) => move(e.clientY)}
         onPointerUp={(e) => { e.preventDefault(); end() }}
         onPointerCancel={() => { cancelRef.current = true; end() }}
-        style={inline
+        style={toolbar ? { touchAction: 'none' } : inline
           // 内联：控制条上的一枚 pill——静息时安静，按住说话才亮成强调色（.tt-mic.rec）。
           // 从前它静息就是一整块实心强调色，跟旁边那颗实心发送键抢，一条控制条两个"主动作"。
           ? { background: cancelArmed ? 'var(--danger)' : undefined, touchAction: 'none' }
@@ -179,8 +183,9 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
             opacity: (configured && micUsable) ? 1 : 0.92,
           }}>
         <span className={(phase === 'recording' || phase === 'transcribing') ? 'cc-pulse' : undefined} style={{ display: 'inline-flex' }}>
-          <MicIcon size={inline ? 15 : 26} silver={!inline || active} />
+          <MicIcon size={toolbar ? 14 : inline ? 15 : 26} silver={!(inline || toolbar) || active} />
         </span>
+        {toolbar && <span>{t('voice.input')}</span>}
       </button>
     </>
   )

--- a/frontend/src/components/terminal/TerminalPane.tsx
+++ b/frontend/src/components/terminal/TerminalPane.tsx
@@ -896,6 +896,11 @@ export default function TerminalPane(props: {
       {/* 「新标签」进了标签右键菜单（标签条上已有「新建」）；文件 / Git 归右栏活动条；
           语音归 composer——22 设计 §3.3 去掉的四枚。独立页（左停靠）没有右栏，文件 / Git 仍在这 */}
       {active && <TBtn icon={TI.rename} label={t('session.rename')} title={t('session.renameTitle')} onClick={() => setRenameSession(active)} />}
+      {/* 终端视图的话筒：识别结果填到命令行上，回车才发（同 /type 的约定）。对话视图的话筒在 composer 里，不重复。
+          不看 showVoiceButton：那个开关管的是手机上的悬浮圆钮；工具条这枚和 composer 里那枚一样常在 */}
+      {active && !inChat && !isPhone && (
+        <VoiceInput toolbar accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(active)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
+      )}
       <span className="tt-sep" />
       <TBtn icon={promptOff ? TI.bellOff : TI.bellOn} label={t('prompt.popup')} on={!promptOff}
         title={promptOff ? t('prompt.popupOff') : t('prompt.popupOn')} onClick={togglePromptOff} />
@@ -1001,7 +1006,8 @@ export default function TerminalPane(props: {
                 <CodexChat name={termName} file={codexMap[termName].file} onOpenFile={openFileFromChat} onOpenGit={openGitFromChat} active={termName === active && !curFile} />
               </div>
             )}
-            {showVoice && !claudeView[termName] && !codexView[termName] && (
+            {/* 悬浮话筒只留给手机：桌面的在工具条上（重命名旁边） */}
+            {showVoice && isPhone && !claudeView[termName] && !codexView[termName] && (
               <VoiceInput accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(termName)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
             )}
           </div>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1317,7 +1317,7 @@ const enUS = {
   'voice.failed': 'Speech recognition failed: {message}',
 
   'settings.speech': 'Voice input',
-  'settings.speechHelp': 'Configure a speech recognition service, then hold the mic at the bottom-right of a session',
+  'settings.speechHelp': 'Configure a speech recognition service; hold the mic on the session toolbar or in the composer (bottom-right on phones)',
   'settings.speechProvider': 'Service',
   'settings.speechProviderNone': 'Off',
   'settings.speechApiKey': 'API Key',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1319,7 +1319,7 @@ const zhCN = {
   'voice.failed': '语音识别失败：{message}',
 
   'settings.speech': '语音输入',
-  'settings.speechHelp': '配置语音识别服务，会话页右下角即可长按说话',
+  'settings.speechHelp': '配置语音识别服务；会话工具条与输入框上的话筒按住说话，手机在右下角',
   'settings.speechProvider': '识别服务',
   'settings.speechProviderNone': '关闭',
   'settings.speechApiKey': 'API Key',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -666,7 +666,8 @@ html[data-pointer="coarse"] .tt-csearch-line, html[data-pointer="coarse"] .tt-cs
 .tt-tree-row.dormant .ic, .tt-tree-row.dormant .nm { opacity: .55; }
 .tt-tree-sessions .tt-tree-row.on .nm { color: var(--text-bright); }
 :where(html[data-pointer="fine"]) .tt-tree-sessions .tt-tree-row:hover .nm { color: var(--text-bright); }
-.tt-tree-sessions .tt-tree-row .tm { flex: 0 0 auto; margin-left: 0; color: var(--text-dimmer); font: 400 var(--fs-micro)/1 var(--mono); }
+/* 行尾时间在会话行和单会话任务卡头行都出现：不许收缩、不许折行——名字一长「刚刚」会被挤成竖排两个字 */
+.tt-tree-row .tm { flex: 0 0 auto; white-space: nowrap; margin-left: 0; color: var(--text-dimmer); font: 400 var(--fs-micro)/1 var(--mono); }
 .tt-tree-sessions .tt-tree-row .nm + .dot { margin-left: 0; }
 /* 收起：一枚「✳ +N ›」小药丸，点了展开 */
 .tt-tree-more { display: inline-flex; align-items: center; gap: 5px; margin: 2px 0 0 30px; height: 24px; padding: 0 8px; border-radius: var(--r-pill); border: 1px solid var(--border-subtle); background: var(--bg-elevated); color: var(--text-dim); font-size: var(--fs-meta); }


### PR DESCRIPTION
## 这个 PR 做了什么

会话工具条「重命名」旁边加一枚「语音输入」：终端视图里也能按住说话，识别结果走 `/sessions/:name/type` 填到命令行上，回车才发。

- `VoiceInput` 加 `toolbar` 形态（扁平按钮 + 文字，按住时亮成强调色），与 composer 里那枚共用同一套录音 / 识别逻辑。
- 只在终端视图出现：对话视图的话筒在 composer 里，不重复。
- 不受「显示语音按钮」偏好影响：那个开关管的是手机上的悬浮圆钮，桌面上从来没见过它（用户这台默认关着）。桌面的悬浮话筒撤掉，只留给手机。
- 语音设置页说明文案改成「工具条 / 输入框上的话筒」。

## 怎么验

- `typecheck / i18n:check / hover:check / vitest(413)` 过，`build-roam.sh` 全绿。
- 130.55 已装上：终端视图工具条见「语音输入」，按住说话松开后文字落在命令行上；切到对话视图它消失、composer 的话筒照旧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BytNuq5C9U5TEjPkYjbiWV
