### PR TITLE
fix(project): 从已在册仓库的 worktree 目录新建项目不再盖掉项目名

### DIFF
--- a/backend/api/project.go
+++ b/backend/api/project.go
@@ -449,11 +449,20 @@ func (a *API) ProjectCreate(c *gin.Context) {
 		dir = filepath.Clean(dir)
 		git = false
 	}
-	key := a.Projects.Add(dir, strings.TrimSpace(b.DisplayName))
+	key, created := a.Projects.Add(dir, strings.TrimSpace(b.DisplayName))
 	projRespMu.Lock()
 	projResp = nil
 	projRespMu.Unlock()
-	c.JSON(http.StatusOK, gin.H{"data": gin.H{"key": key, "dir": dir, "git": git}})
+	// 没新建 = 目录归位到了一个已在册的仓库（多半是它的某个 worktree）：把项目名和归位前的目录
+	// 一起告诉前端，让它说清楚「这是 X 的 worktree，已归到 X 下」，而不是「项目已创建」
+	resp := gin.H{"key": key, "dir": dir, "git": git, "created": created}
+	if !created {
+		resp["name"] = a.Projects.Name(key)
+		if b.Dir != "" && filepath.Clean(b.Dir) != dir {
+			resp["worktree"] = filepath.Clean(b.Dir)
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": resp})
 }
 
 // cloneMaxWait 克隆最多等多久。10 秒是给「读一下本地目录」用的，克隆完全是另一个量级：

--- a/backend/project/service.go
+++ b/backend/project/service.go
@@ -312,10 +312,14 @@ func (s *Store) Touch(dir string) string {
 }
 
 // Add 显式创建（POST /projects）：origin=user 的一等对象。目录已在册则升级为 user
-// （发现来的条目被用户「转正」，id 不变），并可顺带设显示名。返回项目 id。
-func (s *Store) Add(dir, displayName string) string {
+// （发现来的条目被用户「转正」，id 不变）。返回项目 id 和「是不是新建的」。
+//
+// 显示名只在新建、或原来没起过名时写：已有项目再「新建」一次（典型是从它的某个
+// worktree 目录建——ResolveRepo 归位到同一个仓库根），传来的名字是给那个 worktree 起的，
+// 不该把项目本来的名字盖掉（blade-agent 就这么被改成了 blade-agent-sea-attack）。
+func (s *Store) Add(dir, displayName string) (key string, created bool) {
 	if dir == "" {
-		return ""
+		return "", false
 	}
 	now := time.Now().Unix()
 	s.mu.Lock()
@@ -329,11 +333,25 @@ func (s *Store) Add(dir, displayName string) string {
 	e := s.repos[key]
 	e.Origin = "user"
 	e.LastSeen = now
-	if displayName != "" {
+	if displayName != "" && (!ok || e.DisplayName == "") {
 		e.DisplayName = displayName
 	}
 	s.save()
-	return key
+	return key, !ok
+}
+
+// Name 项目的显示名（没起过就是目录名）；不在册返回空。
+func (s *Store) Name(key string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.repos[s.resolve(key)]
+	if !ok {
+		return ""
+	}
+	if e.DisplayName != "" {
+		return e.DisplayName
+	}
+	return filepath.Base(e.Dir)
 }
 
 // NoteSessions 记「这个项目此刻有会话」。聚合层每轮算完会话数调一次，

--- a/backend/project/service_test.go
+++ b/backend/project/service_test.go
@@ -62,7 +62,7 @@ func TestSetPrefsUnknownKey(t *testing.T) {
 // 目录搬家（mv 项目 / worktree 子目录归位仓库根）：id 不变、偏好不丢。
 func TestSetDirKeepsIdentity(t *testing.T) {
 	s := NewStore(t.TempDir(), nil)
-	k := s.Add("/repo/old", "我的项目")
+	k, _ := s.Add("/repo/old", "我的项目")
 	s.SetPrefs(k, func(p *Prefs) { p.Pinned = true })
 	if got := s.SetDir(k, "/repo/new"); got != k {
 		t.Fatalf("平移应保持 id: %q → %q", k, got)
@@ -82,7 +82,7 @@ func TestSetDirKeepsIdentity(t *testing.T) {
 // 新目录已被别的条目占用 → 合并用户意志，被并掉的 id 变别名（老链接仍可解析）。
 func TestSetDirMergesUserIntent(t *testing.T) {
 	s := NewStore(t.TempDir(), nil)
-	sub := s.Add("/repo/.worktrees", "")
+	sub, _ := s.Add("/repo/.worktrees", "")
 	s.SetPrefs(sub, func(p *Prefs) { p.Pinned = true })
 	root := s.Touch("/repo")
 	if got := s.SetDir(sub, "/repo"); got != root {
@@ -352,5 +352,28 @@ func TestTraceTrimsPerRepo(t *testing.T) {
 	}
 	if got := s.ReadTrace("/repo/b", 10); len(got) != 1 {
 		t.Fatalf("修剪串到别的仓库了: %+v", got)
+	}
+}
+
+// 已在册的项目再「新建」一次（典型：从它的 worktree 目录建，归位到同一仓库根）：
+// id 不变、不算新建，传来的名字不许盖掉项目本来的名字。
+func TestAddExistingKeepsDisplayName(t *testing.T) {
+	s := NewStore(t.TempDir(), nil)
+	k, created := s.Add("/repo/blade-agent", "blade-agent")
+	if !created {
+		t.Fatal("第一次该是新建")
+	}
+	k2, created2 := s.Add("/repo/blade-agent", "blade-agent-sea-attack")
+	if k2 != k || created2 {
+		t.Fatalf("同目录再建应返回原 id 且不算新建: %q/%v vs %q", k2, created2, k)
+	}
+	if got := s.Name(k); got != "blade-agent" {
+		t.Fatalf("项目名不该被盖掉: %q", got)
+	}
+	// 从来没起过名的，再建时给的名字可以补上
+	k3, _ := s.Add("/repo/noname", "")
+	s.Add("/repo/noname", "起个名")
+	if got := s.Name(k3); got != "起个名" {
+		t.Fatalf("没起过名的可以补: %q", got)
 	}
 }

--- a/frontend/src/components/projects/Projects.tsx
+++ b/frontend/src/components/projects/Projects.tsx
@@ -343,7 +343,9 @@ export function NewProjectModal({ open, onClose, onCreated }: { open: boolean; o
       })
       message.destroy('newproj')
       pushRecentDir(dir.trim())
-      message.success(t('project.createdProject'))
+      // 目录是某个已在册仓库的 worktree：没有新项目，归到那个项目下，名字也没动
+      if (res.data.created === false) message.info(res.data.worktree ? t('project.existsAsWorktree', { name: res.data.name }) : t('project.existsAlready', { name: res.data.name }), 6)
+      else message.success(t('project.createdProject'))
       onClose(); onCreated?.()
       location.hash = '#/projects/' + encodeURIComponent(res.data.key)
     } catch (e: any) { message.destroy('newproj'); message.error(e.message) }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1870,6 +1870,8 @@ const enUS = {
   'project.cloneHint': 'Clones into the folder above (created if missing; must be empty if it exists). Private repos use this machine\'s existing SSH keys or credentials; a bad URL fails fast instead of hanging on a password prompt.',
   'project.newHint': 'A project is any directory (git optional — worktree/formation/activity need git); a missing directory is created automatically. Stored persistently; start sessions/features from the task box inside the project',
   'project.createdProject': 'Project created',
+  'project.existsAsWorktree': 'This directory is a worktree of "{name}" and now sits under that project; to work in it, show idle worktrees from the project row menu or pick it as the base on the project page',
+  'project.existsAlready': '"{name}" is already registered; nothing was created twice',
   'project.notGit': 'Not a git repository',
   'project.removed': 'Removed from list',
   'project.removeConfirm': 'Remove this project from the list? Directory, worktrees and sessions are untouched',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1875,6 +1875,8 @@ const zhCN = {
   'project.cloneHint': '克隆到上面那个目录（不存在会自动创建，已存在则必须是空的）。私有仓库走本机已配好的 SSH 密钥或凭证；填错地址会直接报错，不会卡在密码提示上。',
   'project.newHint': '项目 = 任意目录（git 可选：是 git 仓库才有 worktree/编队/活动能力）；目录不存在会自动创建。创建后持久保存，开会话/建 feature 请进入项目后在任务框操作',
   'project.createdProject': '项目已创建',
+  'project.existsAsWorktree': '这个目录是「{name}」的一个 worktree，已归到该项目下；要在里面开工，去项目行「…」显示空闲 worktree，或在项目主页选它做起点',
+  'project.existsAlready': '「{name}」已经在册，没有重复创建',
   'project.notGit': '该目录不是 git 仓库',
   'project.removed': '已从列表移除',
   'project.removeConfirm': '从列表移除该项目？不动目录、worktree 与会话',


### PR DESCRIPTION
## 这个 PR 做了什么

从一个已在册仓库的 worktree 目录点「新建项目」，会把那个项目改名。

`~/workspace/blade-agent-sea-attack` 是 `blade-agent` 的 linked worktree（git common dir 指向 `blade-agent/.git`）。新建时 `ResolveRepo` 正确地归位到仓库根，但 `Store.Add` 无条件把传来的显示名写进已有条目，于是项目 `blade-agent` 变成了 `blade-agent-sea-attack`。

- `Store.Add` 返回 `(key, created)`；显示名只在新建、或原来没起过名时写。加 `Store.Name`。
- `POST /projects` 回 `created`，没新建时带上项目名和归位前的目录。
- 前端：`created=false` 时提示「这个目录是「X」的一个 worktree，已归到该项目下；要在里面开工，去项目行「…」显示空闲 worktree，或在项目主页选它做起点」，不再说「项目已创建」。
- 测试：`TestAddExistingKeepsDisplayName`。

## 怎么验

- `go test ./project` 过；前端 `typecheck / i18n:check` 过；`build-roam.sh` 全绿。
- 130.55 上已把 blade-agent 的名字改回来并装上新包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
