### PR TITLE
perf(shell): 左栏树刷新即出——上一轮原料存本地，项目行不等 worktree

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import { GlobalSearch, openPalette, type PaletteActions, type PaletteItem } from
 import { ProjectTree, firstSessionOf, taskPathOf } from './components/shell/ProjectTree'
 import { InspectorPanels, type InspectorPanelKind } from './components/shell/InspectorPanels'
 import { buildTaskTree, type TreeTask } from './components/shell/task-tree'
+import { loadTreeSrc, saveTreeSrc, type TreeSrc } from './components/shell/task-tree-snapshot'
 import { useSessionCloser } from './components/sessions/session-closer'
 import { isInfraSession } from './components/sessions/infra-session'
 import { taskKeyOf, isLooseTask, looseSessionOf, type TaskKey } from './components/sessions/task-key'
@@ -227,8 +228,9 @@ export default function App() {
   }
   // 点会话标签 = 文件标签让位
   const activateSession = (n: string) => { setActive(n); setActiveFile('') }
-  // 左栏树的三份原料（22 设计 §3.2）：/projects 与每项目的 worktree 挂在下面那条 15s 轮询上，/sessions 挂 5s 那条
-  const [treeSrc, setTreeSrc] = useState<{ projects: any[]; worktrees: Record<string, any[]> }>({ projects: [], worktrees: {} })
+  // 左栏树的三份原料（22 设计 §3.2）：/projects 与每项目的 worktree 挂在下面那条 15s 轮询上，/sessions 挂 5s 那条。
+  // 初值取上一轮的本地快照：worktree 那一趟要 1~2s，等它就等于每次刷新都从空树长一遍（见 task-tree-snapshot）
+  const [treeSrc, setTreeSrc] = useState<TreeSrc>(() => loadTreeSrc())
   // 建了新会话就立刻把会话表 / 归属表 / worktree 都刷一遍，不等下一轮（分别 5s / 15s / 60s）
   const sessReload = useRef<(() => void) | null>(null)
   const treeReload = useRef<(() => void) | null>(null)
@@ -344,6 +346,8 @@ export default function App() {
         const swarms = Array.isArray(sw) ? sw : sw?.data || []
         setSwarmCount(swarms.filter((x: any) => x?.status && x.status !== 'archived').length)
         void loadGit()
+        // 项目行先画出来（/projects 是台账，几毫秒就回来）；worktree 慢，别让它压着项目一起等
+        if (hasSider) setTreeSrc((cur) => ({ ...cur, projects }))
         // 左栏树要每个 git 项目的 worktree。后端每个 worktree 要跑十来条 git 命令，
         // 八个项目并发着 15s 一轮会把机器打满（实测 CPU 60%、温度报警），所以：
         // 串行、60s 一轮、项目列表照旧 15s 刷；手机没有树，不拉
@@ -354,11 +358,14 @@ export default function App() {
             if (stop) return
             try { worktrees[p.key] = (await api('GET', `/git/worktrees?dir=${encodeURIComponent(p.dir)}`))?.data || [] }
             catch { worktrees[p.key] = [] }
+            if (stop) return
+            // 到一个画一个：串行扫完要 1~2s，攒到最后一起 set 等于整棵树在那儿干等
+            setTreeSrc((cur) => ({ projects, worktrees: { ...cur.worktrees, [p.key]: worktrees[p.key] } }))
           }
           if (stop) return
+          // 扫完整份替换：这一轮没见到的项目（删了/不再是 git）连同快照里的残留一起清掉
           setTreeSrc({ projects, worktrees })
-        } else if (hasSider) {
-          setTreeSrc((cur) => ({ ...cur, projects }))
+          saveTreeSrc({ projects, worktrees })
         }
       } catch { /* 轮询失败就保持上一轮的值，不清空 */ }
     }
@@ -567,7 +574,9 @@ export default function App() {
     projects: treeSrc.projects, worktrees: treeSrc.worktrees, sessions: sessList, placement: projTable,
     nameOf: (p) => prefs.taskNames?.[p] || undefined,
     agentOf: (n) => (claudeMap[n]?.running ? 'claude' : codexMap[n]?.running ? 'codex' : undefined),
-  }), [treeSrc, sessList, claudeMap, codexMap, projTable, prefs.taskNames])
+    // 会话表一到就以它为准：快照/60s 的 worktree 名单里那些已经关掉的会话不该还挂在树上
+    sessionsLoaded: !!sessIds,
+  }), [treeSrc, sessList, claudeMap, codexMap, projTable, prefs.taskNames, sessIds])
   treeRef.current = tree
 
   // hash 路由：URL #/xxx 与当前页同步（支持前进/后退、刷新保持、收藏分享）

