### PR TITLE
feat(cli): roam 成为唯一入口 —— roam im send / roam cron list / roam ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,21 @@ Roam also provides command-line entry points for scripts, automation, and AI
 agents. This is not the main entry point for most users; start from the Web
 console in most cases.
 
+`roam` is the single entry point. Plugin commands are grouped by plugin name
+(any unique prefix works), and anything else is forwarded to `ttmux`:
+
+```bash
+roam help                        # what is installed and how to reach it
+roam cron list                   # scheduled tasks
+roam im send --text "done"       # message yourself through the IM bridge
+roam host stats                  # host resource snapshot
+roam ls                          # sessions — forwarded to ttmux
+roam ttmux swarm ls              # explicit passthrough when a name collides
+roam -addr 0.0.0.0:13579         # no subcommand: start the web console (unchanged)
+```
+
+Underneath:
+
 - `ttmux`: manages persistent sessions, background tasks, agent workers, swarms,
   and machine-readable state.
 - `chrome`: drives Chrome on the development machine for UI debugging,
@@ -312,10 +327,12 @@ console in most cases.
 
 Plugins extend the console itself — `roam.host-monitor` contributes the resource
 monitor, `roam.cron` adds scheduled prompts with its own configuration panel.
+Whatever a plugin declares in its manifest shows up as a `roam <name> <command>`
+group with no extra wiring.
 
 Command details are intentionally not expanded on the home page, so the README
 does not become a tool manual. When needed, see
-**[docs/install/](docs/install/)**, `ttmux help`, and `chrome help`.
+**[docs/install/](docs/install/)**, `roam help`, `ttmux help`, and `chrome help`.
 
 ## Development And Contribution
 

