### PR TITLE
fix(chat): 刚起的会话别再挂 BAD_FILE，起手的信任确认框搬进对话面板

### DIFF
--- a/backend/api/claude.go
+++ b/backend/api/claude.go
@@ -506,11 +506,18 @@ func (a *API) ClaudeTranscript(c *gin.Context) {
 			file = pickTranscript(filepath.Join(home, ".claude", "projects", encodeProject(dir)), processArgv(pid), processStart(pid))
 		}
 	}
+	// agent 刚起、一句没说（比如还卡在启动的信任确认上）时转录文件根本不存在。
+	// 这是正常起步态，不是坏请求：回 400 的话前端会在输入框上方挂一行红字 BAD_FILE，
+	// 而且它只在轮询出错时写、成功时不擦，于是那行红字一直挂着。
+	if file == "" {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"messages": []cMsg{}, "nextOffset": 0, "file": ""}})
+		return
+	}
 	// 安全：限制在 ~/.claude/projects 下
 	home, _ := os.UserHomeDir()
 	root := filepath.Join(home, ".claude", "projects")
 	file = filepath.Clean(file)
-	if file == "" || !strings.HasPrefix(file, root) {
+	if !strings.HasPrefix(file, root) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_FILE"}})
 		return
 	}

--- a/backend/api/codex.go
+++ b/backend/api/codex.go
@@ -351,10 +351,15 @@ func (a *API) CodexTranscript(c *gin.Context) {
 			file = newestCodexRollout(dir)
 		}
 	}
+	// 同 ClaudeTranscript：还没有 rollout 文件＝agent 刚起，不是坏请求。
+	if file == "" {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"messages": []cMsg{}, "nextOffset": 0, "file": ""}})
+		return
+	}
 	// 安全：限制在 ~/.codex/sessions 下
 	root := codexSessionsRoot()
 	file = filepath.Clean(file)
-	if file == "" || !strings.HasPrefix(file, root) {
+	if !strings.HasPrefix(file, root) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "BAD_FILE"}})
 		return
 	}

