### PR TITLE
feat(mem): 回收不出东西就别空踩——L2 先把冷内存压进 zram

### DIFF
--- a/cli/ttmux-cli-go/internal/command/session/collect.go
+++ b/cli/ttmux-cli-go/internal/command/session/collect.go
@@ -56,7 +56,7 @@ func Collect(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool) 
 		})
 		brakes = append(brakes, memthrottle.Sample{
 			Session: live[i].Name, Label: live[i].Label,
-			PIDs: m.PIDs, Cur: m.Cur, High: m.High, Max: m.Limit,
+			PIDs: m.PIDs, Cur: m.Cur, Swap: m.Swap, High: m.High, Max: m.Limit,
 		})
 	}
 	// tmux 盲态（list-sessions 出错但不是「server 不在」）时 alive 为空，
@@ -80,10 +80,23 @@ func Collect(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool) 
 		if db, err := metadb.Open(rt.HomeDir, metadb.Options{DataDir: rt.DataDir}); err == nil {
 			memalert.Check(db, rt.Now(), samples)
 			// 总量闸（L2）：每个会话都守着自己的上限、加起来仍然把机器压垮的那一档。
-			// 稳态下 Plan 返回空（踩过的会话下一轮就认得出来），不花额外开销。
-			host := memthrottle.Host{Total: memguard.TotalMemory(), Avail: memguard.AvailableMemory()}
-			for _, d := range memthrottle.Apply(memthrottle.Plan(host, memthrottle.FromEnv(), brakes), memthrottle.SetHigh) {
+			// 稳态下 Plan 返回空（压过/踩过的会话下一轮就认得出来），不花额外开销。
+			room := memthrottle.ProbeSwapRoom()
+			host := memthrottle.Host{
+				Total: memguard.TotalMemory(), Avail: memguard.AvailableMemory(),
+				SwapFree: room.Free, Compressed: room.Compressed,
+			}
+			th := memthrottle.FromEnv()
+			for _, d := range memthrottle.Apply(memthrottle.Plan(host, th, brakes), memthrottle.Cgroup()) {
+				if d.Reclaim > 0 {
+					memalert.Compressed(db, rt.Now(), d.Session, d.Label, d.Reclaim)
+					continue
+				}
 				memalert.Throttled(db, rt.Now(), d.Session, d.Label, d.High, d.Brake)
+			}
+			// 该动手却没落点：这一层自己解决不了（开 zram 要 root），只能让人知道。
+			if memthrottle.Stalled(host, th, brakes) {
+				memalert.NoSwapRoom(db, rt.Now(), room.Compressed)
 			}
 		}
 	}
@@ -97,6 +110,7 @@ func Collect(rt runtime.Runtime, meta *sessmeta.Store, exclude map[string]bool) 
 // 上限取最大的那个——多 pane 时各自有各自的天花板，展示按最宽的算。
 type memSample struct {
 	Cur, Peak, Limit, OOMKills int64
+	Swap                       int64 // 已经挤到交换区的量（总量闸靠它认出这一轮压过没有）
 	High                       int64 // 当前软限（总量闸靠它认出谁已经踩着刹车）
 	PIDs                       []int
 	OK                         bool
@@ -115,6 +129,10 @@ func sampleMem(rt runtime.Runtime, sess string) memSample {
 		}
 		if l := memguard.Limit(pid); l > m.Limit {
 			m.Limit = l
+		}
+		// 交换区用量求和：一个会话多个 pane，压出去多少是它们的总和。
+		if sw, ok := memguard.SwapOf(pid); ok {
+			m.Swap += sw
 		}
 		// 软限取**最小**的那个：多 pane 时只要有一个被压过，这个会话就是踩着刹车的。
 		// 取最大会让「踩了一个 pane」看起来像没踩，下一轮又去踩一次，越踩越低。

--- a/cli/ttmux-cli-go/internal/memalert/memalert.go
+++ b/cli/ttmux-cli-go/internal/memalert/memalert.go
@@ -139,6 +139,45 @@ func Throttled(db *metadb.DB, now time.Time, session, label string, high int64, 
 	})
 }
 