--- a/frontend/src/components/shell/task-tree-snapshot.test.ts
+++ b/frontend/src/components/shell/task-tree-snapshot.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { loadTreeSrc, saveTreeSrc } from './task-tree-snapshot'
+
+const src = { projects: [{ key: 'roam', name: 'Roam', dir: '/w/Roam', git: true }], worktrees: { roam: [{ path: '/w/Roam', branch: 'main', isMain: true }] } }
+
+describe('项目树本地快照', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('存了就能原样拿回来', () => {
+    saveTreeSrc(src, 'n1')
+    expect(loadTreeSrc('n1')).toEqual(src)
+  })
+
+  it('每台机器各记各的：拿别的机器的槽是空树', () => {
+    saveTreeSrc(src, 'n1')
+    expect(loadTreeSrc('n2')).toEqual({ projects: [], worktrees: {} })
+    expect(loadTreeSrc(null)).toEqual({ projects: [], worktrees: {} })
+  })
+
+  it('隔了一天的快照不再顶上', () => {
+    saveTreeSrc(src, 'n1')
+    const all = JSON.parse(localStorage.getItem('roam.tree') || '{}')
+    all.n1.at = Date.now() - 25 * 3600 * 1000
+    localStorage.setItem('roam.tree', JSON.stringify(all))
+    expect(loadTreeSrc('n1')).toEqual({ projects: [], worktrees: {} })
+  })
+
+  it('存坏了当没存过，不该崩', () => {
+    localStorage.setItem('roam.tree', '{ not json')
+    expect(loadTreeSrc('n1')).toEqual({ projects: [], worktrees: {} })
+  })
+
+  it('机器多了按最后使用时间淘汰，刚写的那台一定留着', () => {
+    for (const id of ['a', 'b', 'c', 'd', 'e']) saveTreeSrc(src, id)
+    const kept = Object.keys(JSON.parse(localStorage.getItem('roam.tree') || '{}'))
+    expect(kept).toContain('e')
+    expect(kept.length).toBe(4)
+  })
+})

--- a/frontend/src/components/shell/task-tree-snapshot.ts
+++ b/frontend/src/components/shell/task-tree-snapshot.ts
@@ -1,0 +1,56 @@
+// 左栏项目树的本地快照：刷新后第一帧就能把树画出来。
+//
+// 树的原料要两步才齐：/projects（几毫秒）+ 每个 git 项目一条 /git/worktrees。后者在后端
+// 每个 worktree 要跑十来条 git 命令，串行扫十几个项目实测 1.5~2s（冷盘更久）——这段时间里
+// 树是空的，会话全挤在「散会话」下面，等 worktree 到了再整棵跳一次。台账早就在库里了，
+// 用户看到的却是每次刷新都重新长出来一遍。
+//
+// 所以把上一轮扫到的原料按机器存一份，下次进来先拿它画（AGENTS.md「Preferences Arrive
+// Late」那条同一个道理：看得见的东西，第一帧就得是对的）。服务端仍是唯一真相源，快照只
+// 负责这 1~2 秒的空窗；扫完照旧整份替换，所以项目没了、worktree 没了都会自己收敛。
+import { currentNodeId } from '../cluster/node-url'
+
+/** 树的两份服务端原料（第三份 /sessions 5s 一轮、自己就很快，不进快照） */
+export type TreeSrc = { projects: any[]; worktrees: Record<string, any[]> }
+
+const KEY = 'roam.tree'
+/** 最多记几台机器——和终端标签一样按最后使用时间淘汰 */
+const MAX_NODES = 4
+/** 过了这么久的快照不再顶上：隔了一天再回来，工作区大概已经不是那个样子了 */
+const MAX_AGE_MS = 24 * 3600 * 1000
+
+type Entry = TreeSrc & { at: number }
+
+/** 单机（没有 nodeId）也占一格，键是空串——单机与多机走同一条路径，不写分支 */
+function slot(nodeId: string | null): string {
+  return nodeId || ''
+}
+
+function readAll(): Record<string, Entry> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    const v = raw ? JSON.parse(raw) : null
+    return v && typeof v === 'object' && !Array.isArray(v) ? v : {}
+  } catch { return {} }
+}
+
+/** 上一轮的原料；没有 / 过期 / 存坏了都返回空树，调用方照旧等接口 */
+export function loadTreeSrc(nodeId: string | null = currentNodeId()): TreeSrc {
+  const e = readAll()[slot(nodeId)]
+  if (!e || !Array.isArray(e.projects) || Date.now() - (e.at || 0) > MAX_AGE_MS) return { projects: [], worktrees: {} }
+  return { projects: e.projects, worktrees: e.worktrees && typeof e.worktrees === 'object' ? e.worktrees : {} }
+}
+
+/** 一轮 worktree 扫完后存一份。只在扫完整存：半份快照会让下次刷新画出缺几个项目的树 */
+export function saveTreeSrc(src: TreeSrc, nodeId: string | null = currentNodeId()) {
+  const all = readAll()
+  const cur = slot(nodeId)
+  all[cur] = { projects: src.projects, worktrees: src.worktrees, at: Date.now() }
+  // 刚写的这台永远留着，只在**其余**里淘汰
+  const others = Object.keys(all).filter((k) => k !== cur)
+  if (others.length > MAX_NODES - 1) {
+    others.sort((a, b) => (all[b]?.at || 0) - (all[a]?.at || 0))
+    for (const k of others.slice(MAX_NODES - 1)) delete all[k]
+  }
+  try { localStorage.setItem(KEY, JSON.stringify(all)) } catch { /* 隐私模式/配额满：记不住而已，不该崩 */ }
+}