--- a/backend/api/transcript_missing_test.go
+++ b/backend/api/transcript_missing_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// agent 刚起、一句没说（比如还卡在启动的信任确认框上）时根本没有转录文件。
+// 那是正常起步态：必须回 200 + 空列表，不能回 400 —— 前端会把 BAD_FILE 当报错，
+// 在输入框上方挂一行红字，而且成功轮询不会把它擦掉。
+func TestTranscriptNoFileIsEmptyNotError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	a := &API{}
+	for _, tc := range []struct {
+		name    string
+		route   string
+		handler gin.HandlerFunc
+	}{
+		{"claude", "/sessions/:name/transcript", a.ClaudeTranscript},
+		{"codex", "/sessions/:name/codex-transcript", a.CodexTranscript},
+	} {
+		r := gin.New()
+		r.GET(tc.route, tc.handler)
+		path := "/sessions/2026-0101-0000-zzzz/" + strings.TrimPrefix(tc.route, "/sessions/:name/")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d: %s", tc.name, w.Code, w.Body.String())
+		}
+		var got struct {
+			Data struct {
+				Messages []json.RawMessage `json:"messages"`
+				File     string            `json:"file"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if len(got.Data.Messages) != 0 || got.Data.File != "" {
+			t.Fatalf("%s: 该是空转录，got %+v", tc.name, got.Data)
+		}
+
+		// 明确指名一个越界路径仍是坏请求
+		w = httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path+"?file=/etc/passwd", nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("%s: 越界路径该 400，got %d", tc.name, w.Code)
+		}
+	}
+}

--- a/frontend/src/components/chat/ClaudeChat.tsx
+++ b/frontend/src/components/chat/ClaudeChat.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '../../i18n'
 export default memo(function ClaudeChat({ name, file, onOpenFile, onOpenGit, active }: { name: string; file?: string; onOpenFile?: (path: string, line?: number) => void; onOpenGit?: () => void; active?: boolean }) {
   const { t } = useI18n()
   const label = useSessionLabel(name)
-  const { msgs, err, status: raw, hasEarlier, loadEarlier } = useTranscript(name, file, 'transcript', active === false ? 6000 : 1500)
+  const { msgs, err, status: raw, hasEarlier, loadEarlier, resolvedFile } = useTranscript(name, file, 'transcript', active === false ? 6000 : 1500)
   const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
   const pending = isPending(view)
   // TaskUpdate 只给 {taskId,status}，标题在更早那次 TaskCreate 的结果里 —— 跨消息扫一遍才接得上
@@ -26,7 +26,7 @@ export default memo(function ClaudeChat({ name, file, onOpenFile, onOpenGit, act
 
   return (
     <ChatShell
-      emptyHint={file ? undefined : t('chat.noTranscriptYet')}
+      emptyHint={resolvedFile === '' ? t('chat.noTranscriptYet') : undefined}
       name={name} accent="var(--accent)" error={err} onOpenFile={onOpenFile} tasks={tasks} status={status} onOpenGit={onOpenGit} lastErrorId={derived.lastErrorId}
       placeholder={t('chat.sendTo', { name: label })} agent="claude"
       messages={view} results={results} hasEarlier={hasEarlier} onLoadEarlier={loadEarlier}

--- a/frontend/src/components/chat/CodexChat.tsx
+++ b/frontend/src/components/chat/CodexChat.tsx
@@ -15,7 +15,7 @@ import { useI18n } from '../../i18n'
 export default memo(function CodexChat({ name, file, onOpenFile, onOpenGit, active }: { name: string; file?: string; onOpenFile?: (path: string, line?: number) => void; onOpenGit?: () => void; active?: boolean }) {
   const { t } = useI18n()
   const label = useSessionLabel(name)
-  const { msgs, err, status: raw, hasEarlier, loadEarlier } = useTranscript(name, file, 'codex-transcript', active === false ? 6000 : 1500)
+  const { msgs, err, status: raw, hasEarlier, loadEarlier, resolvedFile } = useTranscript(name, file, 'codex-transcript', active === false ? 6000 : 1500)
   const { results, view } = useMemo(() => pairToolResults(msgs), [msgs])
   const pending = isPending(view)
   // TaskUpdate 只给 {taskId,status}，标题在更早那次 TaskCreate 的结果里 —— 跨消息扫一遍才接得上
@@ -26,7 +26,7 @@ export default memo(function CodexChat({ name, file, onOpenFile, onOpenGit, acti
 
   return (
     <ChatShell
-      emptyHint={file ? undefined : t('chat.noTranscriptYet')}
+      emptyHint={resolvedFile === '' ? t('chat.noTranscriptYet') : undefined}
       name={name} accent={CODEX_ACCENT} error={err} onOpenFile={onOpenFile} tasks={tasks} status={status} onOpenGit={onOpenGit} lastErrorId={derived.lastErrorId}
       placeholder={t('chat.sendTo', { name: label })} agent="codex"
       messages={view} results={results} hasEarlier={hasEarlier} onLoadEarlier={loadEarlier}

--- a/frontend/src/components/chat/useTranscript.ts
+++ b/frontend/src/components/chat/useTranscript.ts
@@ -15,6 +15,9 @@ export const FIRST_PAGE = 200
 export function useTranscript(name: string, file: string | undefined, path: string, interval = 1500) {
   const [msgs, setMsgs] = useState<Msg[]>([])
   const [err, setErr] = useState('')
+  // 后端这轮定位到的转录文件：undefined=第一轮还没回来，''=后端也没找到（agent 一句没说）。
+  // 空状态那行字靠它区分「加载中」和「还没有对话」，光看调用方传没传 file 会把两者混成一句。
+  const [resolvedFile, setResolvedFile] = useState<string | undefined>(undefined)
   // 状态是「上次成交价」：这一轮没扫到新行后端就回空，保留上次的值。
   // 会话闲着不动百分比就不动——那是对的，没发生新对话上下文确实没变。
   const [status, setStatus] = useState<RawStatus>({})
@@ -33,7 +36,7 @@ export function useTranscript(name: string, file: string | undefined, path: stri
     let offset = 0
     let f = file
     let lastFile = file || ''
-    setMsgs([]); setErr(''); setStatus({})
+    setMsgs([]); setErr(''); setStatus({}); setResolvedFile(undefined)
     const poll = async () => {
       try {
         // boff=1：告诉后端这个 offset 是字节偏移（升级前的页面不会带，后端据此重新锚定）
@@ -44,6 +47,8 @@ export function useTranscript(name: string, file: string | undefined, path: stri
         const r = await api('GET', `/sessions/${encodeURIComponent(name)}/${path}?${q.toString()}`)
         const d = r.data
         if (stop) return
+        setErr('') // 这轮通了就把上一轮的报错擦掉，否则一次抖动的红字会一直挂到重开面板
+        if (typeof d.file === 'string') setResolvedFile(d.file)
         if (d.file && d.file !== lastFile) {
           f = d.file
           lastFile = d.file
@@ -73,7 +78,7 @@ export function useTranscript(name: string, file: string | undefined, path: stri
     return () => { stop = true; clearTimeout(t) }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, file, path, refreshKey, tail])
-  return { msgs, err, refresh, status, hasEarlier, loadEarlier }
+  return { msgs, err, refresh, status, hasEarlier, loadEarlier, resolvedFile }
 }
 
 // 只有非空字段才覆盖：后端每轮只回它这次扫到的东西，缺的字段不该把已知值抹掉。

--- a/frontend/src/components/prompt.test.ts
+++ b/frontend/src/components/prompt.test.ts
@@ -69,6 +69,65 @@ const QUOTED_LIST = `
    Done.
 `
 
+// Claude 起手的信任确认（真机 capture）：选项没有编号，只有一个 ❯ 游标。
+// 新建 worktree 的会话第一屏就是它——认不出来的话对话面板里什么都没有。
+const TRUST = `
+ Accessing workspace:
+
+ /tmp/probe
+
+ Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source
+ project, or work from your team). If not, take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ ⚠ This folder pre-approves 1 tool permission in .claude/settings.local.json:
+   Bash(git log *)
+ These will apply without asking. Only proceed if you trust this configuration.
+
+ Security guide
+
+ ❯ No, exit
+   Yes, I trust this folder
+
+ Enter to confirm · Esc to cancel
+`
+
+// 输入框那行也是 ❯ 打头，底下跟着状态栏：没有对齐的兄弟项、也没有确认提示，不能当选择框
+const COMPOSER = `
+ ✻ Sautéed for 4m · done 7:50 PM
+
+ ❯ 帮我在配置中心配一个 logos 试试
+   ⏵⏵ auto mode on · 1 shell · ← for agents
+`
+
+// 窄屏（手机 attach 后 tmux 只剩四十来列）：提问被折成五行，离选项十几行远。
+const TRUST_NARROW = `
+ /tmp/trust-probe-e1
+
+ Quick safety check: Is this a project you
+ created or one you trust? (Like your own
+ code, a well-known open source project, or
+ work from your team). If not, take a moment
+ to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and
+ execute files here.
+
+ ⚠ This folder pre-approves 1 tool permission
+ in .claude/settings.local.json:
+   Bash(git log *)
+ These will apply without asking. Only proceed
+ if you trust this configuration.
+
+ Security guide
+
+ ❯ No, exit
+   Yes, I trust this folder
+
+ Enter to confirm · Esc to cancel
+`
+
 describe('detectPrompt', () => {
   it('宽屏选择框：识别出全部选项与当前游标', () => {
     const p = detectPrompt(WIDE)
@@ -100,6 +159,26 @@ describe('detectPrompt', () => {
 
   it('没有可见游标时，明确提问和操作提示组合仍可识别', () => {
     expect(detectPrompt(NO_CURSOR_PROMPT)?.kind).toBe('select')
+  })
+
+  it('无编号的信任确认框：认出两个选项和当前游标', () => {
+    const p = detectPrompt(TRUST)
+    expect(p?.kind).toBe('select')
+    expect(p?.numbered).toBe(false)
+    expect(p?.choices.map((c) => c.label)).toEqual(['No, exit', 'Yes, I trust this folder'])
+    expect(p?.choices.find((c) => c.selected)?.num).toBe(1)
+    expect(p?.question).toContain('trust')
+  })
+
+  it('窄屏折行的信任确认框：提问跨五行也要拼回来', () => {
+    const p = detectPrompt(TRUST_NARROW)
+    expect(p?.numbered).toBe(false)
+    expect(p?.choices.map((c) => c.label)).toEqual(['No, exit', 'Yes, I trust this folder'])
+    expect(p?.question).toContain('Quick safety check')
+  })
+
+  it('输入框那行 ❯ 不当选择框', () => {
+    expect(detectPrompt(COMPOSER)).toBeNull()
   })
 
   it('空屏返回 null', () => {

--- a/frontend/src/components/prompt.tsx
+++ b/frontend/src/components/prompt.tsx
@@ -10,7 +10,8 @@ import { useI18n } from '../i18n'
 import { ArrowDown, ArrowUp, ChevronRight, DotIcon } from '../icons'
 
 export interface Choice { num: number; label: string; selected: boolean }
-export interface Prompt { kind: 'select' | 'yesno'; question: string; choices: Choice[] }
+/** numbered=false：选项没有 1./2. 编号，只能靠方向键挪游标（见 detectUnnumbered） */
+export interface Prompt { kind: 'select' | 'yesno'; question: string; choices: Choice[]; numbered?: boolean }
 
 const CURSOR_PREFIX = /^[❯➤▶►▸→›»☞◉●>]\s*/u           // 选中游标必须位于选项开头，不能匹配正文里的 > / ●
 const LEAD = /^[\s│┃|╎┆┊╭╰├╞┝─━═]+/u                  // 行首方框线/竖线/空白
@@ -20,10 +21,14 @@ const OPT = /^(?:[❯➤▶►▸→›»☞◉●>]\s*)?(\d+)[.)]\s+(\S.*)$/u /
 // Agent 的普通编号总结很容易命中，造成后台标签在“待确认/运行中”之间反复闪动。
 const QUESTION = /(?:would you like|do you want|are you sure|should (?:we|i)|(?:proceed|allow|continue|overwrite|approve|trust).*[?？]|是否(?:继续|允许|确认|执行)|(?:继续|允许|确认|执行).*[?？])/i
 const ACTION_HINT = /(?:(?:enter|return).*(?:select|confirm|continue|submit|accept)|(?:esc|escape).*(?:cancel|back)|(?:回车|enter).*(?:选择|确认|继续)|(?:按|press).*(?:y|n|yes|no).*(?:确认|confirm))/i
+const CURSOR_ONLY = /^(\s*)[❯➤▶►▸›»](\s+)(\S.*)$/u        // [缩进]游标 文本（无编号选项）
+const BOX_LEAD = /^\s*[│┃|╎┆┊╭╰├╞┝─━═]+/u                  // 只吃框线与它前面的空白，缩进要留着
 const ANSI = /\x1b\[[0-?]*[ -/]*[@-~]/g
 const CTRL = /[\x00-\x08\x0b-\x1f\x7f]/g
 const stripCtl = (s: string) => s.replace(ANSI, '').replace(CTRL, '')
 const clean = (s: string) => stripCtl(s).replace(LEAD, '').replace(TAIL, '').trim()
+// 同 clean，但**保留行首缩进**：无编号选择框全靠「文本起始列对齐」认出同一组选项。
+const inner = (s: string) => stripCtl(s).replace(BOX_LEAD, '').replace(TAIL, '')
 
 // 从一屏纯文本里解析当前是否有交互式选择框；没有则返回 null
 export function detectPrompt(capture: string): Prompt | null {
@@ -65,12 +70,76 @@ export function detectPrompt(capture: string): Prompt | null {
       return { kind: 'select', question, choices }
     }
   }
+  const un = detectUnnumbered(lines)
+  if (un) return un
   // y/n 兜底
   for (let i = lines.length - 1; i >= 0 && lines.length - i <= 12; i--) {
     const c = clean(lines[i])
     if (!c) continue
     if (/\((?:y\/n|yes\/no|y\/N|Y\/n)\)|\[y\/n\]/i.test(c)) return { kind: 'yesno', question: c, choices: [] }
     break // 只检查屏幕最后一条非空行，避免把历史说明文字里的 (y/n) 当作当前提示
+  }
+  return null
+}
+
+// 无编号选择框：Claude 起手的「信任这个文件夹吗」就长这样——
+//     ❯ No, exit
+//       Yes, I trust this folder
+//     Enter to confirm · Esc to cancel
+// 一个编号都没有，OPT 那条路一项都认不出，于是新 worktree 的会话在对话面板里看着像
+// 死了：既没消息也没提问框，人只能切回终端页去按键。
+// 判据严到基本只有 TUI 满足：游标行 + 起始列严格对齐的兄弟行 + 附近的 Enter/Esc 操作提示。
+function detectUnnumbered(lines: string[]): Prompt | null {
+  const rows = lines.map(inner)
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const m = rows[i].match(CURSOR_ONLY)
+    if (!m || OPT.test(clean(rows[i]))) continue // 有编号的走上面那条正路
+    const col = m[1].length + 1 + m[2].length    // 游标本身占一列
+    // 兄弟选项：正文起始列与游标行**严格相同**，前面不能有别的字
+    const sibling = (r: string): string | null => {
+      if (r.length <= col || r[col] === ' ' || r.slice(0, col).trim() !== '') return null
+      const label = r.slice(col).trim()
+      return label && label.length <= 80 ? label : null
+    }
+    const group = [{ label: m[3].trim(), selected: true, idx: i }]
+    for (let k = i - 1; k >= 0 && i - k <= 6; k--) {
+      const l = sibling(rows[k]); if (!l) break
+      group.unshift({ label: l, selected: false, idx: k })
+    }
+    for (let k = i + 1; k < rows.length && k - i <= 6; k++) {
+      const l = sibling(rows[k]); if (!l) break
+      group.push({ label: l, selected: false, idx: k })
+    }
+    if (group.length < 2) continue
+    const top = group[0].idx
+    const bottom = group[group.length - 1].idx
+    const around = rows.slice(Math.max(0, top - 12), Math.min(rows.length, bottom + 4)).map((r) => r.trim()).join(' ')
+    if (!ACTION_HINT.test(around)) continue
+    // 真正在问的那句离选项挺远：信任框里隔着一整段权限清单，窄屏上还会折成四五行。
+    // 所以按空行切成段、由近及远找带问号的那段（整段拼起来再判，问号常落在折行处），
+    // 找不到就退回最近的那段。
+    let question = ''
+    let block: string[] = []
+    const take = (b: string[]) => b.slice(-5).join(' ')
+    for (let k = top - 1; k >= 0 && top - k <= 20; k--) {
+      const c = clean(rows[k])
+      if (c) { block.unshift(c); continue }
+      if (!block.length) continue
+      const text = take(block)
+      if (!question) question = text
+      if (QUESTION.test(text)) { question = text; break }
+      block = []
+    }
+    if (block.length) {
+      const text = take(block)
+      if (!question || QUESTION.test(text)) question = text
+    }
+    return {
+      kind: 'select',
+      question,
+      choices: group.map((o, n) => ({ num: n + 1, label: o.label, selected: o.selected })),
+      numbered: false,
+    }
   }
   return null
 }
@@ -105,7 +174,7 @@ function PromptActions({ p, accent, busy, choose, press }: {
                 borderColor: ch.selected ? accent : 'var(--border)', color: 'var(--text-bright)',
                 background: ch.selected ? accent + '22' : 'transparent',
               }}>
-              <b style={{ color: accent, marginRight: 6, display: 'inline-flex', alignItems: 'center' }}>{ch.selected ? <ChevronRight size={12} /> : null}{ch.num}.</b>{ch.label}
+              <b style={{ color: accent, marginRight: 6, display: 'inline-flex', alignItems: 'center' }}>{ch.selected ? <ChevronRight size={12} /> : null}{p.numbered === false ? '' : `${ch.num}.`}</b>{ch.label}
             </Button>
           ))}
         </Space>
@@ -150,6 +219,25 @@ function usePromptControl(name: string) {
     }
   }
 
+  // 无编号选择框只能用方向键：先把游标挪到目标上，**确认它真的挪到了**再回车。
+  // 不核对就回车的代价是替用户答错——信任框的第一项正是「No, exit」，按错一格会话就没了。
+  const chooseByArrows = async (before: Prompt, target: Choice) => {
+    const from = before.choices.find((c) => c.selected)?.num ?? 1
+    const step = target.num - from
+    if (step !== 0) {
+      const keys = Array.from({ length: Math.abs(step) }, () => (step > 0 ? 'Down' : 'Up'))
+      await api('POST', `/sessions/${encodeURIComponent(name)}/keys`, { keys })
+      await new Promise((r) => setTimeout(r, 350))
+    }
+    const moved = await fetchPrompt(name)
+    // 同名选项也要认得出，所以位置和文本都对上才算挪到了
+    const landed = moved?.numbered === false && moved.choices.length === before.choices.length &&
+      moved.choices.find((c) => c.selected)?.num === target.num && moved.choices[target.num - 1]?.label === target.label
+    if (!landed) { setP(moved); return }
+    await api('POST', `/sessions/${encodeURIComponent(name)}/keys`, { keys: ['Enter'] })
+    setTimeout(async () => { setP(await fetchPrompt(name)) }, 350)
+  }
+
   // 点选项只发数字，350ms 后再看屏幕：同一个问题还在（数字只是挪了高亮）才补 Enter。
   // 以前一律发「数字 + Enter」：Claude Code 的 AskUserQuestion 按数字就直接进下一题，
   // 那个 Enter 落到下一题上，把它的第一个选项当成你的答案交了；多问一题就多错一题。
@@ -157,6 +245,7 @@ function usePromptControl(name: string) {
     const before = p
     setBusy(true)
     try {
+      if (before?.numbered === false) { await chooseByArrows(before, target); return }
       await api('POST', `/sessions/${encodeURIComponent(name)}/keys`, { keys: [String(target.num)] })
       await new Promise((r) => setTimeout(r, 350))
       const after = await fetchPrompt(name)


### PR DESCRIPTION
## 问题

新 worktree 开出来的会话，第一屏是 Claude 的 `Do you trust this folder?`。这一刻对话面板两头落空：

1. 转录文件还不存在 → 后端 `GET /sessions/:name/transcript` 回 `400 BAD_FILE` → 前端把它当报错，在输入框上方挂一行红字 `BAD_FILE`；而且这个 err 只在轮询出错时写、成功时不擦，红字就一直挂着。
2. 信任框的选项**没有 `1.` `2.` 编号**（`❯ No, exit` / `  Yes, I trust this folder`），`detectPrompt` 一项都认不出 → 提问框不显示。

结果：面板上只有一行红字和一句「还没说过话」，看着像 agent 死了，人只能切回终端页按键。

## 改动

**转录不再把「还没有」当错误**（`backend/api/claude.go` / `codex.go`）：定位不到文件＝agent 刚起，回 `200` + 空列表；显式传进来的越界路径仍然是 `400 BAD_FILE`。前端每轮成功轮询擦掉上一次的报错；空状态那句话改看后端这轮**实际定位到的**文件（`undefined`=还在加载 → 「加载对话记录…」，`''`=确实没有 → 「这个 agent 刚起来…」），不再靠调用方传没传 `file` 猜。

**`detectPrompt` 认无编号选择框**（`frontend/src/components/prompt.tsx`）：游标行 + 起始列严格对齐的兄弟行 + 附近的 `Enter/Esc` 操作提示，三条都满足才算数。提问按空行切段、由近及远找带问号的那段（窄屏折成五行也拼得回来）。点选项走方向键，**核对游标真的挪到位了才回车**——信任框第一项是 `No, exit`，按错一格会话就没了。

## 验证

- 真机：桌面 Chrome 与安卓真机（触摸）各在对话面板里答了一次信任框，Claude 都正常进主界面；红字 BAD_FILE 消失，答完提问框自动收起。
- 误报扫描：20 个在跑会话 × 455 个 50 行窗口，新旧两版 `detectPrompt` 判定**零差异**。
- 回归用例：真机 capture 的宽屏/窄屏信任框各一条，外加「输入框那行 ❯ 不当选择框」；后端新增「没有转录文件回 200、越界路径仍 400」。
- `scripts/dev/quality/check.sh full` 通过；前端 `typecheck / i18n:check / hover:check / vitest(431) / build` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLHXVqUqHyP9kb4WyLmnt2