### PR TITLE
feat(voice): 工具条语音输入 + 快捷键 ⌘⇧S；火山新版单个 API Key 鉴权

### DIFF
--- a/backend/api/speech.go
+++ b/backend/api/speech.go
@@ -37,7 +37,8 @@ type OpenAISpeech struct {
 }
 
 type VolcanoSpeech struct {
-	AppID       string `json:"appId"`       // 火山控制台 App ID
+	APIKey      string `json:"apiKey"`      // 新版控制台：一个 API Key（请求头 X-Api-Key），填了就不看下面两个
+	AppID       string `json:"appId"`       // 旧版控制台 App ID
 	AccessToken string `json:"accessToken"` // 火山控制台 Access Token
 	ResourceID  string `json:"resourceId"`  // 默认 volc.bigasr.auc(大模型录音识别·标准版)；含 _turbo 走极速版
 	Endpoint    string `json:"endpoint"`    // 默认标准版 submit 接口(极速版用 recognize/flash)
@@ -249,8 +250,13 @@ func volcanoPost(client *http.Client, url string, cfg VolcanoSpeech, resourceID,
 		return "", "", nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Api-App-Key", cfg.AppID)
-	req.Header.Set("X-Api-Access-Key", cfg.AccessToken)
+	// 新版控制台只有一个 API Key（X-Api-Key）；旧版是 App ID + Access Token 两个头。其余头两版相同
+	if cfg.APIKey != "" {
+		req.Header.Set("X-Api-Key", cfg.APIKey)
+	} else {
+		req.Header.Set("X-Api-App-Key", cfg.AppID)
+		req.Header.Set("X-Api-Access-Key", cfg.AccessToken)
+	}
 	req.Header.Set("X-Api-Resource-Id", resourceID)
 	req.Header.Set("X-Api-Request-Id", reqID)
 	req.Header.Set("X-Api-Sequence", "-1")
@@ -279,7 +285,7 @@ func volcanoText(body []byte) (string, error) {
 // transcribeVolcano 调火山引擎豆包大模型录音识别，按 resourceId 自动选路：
 // 含 _turbo → 极速版(flash 一次性同步)；否则 → 标准版(submit→query 异步)。
 func transcribeVolcano(cfg VolcanoSpeech, audio []byte) (string, error) {
-	if cfg.AppID == "" || cfg.AccessToken == "" {
+	if cfg.APIKey == "" && (cfg.AppID == "" || cfg.AccessToken == "") {
 		return "", fmt.Errorf("volcano credentials not set")
 	}
 	resourceID := cfg.ResourceID

--- a/frontend/src/components/chat/ChatShell.tsx
+++ b/frontend/src/components/chat/ChatShell.tsx
@@ -391,7 +391,7 @@ export function ChatShell({ name, accent, placeholder, messages, results, render
               </span>
               <span className="tt-cend">
                 {/* 话筒贴着发送键：pill 是「带什么」，话筒是「怎么说」，分开放（22 设计 §3.3） */}
-                <VoiceInput inline accent={accent} onResult={appendText} />
+                <VoiceInput inline hotkey={live} accent={accent} onResult={appendText} />
                 {/* agent 在跑、又没在打字：那枚圆钮就是「停止」；打了字它又是「发送」（可以边跑边排队）。
                     不另摆一枚「停止」pill——同一个位置一钮两用，和别的对话产品一个习惯 */}
                 {busy && !input.trim() ? (

--- a/frontend/src/components/chat/VoiceInput.tsx
+++ b/frontend/src/components/chat/VoiceInput.tsx
@@ -13,7 +13,11 @@ const CANCEL_DY = 90
 // 录音时长下限：太短的误触不送去识别。
 const MIN_MS = 500
 
-export function VoiceInput({ accent, onResult, inline = false }: { accent: string; onResult: (text: string) => void; inline?: boolean }) {
+/**
+ * 三种形态：悬浮（默认，右下角圆钮，手机用）/ inline（composer 控制条上的 pill）/
+ * toolbar（会话工具条上的一枚扁平按钮，带「语音输入」字样——终端视图也能按住说话）。
+ */
+export function VoiceInput({ accent, onResult, inline = false, toolbar = false }: { accent: string; onResult: (text: string) => void; inline?: boolean; toolbar?: boolean }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
   // 录音能力探测：getUserMedia/MediaRecorder 仅在安全上下文(HTTPS / localhost)可用。
@@ -153,7 +157,7 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
       )}
       <button
         type="button"
-        className={inline ? `tt-pill ico tt-mic${active ? ' rec' : ''}` : undefined}
+        className={toolbar ? `tt-tbtn tt-mic${active ? ' rec' : ''}` : inline ? `tt-pill ico tt-mic${active ? ' rec' : ''}` : undefined}
         title={!micUsable ? micHint : configured ? t('voice.holdToTalk') : t('voice.notConfigured')}
         aria-label={t('voice.holdToTalk')}
         disabled={phase === 'transcribing'}
@@ -162,7 +166,7 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
         onPointerMove={(e) => move(e.clientY)}
         onPointerUp={(e) => { e.preventDefault(); end() }}
         onPointerCancel={() => { cancelRef.current = true; end() }}
-        style={inline
+        style={toolbar ? { touchAction: 'none' } : inline
           // 内联：控制条上的一枚 pill——静息时安静，按住说话才亮成强调色（.tt-mic.rec）。
           // 从前它静息就是一整块实心强调色，跟旁边那颗实心发送键抢，一条控制条两个"主动作"。
           ? { background: cancelArmed ? 'var(--danger)' : undefined, touchAction: 'none' }
@@ -179,8 +183,9 @@ export function VoiceInput({ accent, onResult, inline = false }: { accent: strin
             opacity: (configured && micUsable) ? 1 : 0.92,
           }}>
         <span className={(phase === 'recording' || phase === 'transcribing') ? 'cc-pulse' : undefined} style={{ display: 'inline-flex' }}>
-          <MicIcon size={inline ? 15 : 26} silver={!inline || active} />
+          <MicIcon size={toolbar ? 14 : inline ? 15 : 26} silver={!(inline || toolbar) || active} />
         </span>
+        {toolbar && <span>{t('voice.input')}</span>}
       </button>
     </>
   )

--- a/frontend/src/components/chat/VoiceInput.tsx
+++ b/frontend/src/components/chat/VoiceInput.tsx
@@ -17,7 +17,16 @@ const MIN_MS = 500
  * 三种形态：悬浮（默认，右下角圆钮，手机用）/ inline（composer 控制条上的 pill）/
  * toolbar（会话工具条上的一枚扁平按钮，带「语音输入」字样——终端视图也能按住说话）。
  */
-export function VoiceInput({ accent, onResult, inline = false, toolbar = false }: { accent: string; onResult: (text: string) => void; inline?: boolean; toolbar?: boolean }) {
+/** 快捷键：Mac ⌘⇧S，其它 Ctrl+Shift+S。S 取 speak；Ctrl+Shift+V 是终端粘贴，不能占 */
+const HOTKEY_LABEL = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform || '') ? '⌘⇧S' : 'Ctrl+Shift+S'
+const isHotkey = (e: KeyboardEvent) => (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.code === 'KeyS'
+
+/**
+ * hotkey：这一枚响应全局快捷键。同一时刻页面上可能挂着好几枚话筒（每份对话的 composer 都有一枚），
+ * 只有当前视图的那枚传 true，不然一个键按下去几路一起录。
+ * 键盘开的录音没有「松手」：再按一次识别，Esc 取消。
+ */
+export function VoiceInput({ accent, onResult, inline = false, toolbar = false, hotkey = false }: { accent: string; onResult: (text: string) => void; inline?: boolean; toolbar?: boolean; hotkey?: boolean }) {
   const { t } = useI18n()
   const { message } = AntApp.useApp()
   // 录音能力探测：getUserMedia/MediaRecorder 仅在安全上下文(HTTPS / localhost)可用。
@@ -39,6 +48,8 @@ export function VoiceInput({ accent, onResult, inline = false, toolbar = false }
   const cancelRef = useRef(false)    // 松手时是否处于取消区
   const startYRef = useRef(0)
   const startTsRef = useRef(0)
+  const byKeyRef = useRef(false)     // 这段录音是快捷键开的：覆盖层文案不同，结束靠再按一次
+  const [byKey, setByKey] = useState(false)
   const timerRef = useRef<number | undefined>(undefined)
 
   // 探测后端是否已配置可用的 ASR 服务商，未配置则按钮置灰提示去设置。
@@ -48,7 +59,7 @@ export function VoiceInput({ accent, onResult, inline = false, toolbar = false }
       const ok = c.provider === 'openai'
         ? !!c.openai?.apiKey
         : c.provider === 'volcano'
-          ? !!(c.volcano?.appId && c.volcano?.accessToken)
+          ? !!(c.volcano?.apiKey || (c.volcano?.appId && c.volcano?.accessToken))
           : false
       setConfigured(ok)
     }).catch(() => setConfigured(false))
@@ -62,8 +73,10 @@ export function VoiceInput({ accent, onResult, inline = false, toolbar = false }
     streamRef.current = null
   }
 
-  const begin = async (clientY: number) => {
+  const begin = async (clientY: number, viaKey = false) => {
     if (phase !== 'idle') return
+    byKeyRef.current = viaKey
+    setByKey(viaKey)
     if (!micUsable) { message.error(micHint); return }
     if (!configured) { message.info(t('voice.notConfigured')); return }
     pressedRef.current = true
@@ -111,6 +124,31 @@ export function VoiceInput({ accent, onResult, inline = false, toolbar = false }
     try { recRef.current?.stop() } catch { stopTracks(); setPhase('idle') } // onstop 里走 finish()
   }
 
+  // 全局快捷键：keydown 捕获阶段拦下，别让 xterm / 输入框先吃掉。用 ref 读最新的 phase，监听器只挂一次
+  const phaseRef = useRef<Phase>('idle')
+  phaseRef.current = phase
+  const beginRef = useRef(begin); beginRef.current = begin
+  const endRef = useRef(end); endRef.current = end
+  useEffect(() => {
+    if (!hotkey) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.repeat) return
+      if (isHotkey(e)) {
+        e.preventDefault(); e.stopPropagation()
+        if (phaseRef.current === 'idle') void beginRef.current(0, true)
+        else if (phaseRef.current === 'recording' || phaseRef.current === 'requesting') endRef.current()
+        return
+      }
+      if (e.key === 'Escape' && byKeyRef.current && (phaseRef.current === 'recording' || phaseRef.current === 'requesting')) {
+        e.preventDefault(); e.stopPropagation()
+        cancelRef.current = true
+        endRef.current()
+      }
+    }
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () => window.removeEventListener('keydown', onKey, { capture: true } as any)
+  }, [hotkey])
+
   // 录音停止后：取消 / 太短 / 正常识别。
   const finish = async () => {
     const dur = Date.now() - startTsRef.current
@@ -151,14 +189,14 @@ export function VoiceInput({ accent, onResult, inline = false, toolbar = false }
           </div>
           <div style={{ fontFamily: 'ui-monospace, monospace', fontSize: 18, marginBottom: 6 }}>{mm}:{ss}</div>
           <div style={{ fontSize: 12, opacity: 0.85 }}>
-            {phase === 'requesting' ? t('voice.starting') : cancelArmed ? t('voice.releaseCancel') : t('voice.releaseSend')}
+            {phase === 'requesting' ? t('voice.starting') : byKey ? t('voice.hotkeyStop', { key: HOTKEY_LABEL }) : cancelArmed ? t('voice.releaseCancel') : t('voice.releaseSend')}
           </div>
         </div>
       )}
       <button
         type="button"
         className={toolbar ? `tt-tbtn tt-mic${active ? ' rec' : ''}` : inline ? `tt-pill ico tt-mic${active ? ' rec' : ''}` : undefined}
-        title={!micUsable ? micHint : configured ? t('voice.holdToTalk') : t('voice.notConfigured')}
+        title={!micUsable ? micHint : configured ? (hotkey ? `${t('voice.holdToTalk')} · ${t('voice.hotkeyHint', { key: HOTKEY_LABEL })}` : t('voice.holdToTalk')) : t('voice.notConfigured')}
         aria-label={t('voice.holdToTalk')}
         disabled={phase === 'transcribing'}
         onContextMenu={(e) => e.preventDefault()}

--- a/frontend/src/components/settings/speech-settings.tsx
+++ b/frontend/src/components/settings/speech-settings.tsx
@@ -20,6 +20,7 @@ function normalizeSpeech(d: any) {
       language: c.openai?.language || '',
     },
     volcano: {
+      apiKey: c.volcano?.apiKey || '',
       appId: c.volcano?.appId || '',
       accessToken: c.volcano?.accessToken || '',
       resourceId: c.volcano?.resourceId || SPEECH_DEFAULTS.volcano.resourceId,
@@ -66,6 +67,8 @@ export function SpeechSettings() {
         )}
         {cfg.provider === 'volcano' && (
           <Space direction="vertical" size="small" style={{ width: '100%', maxWidth: 520 }}>
+            <Input.Password addonBefore={t('settings.volcanoApiKey')} placeholder={t('settings.volcanoApiKeyHint')} value={cfg.volcano.apiKey} onChange={(e) => setVolc('apiKey', e.target.value)} />
+            <span className="tt-hint">{t('settings.volcanoLegacyHint')}</span>
             <Input addonBefore={t('settings.volcanoAppId')} value={cfg.volcano.appId} onChange={(e) => setVolc('appId', e.target.value)} />
             <Input.Password addonBefore={t('settings.volcanoAccessToken')} value={cfg.volcano.accessToken} onChange={(e) => setVolc('accessToken', e.target.value)} />
             <Input addonBefore={t('settings.volcanoResourceId')} value={cfg.volcano.resourceId} onChange={(e) => setVolc('resourceId', e.target.value)} />

--- a/frontend/src/components/terminal/TerminalPane.tsx
+++ b/frontend/src/components/terminal/TerminalPane.tsx
@@ -896,6 +896,11 @@ export default function TerminalPane(props: {
       {/* 「新标签」进了标签右键菜单（标签条上已有「新建」）；文件 / Git 归右栏活动条；
           语音归 composer——22 设计 §3.3 去掉的四枚。独立页（左停靠）没有右栏，文件 / Git 仍在这 */}
       {active && <TBtn icon={TI.rename} label={t('session.rename')} title={t('session.renameTitle')} onClick={() => setRenameSession(active)} />}
+      {/* 终端视图的话筒：识别结果填到命令行上，回车才发（同 /type 的约定）。对话视图的话筒在 composer 里，不重复。
+          不看 showVoiceButton：那个开关管的是手机上的悬浮圆钮；工具条这枚和 composer 里那枚一样常在 */}
+      {active && !inChat && !isPhone && (
+        <VoiceInput toolbar accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(active)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
+      )}
       <span className="tt-sep" />
       <TBtn icon={promptOff ? TI.bellOff : TI.bellOn} label={t('prompt.popup')} on={!promptOff}
         title={promptOff ? t('prompt.popupOff') : t('prompt.popupOn')} onClick={togglePromptOff} />
@@ -1001,7 +1006,8 @@ export default function TerminalPane(props: {
                 <CodexChat name={termName} file={codexMap[termName].file} onOpenFile={openFileFromChat} onOpenGit={openGitFromChat} active={termName === active && !curFile} />
               </div>
             )}
-            {showVoice && !claudeView[termName] && !codexView[termName] && (
+            {/* 悬浮话筒只留给手机：桌面的在工具条上（重命名旁边） */}
+            {showVoice && isPhone && !claudeView[termName] && !codexView[termName] && (
               <VoiceInput accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(termName)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
             )}
           </div>

--- a/frontend/src/components/terminal/TerminalPane.tsx
+++ b/frontend/src/components/terminal/TerminalPane.tsx
@@ -899,7 +899,7 @@ export default function TerminalPane(props: {
       {/* 终端视图的话筒：识别结果填到命令行上，回车才发（同 /type 的约定）。对话视图的话筒在 composer 里，不重复。
           不看 showVoiceButton：那个开关管的是手机上的悬浮圆钮；工具条这枚和 composer 里那枚一样常在 */}
       {active && !inChat && !isPhone && (
-        <VoiceInput toolbar accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(active)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
+        <VoiceInput toolbar hotkey accent="var(--accent)" onResult={(text) => { api('POST', `/sessions/${encodeURIComponent(active)}/type`, { text }).catch((e: any) => message.error(e.message)) }} />
       )}
       <span className="tt-sep" />
       <TBtn icon={promptOff ? TI.bellOff : TI.bellOn} label={t('prompt.popup')} on={!promptOff}

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1318,7 +1318,7 @@ const enUS = {
   'voice.failed': 'Speech recognition failed: {message}',
 
   'settings.speech': 'Voice input',
-  'settings.speechHelp': 'Configure a speech recognition service, then hold the mic at the bottom-right of a session',
+  'settings.speechHelp': 'Configure a speech recognition service; hold the mic on the session toolbar or in the composer (bottom-right on phones)',
   'settings.speechProvider': 'Service',
   'settings.speechProviderNone': 'Off',
   'settings.speechApiKey': 'API Key',

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1305,6 +1305,8 @@ const enUS = {
 
   'voice.input': 'Voice input',
   'voice.holdToTalk': 'Hold to talk',
+  'voice.hotkeyHint': 'Press {key} to start / stop',
+  'voice.hotkeyStop': 'Press {key} again to recognize · Esc to cancel',
   'voice.notConfigured': 'Configure speech recognition in Settings first',
   'voice.micDenied': 'Cannot access microphone, please check browser permissions',
   'voice.insecureContext': 'Voice on mobile needs HTTPS; the browser blocks the microphone over plain HTTP',
@@ -1325,6 +1327,9 @@ const enUS = {
   'settings.speechBaseUrl': 'Base URL',
   'settings.speechModel': 'Model',
   'settings.speechLanguage': 'Language',
+  'settings.volcanoApiKey': 'API Key',
+  'settings.volcanoApiKeyHint': 'New console: Doubao Speech › API Service Center › API Key',
+  'settings.volcanoLegacyHint': 'Old console without an API Key: fill App ID + Access Token below. Either works; the API Key wins',
   'settings.volcanoAppId': 'App ID',
   'settings.volcanoAccessToken': 'Access Token',
   'settings.volcanoResourceId': 'Resource ID',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1320,7 +1320,7 @@ const zhCN = {
   'voice.failed': '语音识别失败：{message}',
 
   'settings.speech': '语音输入',
-  'settings.speechHelp': '配置语音识别服务，会话页右下角即可长按说话',
+  'settings.speechHelp': '配置语音识别服务；会话工具条与输入框上的话筒按住说话，手机在右下角',
   'settings.speechProvider': '识别服务',
   'settings.speechProviderNone': '关闭',
   'settings.speechApiKey': 'API Key',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1307,6 +1307,8 @@ const zhCN = {
 
   'voice.input': '语音输入',
   'voice.holdToTalk': '长按说话',
+  'voice.hotkeyHint': '按 {key} 开始 / 结束',
+  'voice.hotkeyStop': '再按 {key} 识别 · Esc 取消',
   'voice.notConfigured': '请先在设置中配置语音识别',
   'voice.micDenied': '无法访问麦克风，请检查浏览器权限',
   'voice.insecureContext': '手机用语音需通过 HTTPS 访问；当前是 HTTP，浏览器已禁用麦克风',
@@ -1327,6 +1329,9 @@ const zhCN = {
   'settings.speechBaseUrl': '接口地址',
   'settings.speechModel': '模型',
   'settings.speechLanguage': '识别语言',
+  'settings.volcanoApiKey': 'API Key',
+  'settings.volcanoApiKeyHint': '新版控制台：豆包语音 › API 服务中心 › API Key',
+  'settings.volcanoLegacyHint': '旧版控制台没有 API Key 的，填下面的 App ID + Access Token；两种填一种即可，API Key 优先',
   'settings.volcanoAppId': 'App ID',
   'settings.volcanoAccessToken': 'Access Token',
   'settings.volcanoResourceId': 'Resource ID',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -669,7 +669,8 @@ html[data-pointer="coarse"] .tt-csearch-line, html[data-pointer="coarse"] .tt-cs
 .tt-tree-sessions .tt-tree-row.review .nm { color: var(--text-dimmer); }
 .tt-tree-sessions .tt-tree-row.on .nm { color: var(--text-bright); }
 :where(html[data-pointer="fine"]) .tt-tree-sessions .tt-tree-row:hover .nm { color: var(--text-bright); }
-.tt-tree-sessions .tt-tree-row .tm { flex: 0 0 auto; margin-left: 0; color: var(--text-dimmer); font: 400 var(--fs-micro)/1 var(--mono); }
+/* 行尾时间在会话行和单会话任务卡头行都出现：不许收缩、不许折行——名字一长「刚刚」会被挤成竖排两个字 */
+.tt-tree-row .tm { flex: 0 0 auto; white-space: nowrap; margin-left: 0; color: var(--text-dimmer); font: 400 var(--fs-micro)/1 var(--mono); }
 .tt-tree-sessions .tt-tree-row .nm + .dot { margin-left: 0; }
 /* 收起：一枚「✳ +N ›」小药丸，点了展开 */
 .tt-tree-more { display: inline-flex; align-items: center; gap: 5px; margin: 2px 0 0 30px; height: 24px; padding: 0 8px; border-radius: var(--r-pill); border: 1px solid var(--border-subtle); background: var(--bg-elevated); color: var(--text-dim); font-size: var(--fs-meta); }


### PR DESCRIPTION
## 这个 PR 做了什么

语音输入三件事，外加一条树的样式修复：

- **工具条语音输入**（原 #241 的三个提交，那个 PR 关了并进来）：会话工具条「重命名」旁一枚「语音输入」，终端视图按住说话，识别结果走 `/sessions/:name/type` 填到命令行上，回车才发。不看「显示语音按钮」偏好（它管的是手机上的悬浮圆钮），桌面悬浮话筒撤掉只留手机。
- **快捷键** ⌘⇧S（Mac）/ Ctrl+Shift+S：一按开录、再按识别、Esc 取消。只有当前视图那枚话筒响应（工具条那枚或当前对话 composer 那枚），keydown 捕获阶段拦下不让 xterm 先吃掉。按钮 tooltip 带快捷键提示。
- **火山引擎新版鉴权**：新版控制台只发一个 API Key（请求头 `X-Api-Key`），设置页加这一栏；旧版 App ID + Access Token 仍可用，两种填一种，API Key 优先。
- 树的行尾时间不折行（名字一长「刚刚」被挤成竖排两个字）。

## 怎么验

- `typecheck / i18n:check / hover:check / vitest(413)` 过，`build-roam.sh` 全绿。
- 130.55 已装上：终端视图按 Ctrl+Shift+S 出录音覆盖层、再按识别、Esc 取消；切到对话视图快捷键落到 composer 的话筒上。
- 火山 API Key 路径需要新版控制台的 key 才能真跑一遍，请求头改法照官方文档「新版控制台用 X-Api-Key，其余头不变」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