--- a/backend/cmd/cli.go
+++ b/backend/cmd/cli.go
@@ -1,0 +1,210 @@
+// roam 的子命令层：把散在各处的命令收进**一个**入口。
+//
+// 在这之前，同一件事有三种叫法：给自己发条消息是
+// `ttmux plugin run im-bridge.send --text …`，看定时任务是
+// `ttmux plugin run cron.list`，开会话又是 `ttmux ls`——插件名、命令名、
+// 前缀各记一套，谁也记不住。现在统一成：
+//
+//	roam <插件> <命令> [--k v]   任何已装插件都自动是一组（im / cron / host / review…）
+//	roam ttmux <参数...>          会话、蜂群、窗格：原样转发给 ttmux
+//	roam <其它>                   也转发给 ttmux（它自己再兜底给 tmux），所以 roam ls 照用
+//	roam [flags]                  没有子命令时照旧启动 Web 服务，一个字都没变
+//
+// 插件那一组不是硬编码的清单：装了什么就有什么，名字按**唯一前缀**认——
+// `roam im send` 对应 roam.im-bridge，`roam host stats` 对应 roam.host-monitor。
+// 短名是插件自己 manifest 里的 name，这一层不替它起别名。
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// pluginInfo 是 `ttmux plugin ls --json` 里我们用得上的那几项。
+type pluginInfo struct {
+	ID       string // roam.im-bridge
+	Name     string // im-bridge
+	Enabled  bool
+	Commands []string // im-bridge.send …
+	Summary  string
+}
+
+// resolveGroup 把用户敲的词认成插件：全名 > 短名 > 唯一前缀。
+// 认不出返回空（调用方据此转发给 ttmux）；前缀撞了要报错——
+// 猜一个跑出去比说不认识危险得多。
+func resolveGroup(plugins []pluginInfo, word string) (*pluginInfo, error) {
+	var hits []int
+	for i, p := range plugins {
+		if p.ID == word || p.Name == word {
+			return &plugins[i], nil
+		}
+		if strings.HasPrefix(p.Name, word) {
+			hits = append(hits, i)
+		}
+	}
+	switch len(hits) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &plugins[hits[0]], nil
+	default:
+		names := make([]string, 0, len(hits))
+		for _, i := range hits {
+			names = append(names, plugins[i].Name)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("%q 对得上好几个插件：%s——写全一点", word, strings.Join(names, " / "))
+	}
+}
+
+// pluginRunArgs 拼出转发给 ttmux 的参数。命令用 id 限定形式（roam.cron:list），
+// 归属由注册表按全 id 精确判定，不会落到短名撞名的另一个插件上。
+func pluginRunArgs(p pluginInfo, cmd string, rest []string) []string {
+	return append([]string{"plugin", "run", p.ID + ":" + cmd}, rest...)
+}
+
+// shortCmd 把 contributes 里的 "cron.list" 剥成 "list"。
+func shortCmd(id string) string {
+	if _, after, ok := strings.Cut(id, "."); ok {
+		return after
+	}
+	return id
+}
+
+func loadPlugins(ttmuxBin string) []pluginInfo {
+	out, err := exec.Command(ttmuxBin, "plugin", "ls", "--json").Output()
+	if err != nil {
+		return nil
+	}
+	var raw []struct {
+		Enabled  bool `json:"enabled"`
+		Manifest struct {
+			ID          string            `json:"id"`
+			Name        string            `json:"name"`
+			Description map[string]string `json:"description"`
+			Contributes struct {
+				Commands []struct {
+					ID string `json:"id"`
+				} `json:"commands"`
+			} `json:"contributes"`
+		} `json:"manifest"`
+	}
+	if json.Unmarshal(out, &raw) != nil {
+		return nil
+	}
+	list := make([]pluginInfo, 0, len(raw))
+	for _, r := range raw {
+		p := pluginInfo{ID: r.Manifest.ID, Name: r.Manifest.Name, Enabled: r.Enabled,
+			Summary: r.Manifest.Description["zh-CN"]}
+		for _, c := range r.Manifest.Contributes.Commands {
+			p.Commands = append(p.Commands, shortCmd(c.ID))
+		}
+		list = append(list, p)
+	}
+	return list
+}
+
+// runCLI 处理子命令。返回 false 表示「这不是子命令」，main 照旧启动服务。
+func runCLI(args []string, ttmuxBin string) (handled bool, code int) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return false, 0
+	}
+	// PATH 上没有 ttmux 时用内嵌那份（单一二进制发行）：子命令层比 main 里那段
+	// 解压逻辑更早跑，不在这儿解一次，`roam cron list` 在干净机器上就直接找不到命令。
+	if _, err := exec.LookPath(ttmuxBin); err != nil {
+		if p := embeddedBin(); p != "" {
+			ttmuxBin = p
+			_ = os.Setenv("TTMUX_BIN", p)
+		}
+	}
+	word, rest := args[0], args[1:]
+
+	if word == "help" || word == "commands" {
+		printHelp(loadPlugins(ttmuxBin))
+		return true, 0
+	}
+	if word == "ttmux" {
+		return true, forward(ttmuxBin, rest)
+	}
+
+	plugins := loadPlugins(ttmuxBin)
+	p, err := resolveGroup(plugins, word)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return true, 2
+	}
+	if p == nil {
+		// 不是插件组：转发给 ttmux（它认会话/蜂群，还会把没见过的命令再兜给 tmux）
+		return true, forward(ttmuxBin, args)
+	}
+	if len(rest) == 0 || rest[0] == "help" {
+		printGroup(*p)
+		return true, 0
+	}
+	if !p.Enabled {
+		fmt.Fprintf(os.Stderr, "插件 %s 已停用：先 roam ttmux plugin enable %s\n", p.Name, p.ID)
+		return true, 2
+	}
+	return true, forward(ttmuxBin, pluginRunArgs(*p, rest[0], rest[1:]))
+}
+
+func forward(bin string, args []string) int {
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if ok := asExitError(err, &ee); ok {
+			return ee.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "调用 %s 失败: %v\n", bin, err)
+		return 1
+	}
+	return 0
+}
+
+func printHelp(plugins []pluginInfo) {
+	fmt.Printf("  roam %s — 一个入口\n\n", displayVersion())
+	fmt.Println("  roam <插件> <命令> [--k v]   插件命令（装了什么就有什么，名字可写唯一前缀）")
+	fmt.Println("  roam ttmux <参数...>          会话 / 蜂群 / 窗格（转发给 ttmux）")
+	fmt.Println("  roam <会话命令>               同上，roam ls / roam a <名> 直接用")
+	fmt.Println("  roam [flags]                 不带子命令＝启动 Web 服务（roam -h 看 flags）")
+	if len(plugins) == 0 {
+		return
+	}
+	fmt.Println("\n  已装插件：")
+	for _, p := range plugins {
+		state := ""
+		if !p.Enabled {
+			state = "（已停用）"
+		}
+		fmt.Printf("    %-14s %s%s\n", p.Name, firstLine(p.Summary), state)
+	}
+	fmt.Println("\n  例：roam im send --text '跑完了'   roam cron list   roam host stats")
+}
+
+func printGroup(p pluginInfo) {
+	fmt.Printf("  %s — %s\n\n", p.Name, firstLine(p.Summary))
+	for _, c := range p.Commands {
+		fmt.Printf("    roam %s %s\n", p.Name, c)
+	}
+}
+
+// displayVersion 保证只有一个 v：注入的 tag 本身就带（v0.1.0-rc.2-…），
+// 开发构建是裸的 "dev"。
+func displayVersion() string {
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexAny(s, "\n;"); i > 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/backend/cmd/cli_exit.go
+++ b/backend/cmd/cli_exit.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// asExitError 单拎出来：errors.As 要的是 **T，内联写在 forward 里读着更绕。
+func asExitError(err error, target **exec.ExitError) bool {
+	return errors.As(err, target)
+}

--- a/backend/cmd/cli_test.go
+++ b/backend/cmd/cli_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func demoPlugins() []pluginInfo {
+	return []pluginInfo{
+		{ID: "roam.cron", Name: "cron", Enabled: true},
+		{ID: "roam.im-bridge", Name: "im-bridge", Enabled: true},
+		{ID: "roam.host-monitor", Name: "host-monitor", Enabled: true},
+		{ID: "roam.review-mesh", Name: "review-mesh", Enabled: true},
+	}
+}
+
+// 名字按唯一前缀认：谁也不想为了发条消息去背「im-bridge」这个全名。
+func TestResolveGroup(t *testing.T) {
+	ps := demoPlugins()
+	for word, want := range map[string]string{
+		"cron":           "roam.cron",
+		"im":             "roam.im-bridge",
+		"im-bridge":      "roam.im-bridge",
+		"roam.im-bridge": "roam.im-bridge",
+		"host":           "roam.host-monitor",
+		"rev":            "roam.review-mesh",
+	} {
+		got, err := resolveGroup(ps, word)
+		if err != nil || got == nil {
+			t.Errorf("%q 没认出来：%v", word, err)
+			continue
+		}
+		if got.ID != want {
+			t.Errorf("%q → %s，想要 %s", word, got.ID, want)
+		}
+	}
+
+	// 认不出不是错：调用方会把它转发给 ttmux（roam ls / roam swarm … 照用）
+	if got, err := resolveGroup(ps, "ls"); got != nil || err != nil {
+		t.Errorf("ls 不该被当成插件组：%v %v", got, err)
+	}
+}
+
+// 前缀撞了必须报错。猜一个跑出去比说不认识危险得多。
+func TestResolveGroupAmbiguous(t *testing.T) {
+	ps := append(demoPlugins(), pluginInfo{ID: "acme.reporter", Name: "reporter", Enabled: true})
+	got, err := resolveGroup(ps, "re")
+	if got != nil || err == nil {
+		t.Fatalf("撞名该报错，got %v err %v", got, err)
+	}
+	for _, want := range []string{"reporter", "review-mesh"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("错误里该列出 %q：%s", want, err)
+		}
+	}
+}
+
+// 转发给 ttmux 的是 id 限定形式：短名撞名时归属才不会落到别人家
+func TestPluginRunArgs(t *testing.T) {
+	got := pluginRunArgs(pluginInfo{ID: "roam.im-bridge", Name: "im-bridge"}, "send", []string{"--text", "跑完了"})
+	want := []string{"plugin", "run", "roam.im-bridge:send", "--text", "跑完了"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestShortCmd(t *testing.T) {
+	if got := shortCmd("cron.list"); got != "list" {
+		t.Errorf("shortCmd = %q", got)
+	}
+	if got := shortCmd("list"); got != "list" {
+		t.Errorf("没有前缀时该原样返回，got %q", got)
+	}
+}
+
+// 子命令层不能吃掉「启动服务」这条老路：第一个参数是 flag 时必须放行
+func TestRunCLILeavesFlagsAlone(t *testing.T) {
+	for _, args := range [][]string{{}, {"-addr", ":13579"}, {"--tls"}} {
+		if handled, _ := runCLI(args, "ttmux"); handled {
+			t.Errorf("%v 不该被子命令层接管", args)
+		}
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -29,6 +29,13 @@ import (
 var version = "dev"
 
 func main() {
+	// 子命令层（roam im send / roam cron list / roam ttmux ls…）。
+	// 必须在 flag.Parse 之前：flag 包遇到非 flag 参数就停下，之后的 --text 会被当成
+	// 本进程的 flag 报错。不带子命令（或第一个参数是 -flag）时原样往下走，启动服务。
+	if handled, code := runCLI(os.Args[1:], envOr("TTMUX_BIN", "ttmux")); handled {
+		os.Exit(code)
+	}
+
 	configFlag := flag.String("config", "", "配置文件路径（覆盖 ROAM_CONFIG / ~/.roam/config.yaml）")
 	addrFlag := flag.String("addr", "", "监听地址，如 0.0.0.0:13579（覆盖配置里的 web.bind）")
 	webFlag := flag.String("web", "", "前端构建产物目录 frontend/dist（覆盖自动探测；留空用内嵌前端）")


### PR DESCRIPTION
## 问题

同一件事有三种叫法：

```bash
ttmux plugin run im-bridge.send --text "跑完了"   # 给自己发条消息
ttmux plugin run cron.list                        # 看定时任务
ttmux ls                                          # 开会话
```

插件名、命令名、前缀各记一套，谁也记不住。

## 改成一个入口

```bash
roam help                        # 装了什么、怎么够得着
roam cron list                   # 定时任务
roam im send --text "跑完了"      # 通过 IM 桥给自己发消息
roam host stats                  # 主机资源快照
roam ls                          # 会话 —— 转发给 ttmux
roam ttmux swarm ls              # 撞名时的显式通道
roam -addr 0.0.0.0:13579         # 不带子命令＝启动 Web 服务，一个字没变
```

![roam help 的真实输出（在 Roam 的定时任务执行记录里跑的）](https://raw.githubusercontent.com/ybz21/Roam/pr-shots/pr-258/roam-cli-help.png)

## 三条设计

1. **插件那一组不是硬编码清单**：读 `plugin ls --json`，装了什么就有什么组。新插件零改动就能 `roam <名> <命令>`。
2. **名字按唯一前缀认**：`roam im send` → `roam.im-bridge`，`roam host stats` → `roam.host-monitor`。前缀撞了**报错并列出候选**——猜一个跑出去比说不认识危险得多。
3. **转发用 id 限定形式**（`roam.im-bridge:send`）：归属按全 id 精确判定，短名撞名时不会落到别人家。

认不出的词直接转发给 `ttmux`（它自己再兜底给 tmux），所以 `roam ls` / `roam a <名>` / `roam swarm ls` 都照用；`roam ttmux …` 是需要时的显式通道。

## 两个坑（都写进注释了）

- 子命令必须在 `flag.Parse` **之前**处理：flag 包遇到第一个非 flag 参数就停下，之后的 `--text` 会被当成 roam 自己的 flag 报错。
- PATH 上没有 ttmux 时，要在这一层就解出内嵌那份（单一二进制发行）——否则干净机器上 `roam cron list` 直接「找不到命令」，而 main 里那段解压逻辑跑得比它晚。

## 验证

真机跑过：`roam help` / `roam cron list` / `roam im send --text …`（如实报出「未绑定通知群」，说明参数确实透传到了插件）/ `roam host stats` / `roam ls` / `roam ttmux --help`；裸 `roam` 与 `roam -addr` 仍然启动服务。五条单测盯住前缀解析、撞名报错、id 限定转发，以及「第一个参数是 flag 时不许接管」。`check.sh full` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)