--- a/frontend/src/components/shell/task-tree.test.ts
+++ b/frontend/src/components/shell/task-tree.test.ts
@@ -101,6 +101,26 @@ describe('buildTaskTree placement', () => {
   })
 })
 
+// worktree 名单（60s 一轮，刷新时还先顶本地快照）比 /sessions 旧：会话关掉后它还挂着人名，
+// 树上就留一行点进去不存在的会话。/sessions 一回来就以它为准。
+describe('已经关掉的会话不留在树上', () => {
+  const wt = { roam: [{ path: '/w/Roam/.worktrees/a', branch: 'chore/a', isMain: false, committedAhead: 2, sessions: [{ session: 'roam-cc' }, { session: 'gone' }] }] }
+  it('会话表还没回来时照旧全画（第一帧不能把快照清空）', () => {
+    const t = buildTaskTree({ projects: [roam], worktrees: wt, sessions: [] })
+    expect(t.projects[0].tasks[0].sessions.map((s) => s.name)).toEqual(['roam-cc', 'gone'])
+  })
+  it('会话表回来了就滤掉不在里面的名字，任务照旧留着', () => {
+    const t = buildTaskTree({ projects: [roam], worktrees: wt, sessions: [{ name: 'roam-cc' }], sessionsLoaded: true })
+    expect(t.projects[0].tasks[0].sessions.map((s) => s.name)).toEqual(['roam-cc'])
+    expect(t.projects[0].tasks[0].unfinished).toBe(false)
+  })
+  it('会话全没了的 worktree 变回待收尾', () => {
+    const t = buildTaskTree({ projects: [roam], worktrees: wt, sessions: [], sessionsLoaded: true })
+    expect(t.projects[0].tasks[0].sessions).toEqual([])
+    expect(t.projects[0].tasks[0].unfinished).toBe(true)
+  })
+})
+
 // _ttmux- 是基础设施会话的命名空间（插件守护进程、IM 监听）。它们跑在真 tmux 会话里，
 // 于是会顺着 /sessions 混进项目树，挂在某个任务下面——既不属于那个任务，人也不该点进去。
 describe('基础设施会话不进树', () => {

--- a/frontend/src/components/shell/task-tree.ts
+++ b/frontend/src/components/shell/task-tree.ts
@@ -63,6 +63,8 @@ export function buildTaskTree(o: {
   placement?: Record<string, { key: string; worktree?: string; branch?: string }>
   /** 人给任务起的名（偏好 taskNames）：有就用它，会话改名不再连带任务改名 */
   nameOf?: (path: string) => string | undefined
+  /** /sessions 已经回来过一轮：此后 sessions 就是「在」的全集，worktree 里多出来的名字都是已经没了的 */
+  sessionsLoaded?: boolean
 }): TaskTree {
   // 会话的展示信息：先从 /projects 的 top / needs 里捞（带 agent / running / waiting），再补 /sessions 的 label
   const info = new Map<string, TreeSession>()
@@ -89,18 +91,24 @@ export function buildTaskTree(o: {
     return agent ? { ...s, agent } : s
   }
 
+  // worktree 那份名单比 /sessions 旧（60s 一轮，还可能是刷新时先顶上的本地快照），
+  // 会话关掉后它还挂着人名——点进去是个不存在的会话。/sessions 是「在」的全集（live +
+  // dormant 都在里面），所以它一回来，就以它为准把已经没了的名字滤掉。
+  const live = o.sessionsLoaded ? new Set(o.sessions.map((s) => s.name)) : null
+  const alive = (n: string) => !live || live.has(n)
+
   const placed = new Set<string>()
   const projects: TreeProject[] = o.projects.map((p) => {
     const tasks: TreeTask[] = []
     for (const wt of o.worktrees[p.key] || []) {
       // worktree 带来的会话列表是**另一条来源**（不是 /sessions），基础设施会话得在这里
       // 再滤一遍——上一版只滤了 /sessions，于是 _ttmux-plugind 照样从这条路挂进任务里。
-      const names = (wt.sessions || []).map((s) => s.session).filter((n) => n && !isInfraSession(n))
+      const names = (wt.sessions || []).map((s) => s.session).filter((n) => n && !isInfraSession(n) && alive(n))
       // 主仓库检出：有会话才立卡（在仓库根目录开的 claude 也得归到项目下，不能丢进散会话）；
       // 没会话不立——它不是一个可收尾的任务位，每个项目都挂一张空的「main」只会碍事
       if (wt.isMain && names.length === 0) continue
       names.forEach((n) => placed.add(n))
-      for (const s of wt.sessions || []) if (s.dormant && !isInfraSession(s.session)) put({ name: s.session, dormant: true })
+      for (const s of wt.sessions || []) if (s.dormant && !isInfraSession(s.session) && alive(s.session)) put({ name: s.session, dormant: true })
       const sessions = names.map(sess)
       const ahead = wt.committedAhead || 0
       tasks.push({


### PR DESCRIPTION
## 现象

每次刷新，左栏「项目」那一段都要空着一会儿才长出来，会话先全挤在「散会话」下面，等 worktree 到了整棵树再跳一次。

## 排查

树要三份原料，本机 18 个项目实测：

| 接口 | 耗时 |
| --- | --- |
| `/projects`（台账，落库） | **4ms** |
| `/sessions/annotations` | 70~170ms |
| `/git/worktrees?dir=` ×13 个 git 项目（**串行**） | **1.59s**（单个 78~185ms） |

落库的那份是快的。慢的是 `/git/worktrees`：后端每个 worktree 要跑十来条 git 命令（config ×4、status、rev-list、merge-base、log…），13 个项目 48 个 worktree 串行扫完就是这段空窗——串行 + 60s 一轮是有意为之（并发扫会把 CPU 打满，见 App.tsx 原注释），不该改。后端那层 3s 的 list 缓存跨不过刷新（前端 60s 才来一轮），所以每次刷新都是从头扫。

前端这边：项目和 worktree 攒到一起、扫完才 `setTreeSrc` 一次，于是这 1~2s 内树是空的。实测第一次刷新 1.31s、第二次赶上冷盘 5.37s。

## 改法

1. **本地快照**（新 `task-tree-snapshot.ts`）：上一轮扫到的原料按机器存 localStorage（~25KB），进来第一帧就画。服务端仍是唯一真相源，快照只顶这 1~2 秒；扫完整份替换，项目/worktree 没了会自己收敛。24h 前的快照不再顶。
2. **项目行不等 worktree**：`/projects` 一回来就先画项目行；串行扫描期间**到一个项目画一个**，不再攒到最后。
3. **顺手修掉幽灵会话**：worktree 名单（60s 一轮，现在还可能是快照）比 `/sessions` 旧，会话关掉后树上还留一行、点进去是不存在的会话。`/sessions` 是「在」的全集（live + dormant），它一回来就以它为准滤掉。

## 验证

dev server + headless Chrome（CDP），18 个项目：

- 改前：项目行出现 **1.31s / 5.37s**（两次刷新）
- 改后：**0.30s / 0.50s**
- 把 `/projects` 与 `/git/worktrees` 两条接口**全掐掉**再刷新：仍在 0.35s 画出 18 个项目 / 12 个任务 / 7 行会话 —— 第一帧确实来自快照
- 手机档（430×932，coarse）：无侧栏、不写快照、文档零溢出，页面正常

`typecheck` / `i18n:check` / `hover:check` / `vitest`（421 passed）/ `build` / `check.sh quick` 全过；新增 8 条测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ymu5exZiR2gfpBAyx7pg1