### PR TITLE
fix(shell): 会话表拉不到就别当「一个都没有」；休眠会话一律不滤

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,6 +248,10 @@ export default function App() {
   // 树头「+」：就地弹新建项目框，不再先跳去项目列表页（建完自己跳到新项目主页）
   const [newProjectOpen, setNewProjectOpen] = useState(false)
   const [sessList, setSessList] = useState<{ name: string; label?: string; lastActivity?: number; agent?: 'claude' | 'codex' }[]>([])
+  // /sessions **成功**回来过一轮才算数（树按它判会话还在不在）。不能拿 sessIds 当这个信号：
+  // 它在请求失败时也会被置成空表（那是为了放行标签还原），首轮就失败的话等于宣布「一个会话
+  // 都没有」，树上的任务和会话会被一起抹掉。
+  const [sessListLoaded, setSessListLoaded] = useState(false)
   // URL 上待还原的 id/名字（还没拿到 id 映射前先原样存着）
   const urlTerms = useRef<string[]>(readTermTokens().terms)
   const urlActive = useRef<string>(readTermTokens().active)
@@ -513,6 +517,7 @@ export default function App() {
         if (s?.name) names.push({ name: s.name, label: s.label || undefined, lastActivity: s.lastActivity || undefined, agent: s.agent === 'claude' || s.agent === 'codex' ? s.agent : undefined })
       }
       setSessIds({ byId, byName })
+      setSessListLoaded(true)
       // 内容没变就不换引用：树是按它 memo 的，5s 一次的空翻新会让整棵树白重算
       setSessList((cur) => (cur.length === names.length && cur.every((x, i) => x.name === names[i].name && x.label === names[i].label && x.lastActivity === names[i].lastActivity && x.agent === names[i].agent) ? cur : names))
       setSessionLabels(labels) // 展示名（@roam_name）：界面显示「名字（id）」，handle 仍是会话名
@@ -575,10 +580,10 @@ export default function App() {
     nameOf: (p) => prefs.taskNames?.[p] || undefined,
     agentOf: (n) => (claudeMap[n]?.running ? 'claude' : codexMap[n]?.running ? 'codex' : undefined),
     // 会话表一到就以它为准：快照/60s 的 worktree 名单里那些已经关掉的会话不该还挂在树上
-    sessionsLoaded: !!sessIds,
+    sessionsLoaded: sessListLoaded,
     // 互审陪跑叫 `<被审会话id>-review`，靠 id 表还原成人看得懂的那个会话
     nameOfId: (id) => sessIds?.byId[id],
-  }), [treeSrc, sessList, claudeMap, codexMap, projTable, prefs.taskNames, sessIds])
+  }), [treeSrc, sessList, claudeMap, codexMap, projTable, prefs.taskNames, sessIds, sessListLoaded])
   treeRef.current = tree
 
   // hash 路由：URL #/xxx 与当前页同步（支持前进/后退、刷新保持、收藏分享）

--- a/frontend/src/components/shell/task-tree.test.ts
+++ b/frontend/src/components/shell/task-tree.test.ts
@@ -114,6 +114,12 @@ describe('已经关掉的会话不留在树上', () => {
     expect(t.projects[0].tasks[0].sessions.map((s) => s.name)).toEqual(['roam-cc'])
     expect(t.projects[0].tasks[0].unfinished).toBe(false)
   })