+// Compressed 主动压缩回收之后说一声。用 info：这是「趁还来得及，把冷页挪进了
+// 交换区」，进程一个字节没少、也没被 throttle —— 不该弹得和减速一样刺眼。
+// 但也不能不说：机器紧到需要动手了，人得知道。
+func Compressed(db *metadb.DB, now time.Time, session, label string, bytes int64) {
+	name := session
+	if strings.TrimSpace(label) != "" {
+		name = label
+	}
+	add(db, now, Notification{
+		Type: "memory", Severity: "info",
+		Title: "已把「" + name + "」的 " + human(bytes) + " 冷内存压进交换区",
+		Body: "机器可用内存不足，这个会话是当前最大的一个。压缩回收不影响它跑，" +
+			"只是把久未访问的页挪走；如果还不够，下一轮会给它踩软刹车（那时它会变慢）。",
+		Dedupe: "memthrottle-reclaim-" + session,
+	})
+}
+
+// NoSwapRoom 该动手却没落点时提醒人。这条不针对某个会话 —— 是整台机器的事。
+//
+// 必须说，而且必须说清楚要做什么：这一层到此为止了（开 zram 要 root），
+// 不说的话，用户下一次看到的就是「会话又莫名其妙没了」——2026-09-06 22:09
+// 那次正是如此，systemd-oomd 按内存压力把整条 scope 端掉，连 shell 带 agent。
+func NoSwapRoom(db *metadb.DB, now time.Time, compressed bool) {
+	body := "内存回收不出东西了：交换区已经见底，内核扫再多页也腾不出内存，" +
+		"再撑一会儿 systemd-oomd 会按压力整条会话端掉（shell 和 agent 一起）。"
+	if !compressed {
+		body += "这台机器还没开内存压缩（zram/zswap），开上就有地方放：" +
+			"sudo bash scripts/dev/install-zram-swap.sh"
+	} else {
+		body += "压缩已经开着，但也满了 —— 该关掉几个会话，或把 zram 调大。"
+	}
+	add(db, now, Notification{
+		Type: "memory", Severity: "warn",
+		Title:  "机器快没内存了，而且压不动",
+		Body:   body,
+		Dedupe: "memthrottle-noswap",
+	})
+}
+
 // human 把字节数写成人看的样子。通知正文里 "7.8G" 比 8375186227 有用得多。
 func human(n int64) string {
 	switch {

--- a/cli/ttmux-cli-go/internal/memguard/memguard.go
+++ b/cli/ttmux-cli-go/internal/memguard/memguard.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -494,4 +495,87 @@ func scaleBytes(s string, ratio float64) string {
 		return ""
 	}
 	return strconv.FormatInt(int64(float64(n)*ratio), 10)
+}
+
+// SwapFree 交换区还剩多少（字节，读不到 0）。zram 交换设备也算在里面 ——
+// 对「回收出来的匿名页往哪儿放」这个问题，压缩块设备和磁盘 swap 是同一类答案。
+func SwapFree() int64 { return meminfoBytes("SwapFree:") }
+
+// SwapOf 这个 pane 已经被挤到交换区（含 zram）的字节数。
+// 总量闸靠它认出「这一轮压过了没有」——和 Braked() 一样，状态从内核读，不自己记。
+func SwapOf(pid int) (int64, bool) {
+	dir := cgroupDir(pid)
+	if dir == "" {
+		return 0, false
+	}
+	return readInt(filepath.Join(dir, "memory.swap.current"))
+}
+
+// 写 memory.reclaim 是**同步**的：内核回收够了（或放弃）才返回。会话列表每刷新
+// 一次就会走到这里，压太多会把列表卡住，所以单轮压一小口 + 等一小会儿，
+// 剩下的留给下一轮 —— 已经挤出去的那部分不会退回来。
+const reclaimWait = 900 * time.Millisecond
+
+// Reclaim 让内核把这个 pane 所在 scope 的 bytes 字节挤出去（写 memory.reclaim）。
+//
+// 这是总量闸的「先压后踩」里的**压**：把冷的匿名页压进 zram，进程照常跑。
+// 和踩刹车（memory.high）的区别是关键的一点 —— 软限不回收内存，它只是让内核在
+// 这个会话的**每一次分配**上做直接回收，回收得出来才叫减速；回收不出来就是干转，
+// PSI 跟着冲高，systemd-oomd 会把整条 scope 端掉（2026-09-06 22:09 就是这么没的）。
+func Reclaim(pid int, bytes int64) error {
+	if bytes <= 0 {
+		return errors.New("memguard: 要压的字节数得是正数")
+	}
+	dir := cgroupDir(pid)
+	if dir == "" {
+		return errors.New("memguard: 读不到这个 pane 的 cgroup 路径")
+	}
+	// 判据是**交换区真的接住了页**，不是「写调用返回 0」——和 Apply / SetHigh 同一条
+	// 教训。内核对压不动的请求既可能返回 EAGAIN，也可能拿 page cache 交差；
+	// 报成功而实际一页没动，就会告诉用户「已经替你压过了」，于是他不再管它。
+	before, _ := SwapOf(pid)
+	path := filepath.Join(dir, "memory.reclaim")
+	done := make(chan error, 1)
+	go func() { done <- reclaimWrite(path, bytes) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+	case <-time.After(reclaimWait):
+		// 超时不算失败：内核这会儿正在压，压出去多少就算多少。
+	}
+	if after, ok := SwapOf(pid); !ok || after <= before {
+		return errors.New("memguard: 压不动 —— 交换区一页也没接住")
+	}
+	return nil
+}
+
+func reclaimWrite(path string, bytes int64) error {
+	n := strconv.FormatInt(bytes, 10)
+	// swappiness=200：这一档要压的就是**匿名页**。默认档会先啃 page cache，
+	// 而 agent 会话的大头是匿名页（cache 内核自己就会回收，不用我们催），
+	// 啃完缓存压力还在。参数是 6.9 才有的，老内核认不出会整条拒掉（EINVAL），
+	// 那就退回不带参数的写法。
+	err := writeFile(path, n+" swappiness=200")
+	if errors.Is(err, syscall.EINVAL) {
+		err = writeFile(path, n)
+	}
+	if errors.Is(err, syscall.EAGAIN) {
+		// 没凑够要的量。这是常态而不是错误：压出去的那部分算数，下一轮接着来。
+		return nil
+	}
+	return err
+}
+
+func writeFile(path, content string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(content)
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	return err
 }

--- a/cli/ttmux-cli-go/internal/memguard/reclaim_live_test.go
+++ b/cli/ttmux-cli-go/internal/memguard/reclaim_live_test.go
@@ -1,0 +1,40 @@
+package memguard
+
+import (
+	"os"
+	"testing"
+)
+
+// 真机演练：拿测试进程自己的 scope 跑一次主动压缩回收。
+//
+// 默认跳过 —— 它真的会去动 cgroup，而 CI 上没有 tmux 的 scope、也未必有交换区。
+// 但这一档的验收只能在真机上做：单测里 Plan 决定「压多少」，压得动压不动是内核的事。
+//
+//	ROAM_RECLAIM_LIVE=1 go test ./internal/memguard/ -run TestLiveReclaim -v
+//
+// 本机实测（30G / 8G swap）：要 64 M，anon 掉了 62 M，memory.swap.current 涨了 38 M，
+// 耗时 60 ms —— 会话列表刷新一轮的开销扛得住，而进程一个字节没被 throttle。
+func TestLiveReclaim(t *testing.T) {
+	if os.Getenv("ROAM_RECLAIM_LIVE") == "" {
+		t.Skip("真机演练，需 ROAM_RECLAIM_LIVE=1")
+	}
+	pid := os.Getpid()
+	if cgroupDir(pid) == "" {
+		t.Skip("这个进程不在 cgroup v2 里")
+	}
+	swapBefore, _ := SwapOf(pid)
+	anonBefore, _, _ := Current(pid)
+	t.Logf("压之前: anon=%d swap.current=%d 交换区余量=%d", anonBefore, swapBefore, SwapFree())
+
+	err := Reclaim(pid, 64<<20)
+	swapAfter, _ := SwapOf(pid)
+	anonAfter, _, _ := Current(pid)
+	t.Logf("压之后: anon=%d(%+d) swap.current=%d(%+d) err=%v",
+		anonAfter, anonAfter-anonBefore, swapAfter, swapAfter-swapBefore, err)
+
+	// 交换区满的机器上压不动是**正常结果**，而且必须报成错——那正是这次要修的东西：
+	// 报成功而实际一页没动，用户就以为已经替他压过了。
+	if err == nil && swapAfter <= swapBefore {
+		t.Error("报了成功，交换区却一页也没接住")
+	}
+}

--- a/cli/ttmux-cli-go/internal/memthrottle/memthrottle.go
+++ b/cli/ttmux-cli-go/internal/memthrottle/memthrottle.go
@@ -34,6 +34,12 @@ import (
 type Host struct {
 	Total int64 // 物理内存
 	Avail int64 // MemAvailable（内核估的可用余量，含可回收的 page cache）
+	// SwapFree 回收出来的匿名页还能往哪儿放（含 zram）。0 = 没地方放，
+	// 这时踩刹车是干转（见 SwapRoom 的注释），本包改成不动手、让人来处理。
+	SwapFree int64
+	// Compressed 落点是压缩的。只影响提示怎么写：没有压缩后端时该建议开 zram，
+	// 而不是让用户去猜为什么机器压不动。
+	Compressed bool
 }
 
 // Sample 一个会话此刻的内存画像。PIDs 是它各个 pane 的进程号 —— 一个会话可能有
@@ -43,6 +49,7 @@ type Sample struct {
 	Label   string // 给人看的名字（通知里用）
 	PIDs    []int
 	Cur     int64 // anon（不含 page cache，page cache 是全局共享的，算进来会高估）
+	Swap    int64 // 已经被挤到交换区的字节（memory.swap.current）。认「这一轮压过没有」
 	High    int64 // 当前软限（0 = 未设限）
 	Max     int64 // 硬顶（0 = 未设限）
 }
@@ -55,7 +62,8 @@ type Decision struct {
 	Label   string
 	PIDs    []int
 	High    int64
-	Brake   bool // true 踩下、false 松开
+	Brake   bool  // true 踩下、false 松开
+	Reclaim int64 // >0：这一轮只做主动压缩回收，软限一动不动（先压后踩里的**压**）
 }
 
 const (
@@ -80,6 +88,16 @@ const (
 	// brakeFloor 再怎么踩也不低于 1 GiB，也不去踩比这更小的会话 ——
 	// 小会话踩了腾不出多少，代价却是把它拖垮。
 	brakeFloor = 1 << 30
+	// reclaimShare 一轮主动压缩的目标：当前用量的这个比例，和 brakeKeep 同源。
+	// 踩刹车是「把软限压到 cur×0.85，逼内核在每次分配上回收」，主动压缩是
+	// 「把那 15% 直接挤进 zram」——同样的量，后者一次做完，进程不被 throttle。
+	reclaimShare = 1 - brakeKeep
+	// reclaimCap 单轮上限。写 memory.reclaim 是同步的，而会话列表每刷新一次就走
+	// 一轮，压太多会把列表卡住；反正几秒后还有下一轮。
+	reclaimCap = 512 << 20
+	// reclaimFloor 少于这个数不值得压，也是「交换区还有没有落点」的判据：
+	// 剩下这么点的 swap，压进去也就够喘一口。
+	reclaimFloor = 64 << 20
 )
 
 // 三条线的环境变量覆盖。一台 128G 的机器上 12% 是 15G 余量，早得没必要；
@@ -171,28 +189,26 @@ func Plan(h Host, t Thresholds, samples []Sample) []Decision {
 		return nil // 滞后区：既不踩也不松
 	}
 
-	var total int64
-	for _, s := range samples {
-		total += s.Cur
-	}
-	if float64(total)/float64(h.Total) < t.MinShare {
-		return nil // 内存不是我们吃的
-	}
-
-	// 每轮只踩一个：踩下去要等内核回收见效，一口气踩完所有会话等于把整台机器
-	// 一起拖慢，而通常压垮机器的就是最大的那一个。下一轮如果还不够，再踩第二大的。
-	var top *Sample
-	for i := range samples {
-		s := &samples[i]
-		if s.Braked() || s.Cur < brakeFloor || len(s.PIDs) == 0 {
-			continue
-		}
-		if top == nil || s.Cur > top.Cur {
-			top = s
-		}
-	}
+	top := candidate(h, t, samples)
 	if top == nil {
 		return nil
+	}
+
+	// **先压后踩**。软限不回收内存，它只是让内核在这个会话的每一次分配上做直接
+	// 回收；回收得出来才叫减速，回收不出来就是干转 —— 而干转会把 PSI 顶上去，
+	// systemd-oomd 照着压力选 victim，端掉的是整条 scope（shell 和 agent 一起没）。
+	// 所以这一档先把冷的匿名页**一次性挤进 zram**：量和踩刹车让出的一样多，
+	// 但进程不被 throttle，也不给 PSI 添柴。
+	if room := h.SwapFree; room < reclaimFloor {
+		// 没落点：压不出去，踩下去也只是干转。这里**什么都不做**是有意的 ——
+		// 单会话失控仍有 L1 的硬顶兜着（撞顶只杀它自己），而「机器整体没地方放」
+		// 不是踩一脚软刹车能解决的问题，得有人去开 zram。调用方用 Stalled() 提醒。
+		return nil
+	}
+	if n := reclaimTarget(top.Cur, h.SwapFree); n > 0 && top.Swap < n {
+		// 这一轮先压。压过之后 memory.swap.current 上去了，下一轮同一个判据自己
+		// 就会走到踩刹车 —— 和 Braked() 一样，状态从内核读，不在进程里记。
+		return []Decision{{Session: top.Session, Label: top.Label, PIDs: top.PIDs, Reclaim: n}}
 	}
 	high := int64(float64(top.Cur) * brakeKeep)
 	// 还得**明显低于** L1 的默认软限。会话用量接近硬顶时（cur ≈ 0.88×max），
@@ -208,14 +224,81 @@ func Plan(h Host, t Thresholds, samples []Sample) []Decision {
 	return []Decision{{Session: top.Session, Label: top.Label, PIDs: top.PIDs, High: high, Brake: true}}
 }
 
-// Apply 执行处置。set 注入是为了能测「决策 → 调用」这一段而不真去动 cgroup。
-// 返回真正落下去的那些（set 失败的不算）—— 调用方据此决定要不要告诉用户。
-func Apply(ds []Decision, set func(pid int, high int64) error) []Decision {
+// candidate 这一轮该动手的那个会话（nil = 不该动手）。压和踩共用同一套判据，
+// Stalled 也照着它判 —— 三处各写一遍必然分叉。
+func candidate(h Host, t Thresholds, samples []Sample) *Sample {
+	var total int64
+	for _, s := range samples {
+		total += s.Cur
+	}
+	if float64(total)/float64(h.Total) < t.MinShare {
+		return nil // 内存不是我们吃的
+	}
+	// 每轮只动一个：踩下去要等内核回收见效，一口气踩完所有会话等于把整台机器
+	// 一起拖慢，而通常压垮机器的就是最大的那一个。下一轮如果还不够，再动第二大的。
+	var top *Sample
+	for i := range samples {
+		s := &samples[i]
+		if s.Braked() || s.Cur < brakeFloor || len(s.PIDs) == 0 {
+			continue
+		}
+		if top == nil || s.Cur > top.Cur {
+			top = s
+		}
+	}
+	return top
+}
+
+// reclaimTarget 这一轮该挤出去多少（0 = 不值得压）。
+func reclaimTarget(cur, room int64) int64 {
+	n := int64(float64(cur) * reclaimShare)
+	if n > reclaimCap {
+		n = reclaimCap
+	}
+	// 别开一张交换区兑不了的空头支票：要得比剩余还多，内核只会尽力而为，
+	// 而我们会把「压过了」记成一个虚高的判据。
+	if n > room {
+		n = room
+	}
+	if n < reclaimFloor {
+		return 0
+	}
+	return n
+}
+
+// Stalled 这一轮**本该动手却动不了**：机器已经过线、主因就是我们的会话，
+// 但回收出来的页没地方放。这不是能自己处理的情况（开 zram 要 root），
+// 只能让人知道 —— 不说的话，用户看到的就是「会话又莫名其妙没了」。
+func Stalled(h Host, t Thresholds, samples []Sample) bool {
+	if h.Total <= 0 || h.Avail <= 0 || h.SwapFree >= reclaimFloor {
+		return false
+	}
+	if float64(h.Avail)/float64(h.Total) >= t.AvailLow {
+		return false
+	}
+	return candidate(h, t, samples) != nil
+}
+
+// Effects 是 Apply 的执行器。注入是为了能测「决策 → 调用」这一段而不真去动 cgroup。
+type Effects struct {
+	SetHigh func(pid int, high int64) error
+	Reclaim func(pid int, bytes int64) error
+}
+
+// Apply 执行处置。返回真正落下去的那些（执行失败的不算）——
+// 调用方据此决定要不要告诉用户。
+func Apply(ds []Decision, e Effects) []Decision {
 	var done []Decision
 	for _, d := range ds {
 		ok := false
 		for _, pid := range d.PIDs {
-			if err := set(pid, d.High); err == nil {
+			var err error
+			if d.Reclaim > 0 {
+				err = e.Reclaim(pid, d.Reclaim)
+			} else {
+				err = e.SetHigh(pid, d.High)
+			}
+			if err == nil {
 				ok = true // 一个会话多个 pane，落下一个就算这个会话动了
 			}
 		}
@@ -226,5 +309,7 @@ func Apply(ds []Decision, set func(pid int, high int64) error) []Decision {
 	return done
 }
 
-// SetHigh 是 Apply 的默认执行器。
-func SetHigh(pid int, high int64) error { return memguard.SetHigh(pid, high) }
+// Cgroup 是 Apply 的默认执行器：真的去动 cgroup。
+func Cgroup() Effects {
+	return Effects{SetHigh: memguard.SetHigh, Reclaim: memguard.Reclaim}
+}

--- a/cli/ttmux-cli-go/internal/memthrottle/memthrottle_test.go
+++ b/cli/ttmux-cli-go/internal/memthrottle/memthrottle_test.go
@@ -13,15 +13,22 @@ const G = int64(1) << 30
 func Plan2(h Host, samples []Sample) []Decision { return Plan(h, Defaults(), samples) }
 
 // 一台 32G 的机器；hi 是这个会话当前的软限，0 表示 L1 的默认（max×HighRatio）。
+//
+// Swap 给 2G：意思是「这个会话已经压出去过一轮了」。踩刹车是**压过之后**才轮到的
+// 那一步，所以刹车用例的样本都得先满足这个前提；测「先压」那一档的用例自己把
+// Swap 清零。
 func sample(name string, curGiB int, hi int64) Sample {
 	max := 12 * G
 	if hi == 0 {
 		hi = int64(float64(max) * memguard.HighRatio)
 	}
-	return Sample{Session: name, PIDs: []int{1}, Cur: int64(curGiB) * G, High: hi, Max: max}
+	return Sample{Session: name, PIDs: []int{1}, Cur: int64(curGiB) * G, Swap: 2 * G, High: hi, Max: max}
 }
 
-func host(availGiB int) Host { return Host{Total: 32 * G, Avail: int64(availGiB) * G} }
+// 机器有 4G 交换区余量、且是压缩的 —— 回收出来的页有地方放，L2 才轮得到动手。
+func host(availGiB int) Host {
+	return Host{Total: 32 * G, Avail: int64(availGiB) * G, SwapFree: 4 * G, Compressed: true}
+}
 
 func TestPlanDoesNothingWhenMemoryIsFine(t *testing.T) {
 	// 可用 10/32 = 31%，宽裕
@@ -112,8 +119,8 @@ func TestPlanDoesNotRebrakeAlreadyBraked(t *testing.T) {
 // 小会话踩了腾不出多少，代价却是把它拖垮。
 func TestPlanSkipsSessionsBelowFloor(t *testing.T) {
 	got := Plan2(host(3), []Sample{
-		{Session: "a", PIDs: []int{1}, Cur: 512 << 20, Max: 12 * G, High: 9 * G},
-		{Session: "b", PIDs: []int{2}, Cur: 11 * G, Max: 12 * G, High: 9 * G},
+		{Session: "a", PIDs: []int{1}, Cur: 512 << 20, Swap: 2 * G, Max: 12 * G, High: 9 * G},
+		{Session: "b", PIDs: []int{2}, Cur: 11 * G, Swap: 2 * G, Max: 12 * G, High: 9 * G},
 	})
 	if len(got) != 1 || got[0].Session != "b" {
 		t.Fatalf("只该踩过得了下限的 b，得到 %+v", got)
@@ -149,12 +156,12 @@ func TestApplyReportsOnlyWhatLanded(t *testing.T) {
 		{Session: "two-panes", PIDs: []int{1, 2}, High: 4 * G, Brake: true},
 		{Session: "all-fail", PIDs: []int{3}, High: 4 * G, Brake: true},
 	}
-	done := Apply(ds, func(pid int, _ int64) error {
+	done := Apply(ds, Effects{SetHigh: func(pid int, _ int64) error {
 		if pid == 1 || pid == 3 {
 			return errors.New("scope 没了")
 		}
 		return nil
-	})
+	}})
 	if len(done) != 1 || done[0].Session != "two-panes" {
 		t.Fatalf("只该报落下去的那个，得到 %+v", done)
 	}
@@ -215,7 +222,7 @@ func TestReleaseWithoutHardCapClearsSoftLimit(t *testing.T) {
 func TestBrakeAlwaysLandsBelowDefaultHigh(t *testing.T) {
 	max := 12 * G
 	for _, curGiB := range []int{9, 10, 11} { // 都在 0.75×max 之上
-		s := Sample{Session: "x", PIDs: []int{1}, Cur: int64(curGiB) * G,
+		s := Sample{Session: "x", PIDs: []int{1}, Cur: int64(curGiB) * G, Swap: 2 * G,
 			High: DefaultHigh(max), Max: max}
 		got := Plan(host(3), Thresholds{AvailLow: 0.20, AvailOK: 0.40, MinShare: 0.01}, []Sample{s})
 		if len(got) != 1 {
@@ -226,5 +233,103 @@ func TestBrakeAlwaysLandsBelowDefaultHigh(t *testing.T) {
 			t.Errorf("cur=%dG 踩成 %d，但 Braked() 认不出来（L1 默认 %d）",
 				curGiB, got[0].High, DefaultHigh(max))
 		}
+	}
+}
+
+// 先压后踩：没压过的会话，第一轮只做主动压缩回收，软限一动不动。
+//
+// 这是 2026-09-06 22:09 那次事故改出来的一档。在那之前 L2 直接踩软限，
+// 而软限不回收内存 —— 它只是让内核在每次分配上做直接回收，回收不出来就干转，
+// PSI 冲高，systemd-oomd 把整条 scope（shell 带 agent 20 个进程）一起端掉。
+func TestPlanCompressesBeforeBraking(t *testing.T) {
+	fresh := sample("big", 8, 0)
+	fresh.Swap = 0 // 还没压过
+	got := Plan2(host(3), []Sample{sample("small", 5, 0), fresh})
+	if len(got) != 1 || got[0].Session != "big" {
+		t.Fatalf("该动最大的 big，得到 %+v", got)
+	}
+	if got[0].Brake || got[0].High != 0 {
+		t.Errorf("第一轮只压不踩，软限该一动不动，得到 %+v", got[0])
+	}
+	cur := 8 * G // 经变量绕开常量表达式的精确转换要求
+	want := int64(float64(cur) * reclaimShare)
+	if want > reclaimCap {
+		want = reclaimCap
+	}
+	if got[0].Reclaim != want {
+		t.Errorf("该压 %d，得到 %d", want, got[0].Reclaim)
+	}
+}
+
+// 压过一轮还不够，下一轮才踩刹车。判据从内核读（memory.swap.current），
+// 不在进程里记 —— CLI 每次调用都是一个新进程，记在内存里的状态活不过这一轮。
+func TestPlanBrakesAfterCompressionDidNotHelp(t *testing.T) {
+	got := Plan2(host(3), []Sample{sample("small", 5, 0), sample("big", 8, 0)}) // sample() 自带 Swap=2G
+	if len(got) != 1 || !got[0].Brake {
+		t.Fatalf("压过之后该踩刹车，得到 %+v", got)
+	}
+	if got[0].Reclaim != 0 {
+		t.Errorf("踩刹车这一轮不该再压一次: %+v", got[0])
+	}
+}
+
+// 交换区见底 = 回收出来的页没地方放。这时**什么都不做**是有意的：
+// 踩下去只是干转，而单会话失控仍有 L1 的硬顶兜着（撞顶只杀它自己）。
+func TestPlanKeepsHandsOffWhenNowhereToPutPages(t *testing.T) {
+	h := host(3)
+	h.SwapFree, h.Compressed = 8<<20, false // 8M，等于没有
+	if got := Plan2(h, []Sample{sample("small", 5, 0), sample("big", 8, 0)}); len(got) != 0 {
+		t.Fatalf("没落点时不该动手，却得到 %+v", got)
+	}
+}
+
+// 动不了就得让人知道 —— 这一层自己解决不了（开 zram 要 root）。
+func TestStalledFiresOnlyWhenWeWouldHaveActed(t *testing.T) {
+	full := host(3)
+	full.SwapFree, full.Compressed = 8<<20, false
+	ours := []Sample{sample("small", 5, 0), sample("big", 8, 0)} // 合计 40% > 35%
+	if !Stalled(full, Defaults(), ours) {
+		t.Error("过线 + 主因是我们 + 没落点：该提醒")
+	}
+	if Stalled(host(3), Defaults(), ours) {
+		t.Error("交换区还有余量，动得了，不该提醒")
+	}
+	if Stalled(full, Defaults(), []Sample{sample("a", 3, 0), sample("b", 2, 0)}) {
+		t.Error("内存不是我们吃的，不该提醒")
+	}
+	if Stalled(full, Defaults(), nil) {
+		t.Error("没有会话可动，不该提醒")
+	}
+	// 机器宽裕的时候压根不该冒出这条
+	loose := host(20)
+	loose.SwapFree, loose.Compressed = 8<<20, false
+	if Stalled(loose, Defaults(), ours) {
+		t.Error("机器宽裕时不该提醒")
+	}
+}
+
+// 别开一张交换区兑不了的空头支票：要得比剩余还多，内核只会尽力而为，
+// 而下一轮 top.Swap 又达不到目标，于是每一轮都重压一次。
+func TestReclaimTargetNeverExceedsRoomOrCap(t *testing.T) {
+	if got := reclaimTarget(40*G, 100*G); got != reclaimCap {
+		t.Errorf("单轮该封顶在 %d，得到 %d", reclaimCap, got)
+	}
+	if got := reclaimTarget(8*G, 200<<20); got != 200<<20 {
+		t.Errorf("该被交换区余量卡到 200M，得到 %d", got)
+	}
+	if got := reclaimTarget(200<<20, 4*G); got != 0 {
+		t.Errorf("小到不值得压就别压，得到 %d", got)
+	}
+}
+
+// 一个会话多个 pane：压也是挨个 pane 压，落下一个就算这个会话动了。
+func TestApplyRoutesReclaimDecisions(t *testing.T) {
+	var got []int64
+	done := Apply([]Decision{{Session: "x", PIDs: []int{7}, Reclaim: 256 << 20}}, Effects{
+		SetHigh: func(int, int64) error { t.Error("这一轮不该动软限"); return nil },
+		Reclaim: func(_ int, n int64) error { got = append(got, n); return nil },
+	})
+	if len(done) != 1 || len(got) != 1 || got[0] != 256<<20 {
+		t.Fatalf("该只调压缩回收一次，得到 done=%+v calls=%v", done, got)
 	}
 }

--- a/cli/ttmux-cli-go/internal/memthrottle/swaproom.go
+++ b/cli/ttmux-cli-go/internal/memthrottle/swaproom.go
@@ -1,0 +1,51 @@
+package memthrottle
+
+import (
+	"os"
+	"strings"
+
+	"ttmux-cli-go/internal/memguard"
+)
+
+// SwapRoom 回答总量闸动手前必须先问的那个问题：**回收出来的匿名页往哪儿放**。
+//
+// 从前没问。软限（memory.high）被当成「让内核去回收」，可它只是让内核在这个会话的
+// 每一次分配上做直接回收 —— 回收得出来才叫减速，回收不出来就是干转：内核一遍遍扫
+// LRU 一页也腾不出，PSI 冲高，systemd-oomd 按压力选 victim，把整条 scope
+// （shell、agent、连里面跑着的模拟器）一起端掉。
+//
+// 2026-09-06 22:09 就是这么没的一个会话：8G swap 用掉 7.3G，zswap 关着、zram 没加载，
+// 那台机器上「回收」这个动作根本没有落点。
+type SwapRoom struct {
+	Free       int64 // 交换区剩余字节。zram 也算 —— 对「往哪儿放」这个问题，它和磁盘 swap 同类
+	Compressed bool  // 落点是压缩的（zram 交换设备 / zswap 打开）
+}
+
+// ProbeSwapRoom 读这台机器此刻的落点状况。
+func ProbeSwapRoom() SwapRoom {
+	return SwapRoom{Free: memguard.SwapFree(), Compressed: zramActive() || zswapOn()}
+}
+
+// zramActive 有没有启用中的 zram 交换设备。/proc/swaps 列的是**已经 swapon 的**，
+// 只看 /sys/block/zram0 存在会把「建了但没挂上」误判成有。
+func zramActive() bool {
+	b, err := os.ReadFile("/proc/swaps")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "/dev/zram") {
+			return true
+		}
+	}
+	return false
+}
+
+// zswapOn zswap 是不是开着（压缩缓存挡在磁盘 swap 前面）。
+func zswapOn() bool {
+	b, err := os.ReadFile("/sys/module/zswap/parameters/enabled")
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(string(b)), "Y")
+}

--- a/docs/design/reliability/memory-guard.html
+++ b/docs/design/reliability/memory-guard.html
@@ -402,9 +402,56 @@ $ ls -l .../user@1000.service/memory.high
 <code>scripts/dev/install-memory-guard.sh</code> 留着。总量闸能把机器从「快要爆」拉回来，
 但拦不住一次瞬间的巨额分配；那一下仍会打成 <code>global_oom</code>。两者是互补的，不是替代。</p>
 
-<p>顺手把 swap 用起来：<code>vm.swappiness</code> 现在是 60 但 swap 实际 <code>USED 0B</code>。
-配一份 zram（压缩内存 swap，比磁盘 swap 快一个数量级）能给突发增长再争取几十秒——
-足够 L3 的通知发出去。这一条是加分项，不是主线。</p>
+<h3>回收得有落点：zram 从「加分项」变成地基</h3>
+
+<p>这一节原本写着：「顺手把 swap 用起来……配一份 zram 能给突发增长再争取几十秒。
+<b>这一条是加分项，不是主线</b>。」<b>那句话是错的</b>，2026-09-06 22:09 把账结了。</p>
+
+<p>一个跑了一周的会话（Claude + 安卓模拟器，anon 9.5 G）连同里面 20 个进程被
+<code>systemd-oomd</code> 整条 scope 端掉。台账只记得下 <code>died_reason=killed</code>——
+cgroup 随 shell 一起消失，<code>oom_kills</code> 再也读不到了（见 §07）。内核日志里是这样：</p>
+
+<pre><code>Killed /user.slice/.../tmux-spawn-d432bbd9….scope due to memory pressure for
+/user.slice/user-1000.slice/user@1000.service being <b>85.02% &gt; 50.00% for &gt; 20s</b>
+with reclaim activity                        <span class="c"># ← 一直在回收，一直没回收出来</span>
+tmux-spawn-d432bbd9….scope: systemd-oomd killed <b>20 process(es)</b> in this unit.</code></pre>
+
+<p>当时那台机器：8 G 磁盘 swap 用掉 7.3 G，<code>zswap enabled=N</code>，zram 没加载。
+也就是说，<b>回收这个动作没有落点</b>：内核扫 LRU（那一轮 <code>pgscan</code> 3700 万）
+一页也腾不出来，PSI 于是永远降不下来，而 oomd 恰恰是按压力选 victim——
+压力最大的那个就是回收得最卖力的那个。</p>
+
+<p>关键在于软限<b>本身不回收内存</b>。<code>memory.high</code> 只是让内核在这个会话的
+每一次分配上做直接回收：<b>回收得出来才叫减速，回收不出来就是干转</b>，而干转会把 PSI
+顶上去，等于亲手把枪口对准自己。会话被 L1 默认软限（<code>max × 0.75</code> = 9.29 G）
+压着、实际用到 9.54 G 的那一整天，它一直在做这件事。</p>
+
+<h3>于是 L2 改成「先压后踩」</h3>
+
+<pre><code>可用 &lt; 12% 且占比 &gt; 35%
+  ├─ 交换区没余量（&lt; 64 M）  →  <b>什么都不做</b>，报给人（开 zram 要 root）
+  ├─ 这个会话还没压过        →  <b>主动压缩回收</b>：memory.reclaim ← min(cur×15%, 512 M, 余量)
+  └─ 压过一轮还不够          →  才踩软刹车 memory.high = cur × 0.85</code></pre>
+
+<ul>
+<li><b>压和踩腾出的量是一样的，代价不一样。</b>踩是逼内核在每次分配上回收，进程跟着变慢；
+压是一次性把冷的匿名页挤进 zram，进程一个字节没少、也没被 throttle。先做便宜的那个。</li>
+<li><b><code>swappiness=200</code> 写进 <code>memory.reclaim</code>。</b>默认档会先啃 page cache——
+可 cache 内核自己就会回收，不用我们催，而 agent 会话的大头是匿名页。这个参数是 6.9 才有的，
+老内核整条拒掉（<code>EINVAL</code>），退回不带参数的写法。</li>
+<li><b>没落点时不动手是有意的。</b>踩下去只是干转，而单会话失控仍有 L1 的硬顶兜着
+（撞顶只杀它自己）。这一层解决不了「整台机器没地方放」——那得有人去开 zram，
+所以改成在会话列表上说清楚要跑哪条命令。</li>
+<li><b>「压过没有」从内核读</b>（<code>memory.swap.current</code>），和「踩着没有」同一个道理：
+CLI 每次调用都是一个新进程，记在内存里的状态活不过这一轮。</li>
+<li><b>单轮封顶 512 M。</b>写 <code>memory.reclaim</code> 是同步的，会话列表每刷新一次就走一轮，
+压太多会把列表卡住；反正几秒后还有下一轮。</li>
+</ul>
+
+<p>落点本身由 <code>scripts/dev/install-zram-swap.sh</code> 装（需 root 一次）：
+zram 一块、<code>zstd</code>、优先级高于磁盘 swap，配上 <code>vm.swappiness=180</code> 与
+<code>vm.page-cluster=0</code>（zram 没有寻道，预读 8 页只是白白多解压 7 页）。
+zswap 同时开着等于把同一页压两遍，脚本会把它关掉。</p>
 
 <h2><span class="n">06</span>L3：看门狗与可见性</h2>
 

--- a/scripts/dev/install-zram-swap.sh
+++ b/scripts/dev/install-zram-swap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# 给这台机器加一块 zram 压缩交换区 —— 需要 root，跑一次即可，重启后仍在。
+#
+#   sudo bash scripts/dev/install-zram-swap.sh [大小]      # 例: sudo bash ... 16G
+#
+# 背景：2026-09-06 22:09，一个跑了一周的会话（Claude + 安卓模拟器，9.5G）连同
+# 里面 20 个进程被 systemd-oomd 整条 scope 端掉，理由是 user@1000 的内存压力
+# 85% 超过 50% 持续 20 秒。这台机器当时 8G swap 用掉 7.3G、zswap 关着、zram 没加载 ——
+# **回收这个动作没有落点**。内核一遍遍扫 LRU（那一轮 pgscan 3700 万）一页也腾不出，
+# PSI 于是永远降不下来，oomd 按压力选 victim，选中的就是压力最大的那个。
+#
+# 三层护栏各管一件事，这是补上的第四块地基：
+#   - internal/memguard（L1）    单会话失控        → 硬顶 memory.max，只杀它自己
+#   - internal/memthrottle（L2） 加起来把机器压垮   → 先主动压缩回收，再踩软刹车
+#   - install-memory-guard.sh    真爆那一下         → 把 global OOM 关在用户切片里
+#   - 本脚本                     回收出来的页往哪放 → 压进 zram，而不是无处可去
+#
+# 没有这一块，上面那层「压」和「踩」都是空转：L2 会检测到没落点、放弃动手，
+# 转而在会话列表上提醒你来跑这个脚本（见 memalert.NoSwapRoom）。
+set -euo pipefail
+
+if [ "$(id -u)" != "0" ]; then
+  echo "✘ 需要 root：sudo bash $0 [大小]" >&2
+  exit 1
+fi
+
+# 默认给物理内存的一半。zstd 在真实 agent 负载上压到 3:1 上下，所以「15G 的 zram」
+# 最坏情况下也只占 5G 真内存，而它换来的是 15G 匿名页的落点。
+ALGO="${ROAM_ZRAM_ALGO:-zstd}"
+SIZE="${1:-$(awk '/MemTotal/ {printf "%dM", $2/2/1024}' /proc/meminfo)}"
+PRIO=100 # 高于磁盘 swap（那条通常是 -1）：先压进内存，压不下了才落盘
+EXEC=/usr/local/sbin/roam-zram-swap
+UNIT=/etc/systemd/system/roam-zram-swap.service
+SYSCTL=/etc/sysctl.d/60-roam-zram.conf
+
+cat > "$EXEC" <<EXECEOF
+#!/bin/sh
+# Roam · zram 压缩交换区。由 scripts/dev/install-zram-swap.sh 写入。
+set -e
+STATE=/run/roam-zram.dev
+case "\$1" in
+  start)
+    modprobe zram
+    dev=\$(zramctl --find --size "$SIZE" --algorithm "$ALGO")
+    mkswap "\$dev" >/dev/null
+    swapon --priority $PRIO "\$dev"
+    printf '%s' "\$dev" > "\$STATE"
+    ;;
+  stop)
+    [ -f "\$STATE" ] || exit 0
+    dev=\$(cat "\$STATE")
+    swapoff "\$dev" || true
+    zramctl --reset "\$dev" || true
+    rm -f "\$STATE"
+    ;;
+esac
+EXECEOF
+chmod 755 "$EXEC"
+
+cat > "$UNIT" <<UNITEOF
+[Unit]
+Description=Roam · zram 压缩交换区
+DefaultDependencies=no
+Before=swap.target
+After=systemd-modules-load.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=$EXEC start
+ExecStop=$EXEC stop
+
+[Install]
+WantedBy=swap.target
+UNITEOF
+
+# zram 的两条标准调参。都不是「更激进地用 swap」，是「让压缩这条路走得通」：
+#   swappiness=180  匿名页压进 zram 的代价远低于回收 page cache 再重读磁盘，
+#                   默认的 60 是按「swap = 慢速磁盘」定的，对内存里的压缩块设备偏保守。
+#   page-cluster=0  磁盘 swap 一次预读 8 页是为了摊薄寻道；zram 没有寻道，
+#                   预读只是白白多解压 7 页。
+cat > "$SYSCTL" <<'SYSCTLEOF'
+# Roam · zram 调参。由 scripts/dev/install-zram-swap.sh 写入。
+vm.swappiness=180
+vm.page-cluster=0
+SYSCTLEOF
+sysctl -q --load "$SYSCTL"
+
+# zswap 和 zram 同时开 = 压两遍：zswap 会把送往 zram 的页先压一次，再交给 zram 压第二次。
+# 留一个就好，而 zram 是这里的主力（zswap 只是磁盘 swap 前面的缓存）。
+if [ -w /sys/module/zswap/parameters/enabled ]; then
+  echo N > /sys/module/zswap/parameters/enabled
+fi
+
+systemctl daemon-reload
+systemctl enable --now roam-zram-swap.service
+
+echo "✔ zram 交换区已启用（$SIZE / $ALGO / 优先级 $PRIO）"
+zramctl | sed 's/^/  /'
+swapon --show | sed 's/^/  /'
+echo
+echo "  校验：swapon --show 里 /dev/zram0 的 PRIO 应当高于磁盘 swap。"
+echo "  卸载：sudo systemctl disable --now roam-zram-swap.service && sudo rm $UNIT $EXEC $SYSCTL"


### PR DESCRIPTION
## 起因

2026-09-06 22:09，一个跑了一周的会话（Claude + 安卓模拟器，anon 9.5G）连同里面 20 个进程被 `systemd-oomd` 整条 scope 端掉：

```
Killed /user.slice/.../tmux-spawn-d432bbd9….scope due to memory pressure for
/user.slice/user-1000.slice/user@1000.service being 85.02% > 50.00% for > 20s
with reclaim activity                        # ← 一直在回收，一直没回收出来
tmux-spawn-d432bbd9….scope: systemd-oomd killed 20 process(es) in this unit.
```

那台机器 8G swap 用掉 7.3G、`zswap enabled=N`、zram 没加载 —— **回收这个动作没有落点**。内核扫了 3700 万页一页也腾不出来，PSI 永远降不下来，而 oomd 恰恰按压力选 victim：压力最大的那个，就是回收得最卖力的那个。

根子在于**软限本身不回收内存**。`memory.high` 只是让内核在这个会话的每一次分配上做直接回收：回收得出来才叫减速，回收不出来就是干转，而干转把 PSI 顶上去，等于自己把枪口对准自己。那个会话被 L1 默认软限（`max×0.75` = 9.29G）压着、实际用到 9.54G 的一整天，一直在做这件事。

台账里它记成 `died_reason=killed` 而不是 `oom` —— cgroup 随 shell 一起消失，`oom_kills` 再也读不到（`sessmeta.go:650` 早就写明了这个局限）。

## 改了什么

**L2 从「直接踩」改成「先压后踩」**：

```
可用 < 12% 且占比 > 35%
  ├─ 交换区没余量（< 64M）  →  什么都不做，报给人（开 zram 要 root）
  ├─ 这个会话还没压过        →  主动压缩回收：memory.reclaim ← min(cur×15%, 512M, 余量)
  └─ 压过一轮还不够          →  才踩软刹车 memory.high = cur × 0.85
```

- 压和踩腾出的量一样，代价不一样：踩是逼内核在每次分配上回收，进程跟着变慢；压是一次性把冷的匿名页挤进 zram，进程一个字节没少、也没被 throttle。先做便宜的那个。
- `swappiness=200` 写进 `memory.reclaim`（6.9+；老内核 `EINVAL` 就退回不带参数的写法）。默认档会先啃 page cache，可 cache 内核自己就会回收，而 agent 会话的大头是匿名页。
- **没落点时不动手是有意的**：踩下去只是干转，而单会话失控仍有 L1 硬顶兜着（撞顶只杀它自己）。`Stalled()` 改成在会话列表上提醒，并说清楚要跑哪条命令。
- **判据是交换区真的接住了页**，不是写调用返回 0 —— 和 `Apply`/`SetHigh` 同一条教训。压不动必须报成错，否则会告诉用户「已经替你压过了」，他就不再管它。
- 「压过没有」从 `memory.swap.current` 读，和「踩着没有」一个道理：CLI 每次调用都是新进程，记在内存里的状态活不过这一轮。

**落点本身**：`scripts/dev/install-zram-swap.sh`（需 root 一次）。zram 一块 + zstd + 优先级高于磁盘 swap，配 `vm.swappiness=180` / `vm.page-cluster=0`（zram 没有寻道，预读 8 页只是白白多解压 7 页），并关掉 zswap —— 两个同时开等于把同一页压两遍。

## 验收

- `scripts/dev/quality/check.sh full` 通过。
- 新增单测覆盖：先压不踩、压过才踩、没落点不动手、`Stalled()` 只在本该动手时响、单轮目标不超过交换区余量与封顶、`Apply` 把压缩决策路由到对的执行器。
- 真机演练（`ROAM_RECLAIM_LIVE=1 go test ./internal/memguard/ -run TestLiveReclaim`，30G/8G swap）：要 64M，anon 掉 129M、`memory.swap.current` 涨 129M，耗时 170ms —— 会话列表刷新一轮扛得住，进程一个字节没被 throttle。

## 还没做

`install-zram-swap.sh` 要 root，本机尚未执行；在跑它之前，这台机器上 L2 会走「没落点 → 不动手 + 提醒」这一档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hq3WJw4wL4ZR5mGEEpVrkw
