### PR TITLE
fix(api): 返回 JSON 的端点只认 stdout —— 插件日志混进来，整份响应就不是 JSON 了

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -63,12 +63,38 @@ func New(tt *ttmux.Client, browserHome, dataDir, fallbackBin string) *API {
 
 // json 透传 ttmux 的 --json 输出
 func (a *API) json(c *gin.Context, args ...string) {
-	out, err := a.TT.Run(args...)
+	// 只认 stdout。日志走 stderr（插件 SDK 的 Logf 就是这么写的），混进来会让整份
+	// 响应不再是 JSON，浏览器那边只剩一句「Unexpected token 'r'」——定时任务保存
+	// 明明成功了，界面上却是一条报错，就是这么来的。
+	out, errOut, err := a.TT.RunJSON(args...)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": ttmux.StripANSI(out)}})
+		msg := strings.TrimSpace(ttmux.StripANSI(errOut))
+		if msg == "" {
+			msg = ttmux.StripANSI(out)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "TTMUX_ERROR", "message": msg}})
 		return
 	}
-	c.Data(http.StatusOK, "application/json; charset=utf-8", []byte(out))
+	body := strings.TrimSpace(ttmux.StripANSI(out))
+	if !json.Valid([]byte(body)) {
+		// 命令说自己成功了，吐的却不是 JSON。把 stderr 原样报出去：那里通常写着原因，
+		// 而前端拿到半截 JSON 只会抛解析错，把真正的话盖掉。
+		msg := strings.TrimSpace(ttmux.StripANSI(errOut))
+		if msg == "" {
+			msg = firstLine(body)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "BAD_JSON", "message": msg}})
+		return
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", []byte(body))
+}
+
+// firstLine 截第一行给错误消息用：命令失败时输出可能是一整屏。
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // text 返回写操作的纯文本结果（去 ANSI）

--- a/backend/api/json_stdout_test.go
+++ b/backend/api/json_stdout_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"ttmux-web/ttmux"
+)
+
+// 返回 JSON 的端点只认 stdout。
+//
+// 插件 SDK 的 Logf 写的是 stderr（`[roam.cron] 已添加定时任务 …`），而底层的
+// ttmux.Run 把两股合在一起——于是「新增定时任务」明明保存成功了，界面上弹的却是
+// 「Unexpected token 'r', "[roam.cron]"… is not valid JSON」，真正的那行日志反倒
+// 把结果盖掉了。
+func fakeTT(t *testing.T, script string) *gin.Engine {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "fake-ttmux")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/plugins/:id/run", (&API{TT: ttmux.New(bin)}).PluginRun)
+	return r
+}
+
+func postRun(r *gin.Engine) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/plugins/roam.cron/run",
+		strings.NewReader(`{"command":"cron.add","args":{"name":"zz"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestJSONIgnoresStderrLogs(t *testing.T) {
+	w := postRun(fakeTT(t, "echo '[roam.cron] 已添加定时任务 zz' >&2\nprintf '{\"name\":\"zz\",\"enabled\":true}\\n'\n"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("响应必须是干净的 JSON：%v，body = %q", err, w.Body.String())
+	}
+	if got["name"] != "zz" {
+		t.Errorf("name = %v, want zz", got["name"])
+	}
+}
+
+// 命令自称成功却没吐 JSON：报 BAD_JSON，并把 stderr 原样带出来——
+// 前端拿半截 JSON 只会抛解析错，把真正的原因盖掉。
+func TestJSONReportsNonJSONOutput(t *testing.T) {
+	w := postRun(fakeTT(t, "echo 'cron: 配置文件损坏' >&2\necho 'not json'\n"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "配置文件损坏") {
+		t.Errorf("错误消息该带上 stderr 的原文，got %s", w.Body.String())
+	}
+}
+
+// 命令失败时，诊断信息通常在 stderr
+func TestJSONFailureUsesStderr(t *testing.T) {
+	w := postRun(fakeTT(t, "echo 'plugin not found: roam.cron' >&2\nexit 1\n"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "plugin not found") {
+		t.Errorf("got %s", w.Body.String())
+	}
+}

--- a/backend/ttmux/client.go
+++ b/backend/ttmux/client.go
@@ -35,5 +35,20 @@ func (c *Client) RunCtx(ctx context.Context, args ...string) (string, error) {
 	return out.String(), err
 }
 
+// RunJSON 执行子命令，**分开**拿 stdout 与 stderr。
+//
+// 取 JSON 的地方必须用它：插件的日志走 stderr（SDK 的 Logf 写的
+// `[roam.cron] 已添加定时任务 …`），和 stdout 混在一起，返回的就不再是 JSON——
+// 浏览器只会看到「Unexpected token 'r'」，而真正发生了什么（那行日志）反被吞掉。
+// 出错时两股都要：诊断信息通常正在 stderr 里。
+func (c *Client) RunJSON(args ...string) (stdout, stderr string, err error) {
+	cmd := exec.CommandContext(context.Background(), c.Bin, args...)
+	var o, e bytes.Buffer
+	cmd.Stdout = &o
+	cmd.Stderr = &e
+	err = cmd.Run()
+	return o.String(), e.String(), err
+}
+
 // StripANSI 去除文本中的 ANSI 颜色转义。
 func StripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }


### PR DESCRIPTION
## 问题

「插件 → 定时任务 → 新增任务」保存，弹的是：

> ❌ Unexpected token 'r', "[roam.cron]"... is not valid JSON

而任务其实**已经加好了**——报错只是解析失败。

## 原因

`ttmux.Client.Run` 把 stdout 和 stderr **合成一股**返回，而插件 SDK 的 `Logf` 写的正是 stderr：

```
$ ttmux plugin run cron.add --name zz --cron '0 2 * * *' ...
# stdout: {"action":"agent","cron":"0 2 * * *",...}
# stderr: [roam.cron] 已添加定时任务 zz(cron: 0 2 * * *),下次触发 2026-09-08 02:00:00
```

`a.json` 把「一行日志 + 一份 JSON」原样贴上 `application/json` 发回去，前端 `res.json()` 在第一个字符上就炸了。真正发生的事被那行日志盖掉。

## 改法

- 新增 `ttmux.Client.RunJSON`：分开取 stdout / stderr。
- `a.json` 只发 stdout；命令失败时报 **stderr**（诊断信息通常在那儿）；命令自称成功却吐了非 JSON，报 `BAD_JSON` 并把 stderr 原样带出——而不是让前端撞上解析错、把真正的话吞掉。
- 返回纯文本的 `a.text` 不动。

影响面是所有走 `a.json` 的端点（会话/项目/插件列表、审计……），它们本来就该只读 stdout；插件命令是唯一会常态写日志的那类，所以只有它露了馅。

## 验证

真机在「新增任务」里存了一条，现在弹的是「已添加任务「zz-probe-ui」」，表格当场多出那一行（验完已删）：

![改后：保存成功的提示与新增的那一行](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-254/cron-add-after.png)

三条回归测试用一个假 ttmux（stderr 写日志、stdout 出 JSON）盯住三种情形：日志不许污染 JSON、非 JSON 输出要报 BAD_JSON、失败时错误消息取 stderr。`check.sh full` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)