+  it('休眠会话不滤：点开即恢复的唯一入口不能因为两边错开一次就没了', () => {
+    const dw = { roam: [{ path: '/w/Roam/.worktrees/d', branch: 'fix/d', isMain: false, sessions: [{ session: 'napping', dormant: true }, { session: 'gone' }] }] }
+    const t = buildTaskTree({ projects: [roam], worktrees: dw, sessions: [], sessionsLoaded: true })
+    expect(t.projects[0].tasks[0].sessions.map((s) => s.name)).toEqual(['napping'])
+    expect(t.projects[0].tasks[0].sessions[0].dormant).toBe(true)
+  })
   it('会话全没了的 worktree 变回待收尾', () => {
     const t = buildTaskTree({ projects: [roam], worktrees: wt, sessions: [], sessionsLoaded: true })
     expect(t.projects[0].tasks[0].sessions).toEqual([])

--- a/frontend/src/components/shell/task-tree.ts
+++ b/frontend/src/components/shell/task-tree.ts
@@ -97,9 +97,15 @@ export function buildTaskTree(o: {
 
   // worktree 那份名单比 /sessions 旧（60s 一轮，还可能是刷新时先顶上的本地快照），
   // 会话关掉后它还挂着人名——点进去是个不存在的会话。/sessions 是「在」的全集（live +
-  // dormant 都在里面），所以它一回来，就以它为准把已经没了的名字滤掉。
+  // dormant 都在里面：CLI 的 ls 收尾会 appendDormant），所以它一回来，就以它为准把已经
+  // 没了的名字滤掉。
+  //
+  // **休眠会话一律不滤**：两边的 dormant 都读同一张 sessions 表、同一套条件（见
+  // backend/worktree/sessionhome.go 的 dormantSQL 注释），照理不会打架；但两次查询之间
+  // 隔着 60s，真要错开一次，代价是「点开即恢复」的唯一入口从树上没了——这一格的保险
+  // 比那点整洁值钱。已经关掉的会话在快照里本来就是活的、不带这个标，照滤不误。
   const live = o.sessionsLoaded ? new Set(o.sessions.map((s) => s.name)) : null
-  const alive = (n: string) => !live || live.has(n)
+  const alive = (n: string, dormant?: boolean) => !live || dormant || live.has(n)
 
   const placed = new Set<string>()
   const projects: TreeProject[] = o.projects.map((p) => {
@@ -107,12 +113,12 @@ export function buildTaskTree(o: {
     for (const wt of o.worktrees[p.key] || []) {
       // worktree 带来的会话列表是**另一条来源**（不是 /sessions），基础设施会话得在这里
       // 再滤一遍——上一版只滤了 /sessions，于是 _ttmux-plugind 照样从这条路挂进任务里。
-      const names = (wt.sessions || []).map((s) => s.session).filter((n) => n && !isInfraSession(n) && alive(n))
+      const names = (wt.sessions || []).filter((s) => s.session && !isInfraSession(s.session) && alive(s.session, s.dormant)).map((s) => s.session)
       // 主仓库检出：有会话才立卡（在仓库根目录开的 claude 也得归到项目下，不能丢进散会话）；
       // 没会话不立——它不是一个可收尾的任务位，每个项目都挂一张空的「main」只会碍事
       if (wt.isMain && names.length === 0) continue
       names.forEach((n) => placed.add(n))
-      for (const s of wt.sessions || []) if (s.dormant && !isInfraSession(s.session) && alive(s.session)) put({ name: s.session, dormant: true })
+      for (const s of wt.sessions || []) if (s.dormant && !isInfraSession(s.session)) put({ name: s.session, dormant: true })
       const sessions = names.map(sess)
       const ahead = wt.committedAhead || 0
       tasks.push({


### PR DESCRIPTION
#243 的互审（j615722）修复。原 PR 合入时只带走了第一个提交，这条修复留在了分支上，这里补进来（已 rebase 到最新 main，与 #242 的 `nameOfId` 合到一起）。

**① `/sessions` 首轮失败会把树上的任务和会话全抹掉**

判「会话表到了没」用的是 `sessIds`，而它在请求失败时也会被置成空表（那是为了放行标签还原），首轮就失败等于宣布一个会话都没有，`buildTaskTree` 会把 worktree 里的会话名全判成不存活。改成单独一个只在**成功**时置位的 `sessListLoaded`。

浏览器实测（掐掉 `/api/sessions` 再刷新，18 个项目）：

| | 项目 / 任务 / 会话行 |
| --- | --- |
| 正常 | 18 / 12 / 7 |
| `/sessions` 全挂（改前） | 18 / **0 / 0** |
| `/sessions` 全挂（改后） | 18 / 12 / 7 |
| 接口恢复后 | 18 / 12 / 7 |

**② 休眠会话加一格保险**

worktree join 里带 `dormant` 标的一律不滤。两边的 dormant 读同一张 sessions 表、同一套条件（CLI `ls` 收尾的 `appendDormant` / backend 的 `dormantSQL`，注释写明「同一个口径」），照理不会打架；但两次查询隔着 60s，真错开一次，代价是「点开即恢复」的唯一入口从树上没了。已经关掉的会话在快照里本来就是活的、不带这个标，照滤不误。

`typecheck` / `vitest`（429 passed）/ `check.sh quick` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ymu5exZiR2gfpBAyx7pg1