### PR TITLE
fix(status): 底部那六格监控别机器一忙就整条消失

### DIFF
--- a/docs/design/web/20-status-bar/index.html
+++ b/docs/design/web/20-status-bar/index.html
@@ -544,8 +544,9 @@ Roam 抄过来有两个实际问题：壳里已经有强调蓝在导航选中项
   <div class="step"><div class="i r">4</div><div>
     <b>一个 provider 崩了，只熄它那几格</b>
     <small>宿主<b class="hl">永远不 await 插件来渲染第一帧</b>：条先画出来，格子有值了再填。
-    命令超时 1s、连续失败 3 次熄灯并退避到 60s 重试、值超过 <code>3×refresh</code> 判 stale
-    （变暗置 <code>--</code>，见 §08 ④）。插件死了条不动，这是底线。</small>
+    命令的超时预算是<b class="hl">一帧</b>（该组的 <code>refresh</code>）、连续失败 3 次熄灯并退避到
+    60s 重试、值超过 <code>3×refresh</code> 判 stale（变暗置 <code>--</code>，见 §08 ④）。
+    插件死了条不动，这是底线。<b class="hl">主线程被占住的时间不算在插件头上</b>——见下面那张表。</small>
   </div></div>
 </div>
 
@@ -556,7 +557,14 @@ Roam 抄过来有两个实际问题：壳里已经有强调蓝在导航选中项
 <tbody>
 <tr><td>每插件格数</td><td class="mono">2</td><td>内置 provider 可以多（主机监控 6 格），第三方 2 格封顶——一条 24px 装不下三个插件各五格</td></tr>
 <tr><td>最小 <code>refresh</code></td><td class="mono">2s</td><td><code>plugin run</code> 每次起一个子进程。主机监控自己的面板用的是 3s，条上沿用</td></tr>
-<tr><td>单次超时</td><td class="mono">1s</td><td>超时就不画这一帧，绝不卡住整条</td></tr>
+<tr><td>单次超时</td><td class="mono">一帧<br>（<code>refresh</code>，≥2s）</td>
+    <td>超时就不画这一帧，绝不卡住整条。到点还没回来的值，下一轮就会被新的取代，留着等没有意义。
+    <b class="hl">但主线程被占住的那段不计入</b>：超时是墙上时间量的，请求的收尾却要排在主线程上，
+    上面的编辑器/终端一次重渲染占住主线程一秒多，服务端 100ms 就答完的调用照样判超时——
+    真机 Chrome 里量过，阻塞 2s 连发三次全是 <code>AbortError</code>，而三次就够熄灯 60s，
+    六格主机监控于是「总在上面刚渲染完的时候消失」。计时器比约定时刻晚到多久，就是刚才卡了多久，
+    晚得离谱就重新计时（最多顺延 3 次，挂住的插件不能靠页面卡着无限续命）</td></tr>
+<tr><td>同组并发</td><td class="mono">1</td><td>上一轮还没回来就跳过这一轮——否则一次卡顿堆出同一个插件的一串子进程</td></tr>
 <tr><td>文本长度</td><td class="mono">24 字符</td><td>超出截断。一个插件不该有能力把条撑满</td></tr>
 <tr><td>第三方格默认可见性</td><td class="mono">关</td><td>装了插件 ≠ 同意它上我的状态条。插件详情页显示「想在状态条放 2 格」+ 一键打开；
     <b class="hl">内置 provider 默认开</b></td></tr>
@@ -1023,7 +1031,7 @@ M1 的后端改动只有 manifest 结构和一段 <code>statusItems</code> 声�
 <tr><td class="mono">M1</td><td class="mono">docs/design/plugin/05-manifest.md</td><td>贡献点表加 <code>statusItems</code> 一行（v1）；激活事件表加 <code>onStatusItem:&lt;id&gt;</code></td></tr>
 <tr><td class="mono">M1</td><td class="mono">shell/status-registry.ts</td><td><span class="tag new">新</span> 注册表：内置 provider 与插件贡献点合流、按段与 priority 排序、格数预算、失败熄灯与退避</td></tr>
 <tr><td class="mono">M1</td><td class="mono">shell/status-renderers.tsx</td><td><span class="tag new">新</span> 四种渲染器（<code>text/gauge/dot/progress</code>）。<b>插件只能选，不能自带</b></td></tr>
