### PR TITLE
docs(agents): PR 必须带截图 —— 连「图放哪」一起定死，附推图脚本

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,33 @@ authority, it just no longer moves the layout under the user a beat after load.
 - The `commit-msg` hook enforces the format locally. PR titles must follow it too — squash merges
   turn the title into the final commit.
 
+## Pull Request 必须带截图
+
+每个 PR 都要能**看**出来改了什么，不能只读得出来。文字描述由写的人挑角度，截图不会。
+
+- **界面改动**：至少一张改后的截图；动的是既有界面就给改前 / 改后两张。手机档也受影响的，
+  桌面与手机各一张——`data-size` 与粗指针那套差别恰恰是最容易漏的一类。
+- **没有界面的改动**（后端 / CLI / 插件 / 脚本）：截能证明它真跑起来的那一屏——命令输出、
+  日志、测试结果。
+- **文档与规则类改动**：截「这条规则落地之后长什么样」。
+
+放法：仓库是公开的，截图走 `pr-shots` 这条**孤儿分支**（只存图，永不并入 `main`），
+正文里引 raw 链接。有脚本，别手搓：
+
+```bash
+scripts/dev/pr-shot.sh 253 menu-after.png      # 推图，并打印可直接粘的 markdown
+```
+
+```markdown
+![改后：合成行的右键菜单](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-253/menu-after.png)
+```
+
+脚本用 git plumbing 写（独立索引 + `commit-tree`），不切分支、不碰工作区——截图不该逼你
+把手里的活停下来；拉不到 `pr-shots` 时它宁可报错也不从空树重建（那样一推就把之前所有
+PR 的图抹了）。
+
+截图不要提交进 `main`：仓库里不留 PR 的一次性产物。
+
 ## Code Review
 
 - PRs are reviewed by the **Codex GitHub App** (`chatgpt-codex-connector` bot). See

--- a/scripts/dev/pr-shot.sh
+++ b/scripts/dev/pr-shot.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 把 PR 截图推到 pr-shots 分支，并打印可直接粘进 PR 正文的 markdown。
+#
+# 用法：scripts/dev/pr-shot.sh <PR号> <图片> [图片...]
+#
+# 为什么单独存一条孤儿分支：截图是 PR 的一次性产物，提交进 main 就是往仓库里堆垃圾；
+# 而 GitHub 的 PR 正文引不了相对路径，只能给它一个 raw 链接。
+# 为什么用 plumbing 而不是 checkout：截图不该逼你把手里的活停下来切分支。
+set -euo pipefail
+
+PR="${1:-}"; shift || true
+[ -n "$PR" ] && [ "$#" -gt 0 ] || { echo "用法: $0 <PR号> <图片> [图片...]" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+REMOTE="${PR_SHOT_REMOTE:-origin}"
+BRANCH="${PR_SHOT_BRANCH:-pr-shots}"
+SLUG="$(git remote get-url "$REMOTE" | sed -E 's#(git@github\.com:|https://github\.com/)##; s#\.git$##')"
+
+INDEX="$(mktemp -u "${TMPDIR:-/tmp}/pr-shot-index.XXXXXX")"
+trap 'rm -f "$INDEX"' EXIT
+export GIT_INDEX_FILE="$INDEX"
+
+# 已有的图必须保住：这条分支是攒下来的，不是每次覆盖。
+# 拉不到时**不许**默默从空开始——那样推上去的是一个没有父提交的树，轻则被拒，
+# 重则一个 --force 就把之前所有 PR 的图全抹了。只有明说 PR_SHOT_INIT=1 才从空建。
+base=""
+if git fetch -q "$REMOTE" "$BRANCH" 2>/dev/null; then
+  base="$(git rev-parse FETCH_HEAD)"
+  git read-tree "$base"
+elif [ "${PR_SHOT_INIT:-0}" = "1" ]; then
+  git read-tree --empty
+else
+  echo "拉不到 $REMOTE/$BRANCH（网络？分支不存在？）。确认要新建这条分支就 PR_SHOT_INIT=1 再跑。" >&2
+  exit 1
+fi
+
+names=()
+for f in "$@"; do
+  [ -f "$f" ] || { echo "找不到文件: $f" >&2; exit 1; }
+  name="$(basename "$f")"
+  blob="$(git hash-object -w "$f")"
+  git update-index --add --cacheinfo "100644,$blob,pr-$PR/$name"
+  names+=("$name")
+done
+
+tree="$(git write-tree)"
+[ -n "$tree" ] || { echo "write-tree 失败" >&2; exit 1; }
+if [ -n "$base" ]; then
+  commit="$(git commit-tree "$tree" -p "$base" -m "shots: PR #$PR")"
+else
+  commit="$(git commit-tree "$tree" -m "shots: PR #$PR")"
+fi
+# 空的 commit 变量会让下面这条 push 变成「删除远端分支」——这一步不能省
+[ -n "$commit" ] || { echo "commit-tree 失败，已中止（空 sha 会删掉远端分支）" >&2; exit 1; }
+
+git push "$REMOTE" "$commit:refs/heads/$BRANCH"
+
+echo
+echo "粘进 PR 正文："
+for n in "${names[@]}"; do
+  echo "![说明](https://raw.githubusercontent.com/$SLUG/$BRANCH/pr-$PR/$n)"
+done


### PR DESCRIPTION
## 规则

**每个 PR 都要带截图。** 文字描述由写的人挑角度，截图不会。写进 `AGENTS.md`（规则的唯一出处）：

- **界面改动**：至少一张改后的；动的是既有界面就给改前/改后两张。手机档也受影响的，桌面 + 手机各一张。
- **没有界面的改动**（后端 / CLI / 插件 / 脚本）：截能证明它真跑起来的那一屏——命令输出、日志、测试结果。
- **文档与规则类**：截「这条规则落地之后长什么样」。

## 图放哪 —— 这条不定死，规则就会烂掉

要么图提交进 `main` 让仓库堆满一次性产物，要么每人换一种存法。定成走 `pr-shots` 孤儿分支（只存图、永不并入 main），正文引 raw 链接，推图走新加的 `scripts/dev/pr-shot.sh`：

```console
$ scripts/dev/pr-shot.sh 255 pr-rule-proof.png
   a8878ed..d81de44  -> pr-shots

粘进 PR 正文：
![说明](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-255/pr-rule-proof.png)
```

脚本用 git plumbing（独立 `GIT_INDEX_FILE` + `commit-tree`），**不切分支、不碰工作区**——截图不该逼人把手里的活停下来。

两个坑直接写进了代码，因为我今天都踩了：

1. `commit` 变量为空时中止——`git push origin :refs/heads/pr-shots` 等于**删远端分支**，我这么删过一次（已恢复）。
2. 拉不到 `pr-shots` 时宁可报错也不从空树重建——那样一推就把之前所有 PR 的图抹了；真要新建得显式 `PR_SHOT_INIT=1`。

## 这条规则落地长什么样

PR #254 的正文，图就在验证那一节里：

![截图规则落地：PR 正文里直接显示改后的界面](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-255/pr-rule-proof.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)