-<tr><td class="mono">M1</td><td class="mono">shell/status-poll.ts</td><td><span class="tag new">新</span> 插件拉取：同插件多 item 合并成一次 <code>run</code>、<code>document.hidden</code> 停、1s 超时、3 次熄灯</td></tr>
+<tr><td class="mono">M1</td><td class="mono">shell/status-poll.ts</td><td><span class="tag new">新</span> 插件拉取：同插件多 item 合并成一次 <code>run</code>、<code>document.hidden</code> 停、一帧超时（扣掉主线程卡住的时间）、同组不并发、3 次熄灯</td></tr>
 <tr><td class="mono">M1</td><td class="mono">frontend/src/components/shell/StatusBar.tsx</td><td><span class="tag new">新</span> 组件本体（只渲染左半 + 通知/版本）</td></tr>
 <tr><td class="mono">M1</td><td class="mono">shell/status-cells.ts · status-cells.test.ts</td><td><span class="tag new">新</span> 纯函数：阈值判等级、CPU 的 60s 滞后、按宽度四档挑格（钉住规则）</td></tr>
 <tr><td class="mono">M1</td><td class="mono">frontend/src/index.css</td><td><code>.tt-statusbar</code>；新令牌 <code>--status-h</code>；hover 一律 <code>:where(html[data-pointer="fine"])</code></td></tr>

--- a/frontend/src/components/shell/WorkspaceStatusBar.tsx
+++ b/frontend/src/components/shell/WorkspaceStatusBar.tsx
@@ -34,12 +34,21 @@ export function WorkspaceStatusBar({ system, onAction }: {
 
   // 一次性拉插件清单——这是**注册表**，不是读数：不知道注册了什么就没法渲染。
   // 之后不再轮询，装/停用插件后刷新页面生效。
+  //
+  // 但这一发失败就等于整场会话都没有插件格（清单不重拉，错误又是咽掉的），所以
+  // 失败重试几次：开机那阵后端正在起一堆子进程，一次偶发的 5xx 不该让主机监控
+  // 消失到下次刷新页面为止。
   useEffect(() => {
     let stop = false
-    api('GET', '/plugins')
-      .then((r) => { if (!stop) setPlugins(Array.isArray(r) ? r : r?.data || []) })
-      .catch(() => {})
-    return () => { stop = true }
+    let tries = 0
+    let retry: ReturnType<typeof setTimeout> | undefined
+    const load = () => {
+      api('GET', '/plugins')
+        .then((r) => { if (!stop) setPlugins(Array.isArray(r) ? r : r?.data || []) })
+        .catch(() => { if (!stop && ++tries < 3) retry = setTimeout(load, 2000 * tries) })
+    }
+    load()
+    return () => { stop = true; clearTimeout(retry) }
   }, [])
 
   // 只量容器，不量格子：格宽是估出来的纯函数（status-cells.estimateWidth）。

--- a/frontend/src/components/shell/status-poll.test.ts
+++ b/frontend/src/components/shell/status-poll.test.ts
@@ -1,0 +1,49 @@
+// 超时预算的账要算在插件头上，不能算在「上面刚渲染完」头上。
+// 这条正是六格主机监控经常整体消失的原因（budgetedAbort 的注释里有真机数据）。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { budgetedAbort } from './status-poll'
+
+/** 主线程被占住 ms 毫秒：钟往前走了，可挂着的定时器一个都没轮到执行 */
+function block(ms: number) {
+  vi.setSystemTime(Date.now() + ms)
+}
+
+describe('一次调用的超时预算', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('线程没卡的时候，到点就掐', () => {
+    const { signal } = budgetedAbort(3000)
+    vi.advanceTimersByTime(2999)
+    expect(signal.aborted).toBe(false)
+    vi.advanceTimersByTime(1)
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('主线程被占住的那段不算数：卡完重新给一整段预算', () => {
+    const { signal } = budgetedAbort(3000)
+    block(5000)          // 编辑器/终端重渲染，5 秒里定时器一次都没跑
+    vi.advanceTimersByTime(3000) // 到点的定时器这才轮到 —— 晚了 5 秒
+    expect(signal.aborted).toBe(false)
+    vi.advanceTimersByTime(2999)
+    expect(signal.aborted).toBe(false)
+    vi.advanceTimersByTime(1)
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('顺延有上限：插件真挂住了，不能靠页面一直卡着续命', () => {
+    const { signal } = budgetedAbort(1000)
+    for (let i = 0; i < 6; i++) {
+      block(5000)
+      vi.advanceTimersByTime(1000)
+    }
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('clear 之后不再掐 —— 请求已经正常回来了', () => {
+    const { signal, clear } = budgetedAbort(1000)
+    clear()
+    vi.advanceTimersByTime(10_000)
+    expect(signal.aborted).toBe(false)
+  })
+})

--- a/frontend/src/components/shell/status-poll.ts
+++ b/frontend/src/components/shell/status-poll.ts
@@ -4,7 +4,7 @@
 // 三条不能省的规矩：
 //   ① 同插件同命令的多个格**合并成一次调用**——主机六格共用一次 stats，不是六次。
 //   ② `document.hidden` 时全停——否则后台标签页每 3 秒起一堆子进程。
-//   ③ 一个 provider 崩了只熄它那几格：超时 1s、连续失败 3 次熄灯并退避到 60s。
+//   ③ 一个 provider 崩了只熄它那几格：一帧的超时预算、连续失败 3 次熄灯并退避到 60s。
 //      宿主**永远不 await 插件来渲染第一帧**，条先画出来，格子有值了再填。
 
 import { useEffect, useRef, useState } from 'react'
@@ -12,23 +12,64 @@ import { api } from '../../api'
 import { groupRefreshMs, groupSources, readPath, type PluginSource } from './status-registry'
 import { formatRatio, type CellValue } from './status-cells'
 
-const CALL_TIMEOUT_MS = 1000
 const FAIL_BLACKOUT = 3
 const BLACKOUT_MS = 60_000
 /** 超过 STALE_FACTOR × refresh 没拿到新值就判过期：变暗置 `--`，不留最后一帧 */
 const STALE_FACTOR = 3
+/** 定时器比约定时刻晚这么多，就认定刚才主线程被占着，这一轮不算插件的账 */
+const JANK_MS = 250
+/** 顺延次数上限：真挂住的插件不能靠页面一直卡着无限续命 */
+const MAX_EXTEND = 3
 
-type GroupState = { fails: number; blackUntil: number; lastOk: number }
+type GroupState = { fails: number; blackUntil: number; lastOk: number; busy: boolean }
 
-async function runCommand(pluginId: string, command: string): Promise<any> {
+/**
+ * 到点掐掉这次调用，但**主线程被占住的那段不算数**。
+ *
+ * 超时是墙上时间量的，请求的收尾却要排在主线程上：上面的编辑器/终端一次重渲染
+ * 占住主线程一秒多，服务端 100ms 就答完的调用照样判超时。真机 Chrome 里量过——
+ * 发出请求后阻塞主线程 2s，连发三次全是 `AbortError`，而三次就够熄灯一分钟。
+ * 这也是「监控总在上面刚渲染完的时候没了」那种感觉的来处。
+ *
+ * 判据就是定时器自己：它比约定的时刻晚到多久，就是刚才主线程卡了多久。晚得离谱
+ * 就重新计时，把一整段「线程真的能干活」的时间还给这次调用。
+ */
+export function budgetedAbort(budgetMs: number): { signal: AbortSignal; clear: () => void } {
   const ctrl = new AbortController()
-  const timer = setTimeout(() => ctrl.abort(), CALL_TIMEOUT_MS)
+  let due = Date.now() + budgetMs
+  let extended = 0
+  let timer: ReturnType<typeof setTimeout>
+  const arm = () => {
+    timer = setTimeout(() => {
+      if (Date.now() - due > JANK_MS && extended++ < MAX_EXTEND) {
+        due = Date.now() + budgetMs
+        arm()
+        return
+      }
+      ctrl.abort()
+    }, Math.max(0, due - Date.now()))
+  }
+  arm()
+  return { signal: ctrl.signal, clear: () => clearTimeout(timer) }
+}
+
+/**
+ * 一次调用的预算就是**这一帧**（该组的 refresh，≥2s）：到点还没回来，这个数字下一轮
+ * 就会被新的取代，留着等没有意义。
+ *
+ * 原来钉死 1s，而这条路上 `plugin run` 每次起一个子进程——机器忙起来（编译、几个 agent
+ * 会话、swap 在换页）1s 根本不够 fork+exec 加采样。而且慢一次不是慢一次：三次超时就熄灯
+ * 60s，退避结束后再探一次照样慢、照样熄，于是**监控格一整场都不出现**。量过：把后端那次
+ * 调用钉在 1.2s，条上右半六格全没，只剩「当前设备」和版本号——正是用户截图里的样子。
+ */
+async function runCommand(pluginId: string, command: string, budgetMs: number): Promise<any> {
+  const { signal, clear } = budgetedAbort(budgetMs)
   try {
     const r = await api('POST', `/plugins/${encodeURIComponent(pluginId)}/run`,
-      { command, args: {} }, { signal: ctrl.signal })
+      { command, args: {} }, { signal })
     return r?.data ?? r
   } finally {
-    clearTimeout(timer)
+    clear()
   }
 }
 
@@ -74,11 +115,13 @@ export function usePluginValues(sources: PluginSource[]): Record<string, CellVal
 
     const tick = async (key: string, group: PluginSource[]) => {
       if (stopped || document.hidden) return
-      const st = state.get(key) ?? { fails: 0, blackUntil: 0, lastOk: 0 }
+      const st = state.get(key) ?? { fails: 0, blackUntil: 0, lastOk: 0, busy: false }
       state.set(key, st)
-      if (Date.now() < st.blackUntil) return
+      // 上一轮还没回来就别再发：主线程一卡，堆起来的只是同一个插件的一串子进程
+      if (st.busy || Date.now() < st.blackUntil) return
+      st.busy = true
       try {
-        const snap = await runCommand(group[0].pluginId, group[0].command)
+        const snap = await runCommand(group[0].pluginId, group[0].command, groupRefreshMs(group))
         if (stopped) return
         st.fails = 0
         st.lastOk = Date.now()
@@ -96,6 +139,8 @@ export function usePluginValues(sources: PluginSource[]): Record<string, CellVal
             return next
           })
         }
+      } finally {
+        st.busy = false
       }
     }
 


### PR DESCRIPTION
底部状态条右半那六格主机监控（CPU / 内存 / 磁盘 / 温度 / GPU / 网络）经常整条不出现，
只剩左边的「当前设备」和最右的版本号。

## 为什么会没

一次取值是 `POST /plugins/<id>/run` → 后端 `ttmux plugin run` **起一个子进程**，而前端
给单次调用的超时钉死在 **1s**。机器忙起来（编译、几个 agent 会话、swap 在换页）这一秒
不够 fork+exec 加一次采样。

慢一次不是只慢一次：连着三次超时就**熄灯 60s**，退避结束后再探一次，照样慢、照样熄——
于是监控格一整场都不出现。

量过：把后端那次调用钉在 1.2s，条上右半六格全没，只剩「当前设备」和版本号，与反馈的
截图一模一样（见下图上半）。

还有第二条路会踩同一个坑：**超时是墙上时间量的，请求的收尾却要排在主线程上**。上面的
编辑器/终端一次重渲染占住主线程一秒多，服务端 100ms 就答完的调用照样被判超时。真机
Chrome 里量过——发出请求后阻塞主线程 2s，连发三次全是 `AbortError`，三次就够熄灯。
这正是「感觉是上面东西渲染完影响了下面」那种体感的来处。

## 改了什么

- **单次预算 1s → 一帧**（该组的 `refresh`，≥2s）。到点还没回来的值，下一轮就会被新的
  取代，留着等没有意义；一帧就是这个数字本来的保质期。
- **主线程被占住的那段不计入预算**。判据是计时器自己：它比约定时刻晚到多久，就是刚才
  主线程卡了多久；晚得离谱就重新计时，把一整段「线程真的能干活」的时间还给这次调用。
  最多顺延 3 次——挂住的插件不能靠页面卡着无限续命。
- **同组不并发**：上一轮还没回来就跳过这一轮，否则一次卡顿堆出来的只是同一个插件的
  一串子进程。
- 顺带：插件清单那一发失败补上重试。清单只拉一次、错误又是咽掉的，开机那阵后端正在起
  一堆子进程，一次偶发失败就等于整场会话都没有插件格。

设计文档 `docs/design/web/20-status-bar/index.html` 的预算表同步更新。

## 怎么验的

两个隔离实例（各自 `ROAM_HOME` + 独立端口 + `tmux -L` 壳），同一个 backend，一个吃改前
的 dist、一个吃改后的；中间垫一层把 `plugin run` 钉在 1.2s 的 shim，模拟机器忙的时候。

![改前 / 改后 底部状态条](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-258/statusbar-monitor-before-after.png)

- 改前：右半六格全没，等过一整个 60s 退避周期仍然没有。
- 改后：六格照常刷新。
- 新增单测 `status-poll.test.ts`：不卡时到点就掐、卡住的那段不算数、顺延有上限、
  `clear` 之后不再掐。
- 门禁：`check.sh quick`（pre-commit 全量跑过）+ `typecheck / i18n:check / hover:check /
  vitest(459) / build` 全绿。

无视觉改动（渲染路径一行没动），所以没有另跑真机触摸档那套清单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPgX5ukqcBrwcFFzufUSrV
