### PR TITLE
perf(p2p): 建链 30 秒 → 0.7 秒 —— 别为几台不回话的 STUN 干等半分钟

### DIFF
--- a/backend/p2p/pc.go
+++ b/backend/p2p/pc.go
@@ -13,7 +13,9 @@ package p2p
 import (
 	"encoding/json"
 	"log"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -25,6 +27,40 @@ type peer struct {
 	pc        *webrtc.PeerConnection
 	closed    int32 // 原子终结标志，幂等 close
 	connected int32 // 原子：已进入 Connected
+	// srflx 在拿到第一个反射候选时关闭（见 waitGathered）。
+	srflx     chan struct{}
+	srflxOnce sync.Once
+}
+
+// noteSrflx 记下「已经有反射候选了」，幂等。
+func (p *peer) noteSrflx() {
+	p.srflxOnce.Do(func() { close(p.srflx) })
+}
+
+// 拿到 srflx 之后再宽限多久 / 一直等不到 srflx 时最多等多久。var 而非 const：单测要调小。
+var (
+	srflxGraceDur = 500 * time.Millisecond
+	gatherMaxDur  = 30 * time.Second
+)
+
+// waitGathered 等候选收集——但不死等「全部完成」。
+//
+// gathering=complete 的语义是「所有 STUN 都答完或超时」，这在实测里要 ~40s（Chrome 侧同理），
+// 而能用的候选 0.2 秒就齐了。整整半分钟的建链等待全花在等那几台不回话的服务器上。
+// 所以改成：拿到第一个反射候选就只再宽限 500ms（给同一批里稍慢的那台留条路），到点就发。
+// 一个 srflx 都没有时才等满上限——那种情况确实无从判断它是不是马上要来。
+func waitGathered(done <-chan struct{}, srflx <-chan struct{}) {
+	select {
+	case <-done:
+		return
+	case <-srflx:
+	case <-time.After(gatherMaxDur):
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(srflxGraceDur):
+	}
 }
 
 // peerConfig 参数化一条 PC 的信令字段与回调，抹平持久/临时两类的差异。
@@ -67,20 +103,26 @@ func (s *session) newPeer(cfg peerConfig) (*peer, error) {
 	if err != nil {
 		return nil, err
 	}
-	p := &peer{pc: pc}
+	p := &peer{pc: pc, srflx: make(chan struct{})}
 
 	// 非 trickle（P0-2）：本端候选**不再**逐个回传前端——answerOffer 等 gathering 完成后一次性
 	// 把全部候选编进 answer 完整 SDP 发出。这里只保留候选诊断日志（复验 gather 到没到 srflx）。
 	pc.OnICECandidate(func(c *webrtc.ICECandidate) {
-		if !cfg.verboseCand {
-			return
-		}
 		if c == nil {
-			log.Printf("p2p: %s local-cand gathering-complete", cfg.keyLog)
+			// 收集结束：把 srflx 闸也放开，免得 waitGathered 在「一个 srflx 都没有」时白等宽限。
+			p.noteSrflx()
+			if cfg.verboseCand {
+				log.Printf("p2p: %s local-cand gathering-complete", cfg.keyLog)
+			}
 			return
 		}
-		log.Printf("p2p: %s local-cand typ=%s proto=%s addr=%s:%d",
-			cfg.keyLog, c.Typ.String(), c.Protocol.String(), c.Address, c.Port)
+		if c.Typ == webrtc.ICECandidateTypeSrflx {
+			p.noteSrflx()
+		}
+		if cfg.verboseCand {
+			log.Printf("p2p: %s local-cand typ=%s proto=%s addr=%s:%d",
+				cfg.keyLog, c.Typ.String(), c.Protocol.String(), c.Address, c.Port)
+		}
 	})
 
 	pc.OnConnectionStateChange(func(st webrtc.PeerConnectionState) {
@@ -134,9 +176,9 @@ func (s *session) answerOffer(p *peer, cfg peerConfig, offerSDP string) error {
 		log.Printf("p2p: %s SetLocalDescription: %v", cfg.keyLog, err)
 		return err
 	}
-	// 等 ICE gathering 完成，让 LocalDescription 携带全部候选（含 srflx）后再发。PC 关闭时 promise
-	// 也会 resolve，此时 LocalDescription 仍可用（含已 gather 的候选），不阻塞终结。
-	<-gatherDone
+	// 等候选，但不死等 gathering=complete（见 waitGathered）。PC 关闭时 promise 也会 resolve，
+	// 此时 LocalDescription 仍可用（含已 gather 的候选），不阻塞终结。
+	waitGathered(gatherDone, p.srflx)
 	sdp := ans.SDP
 	if ld := p.pc.LocalDescription(); ld != nil {
 		sdp = ld.SDP

--- a/backend/p2p/pc_test.go
+++ b/backend/p2p/pc_test.go
@@ -225,3 +225,36 @@ func TestPathFromCands(t *testing.T) {
 		}
 	}
 }
+
+// TestWaitGathered 三条路：完成、拿到 srflx 后宽限、一个都没有等满上限。
+func TestWaitGathered(t *testing.T) {
+	oldGrace, oldMax := srflxGraceDur, gatherMaxDur
+	srflxGraceDur, gatherMaxDur = 30*time.Millisecond, 120*time.Millisecond
+	defer func() { srflxGraceDur, gatherMaxDur = oldGrace, oldMax }()
+
+	elapsed := func(done, srflx chan struct{}) time.Duration {
+		t0 := time.Now()
+		waitGathered(done, srflx)
+		return time.Since(t0)
+	}
+
+	// gathering 完成：立刻返回。
+	done := make(chan struct{})
+	close(done)
+	if d := elapsed(done, make(chan struct{})); d > 20*time.Millisecond {
+		t.Errorf("完成后应立刻返回，等了 %v", d)
+	}
+
+	// 拿到 srflx：只再宽限 srflxGraceDur，不等满上限。
+	srflx := make(chan struct{})
+	close(srflx)
+	d := elapsed(make(chan struct{}), srflx)
+	if d < srflxGraceDur || d > gatherMaxDur {
+		t.Errorf("srflx 后应只宽限 %v，实际 %v", srflxGraceDur, d)
+	}
+
+	// 一个 srflx 都没有：等满上限——那种情况无从判断它是不是马上要来。
+	if d := elapsed(make(chan struct{}), make(chan struct{})); d < gatherMaxDur {
+		t.Errorf("无 srflx 应等满 %v，实际 %v", gatherMaxDur, d)
+	}
+}

--- a/frontend/src/p2p/transport.negotiate.test.ts
+++ b/frontend/src/p2p/transport.negotiate.test.ts
@@ -11,6 +11,12 @@ class FakePC extends EventTarget {
     this.iceGatheringState = s
     this.dispatchEvent(new Event('icegatheringstatechange'))
   }
+  // 造一个候选事件：只有 type 会被读到。
+  cand(type: RTCIceCandidateType | null) {
+    const e = new Event('icecandidate') as Event & { candidate: { type: RTCIceCandidateType } | null }
+    e.candidate = type ? { type } : null
+    this.dispatchEvent(e)
+  }
 }
 
 describe('waitForIceGathering (non-trickle)', () => {
@@ -54,6 +60,65 @@ describe('waitForIceGathering (non-trickle)', () => {
       expect(resolved).toBe(false)
       // 推进到上限：即便没 complete 也要 resolve（用当前候选发出，不无限等）。
       await vi.advanceTimersByTimeAsync(4_000)
+      await p
+      expect(resolved).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// M1：拿到反射候选就只再宽限一小会儿发 offer，别死等 gathering=complete。
+// complete 的语义是「所有 STUN 都答完或超时」，实测 ~40s，而候选 0.2 秒就齐了。
+describe('waitForIceGathering：srflx 宽限', () => {
+  it('第一个 srflx 之后宽限到点就 resolve，不等 complete', async () => {
+    vi.useFakeTimers()
+    try {
+      const pc = new FakePC()
+      let resolved = false
+      const p = waitForIceGathering(pc as unknown as RTCPeerConnection, 30_000, 500).then(() => { resolved = true })
+      pc.cand('host')
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(resolved).toBe(false) // host 不算：跨网要的是 srflx
+
+      pc.cand('srflx')
+      await vi.advanceTimersByTimeAsync(499)
+      expect(resolved).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      await p
+      expect(resolved).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('后来的 srflx 不重置宽限——否则一台慢服务器就能把它一路往后推', async () => {
+    vi.useFakeTimers()
+    try {
+      const pc = new FakePC()
+      let resolved = false
+      const p = waitForIceGathering(pc as unknown as RTCPeerConnection, 30_000, 500).then(() => { resolved = true })
+      pc.cand('srflx')
+      await vi.advanceTimersByTimeAsync(400)
+      pc.cand('srflx')
+      await vi.advanceTimersByTimeAsync(100)
+      await p
+      expect(resolved).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('一个 srflx 都没有就等满上限——那种情况无从判断它是不是马上要来', async () => {
+    vi.useFakeTimers()
+    try {
+      const pc = new FakePC()
+      let resolved = false
+      const p = waitForIceGathering(pc as unknown as RTCPeerConnection, 30_000, 500).then(() => { resolved = true })
+      pc.cand('host')
+      await vi.advanceTimersByTimeAsync(29_999)
+      expect(resolved).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
       await p
       expect(resolved).toBe(true)
     } finally {

--- a/frontend/src/p2p/transport.ts
+++ b/frontend/src/p2p/transport.ts
@@ -22,30 +22,50 @@ import { getPreferences } from '../preferences'
 const P2P_DEBUG = import.meta.env.DEV
 function dlog(...args: unknown[]) { if (P2P_DEBUG) console.log(...args) }
 
-// 非 trickle（P0-2）：ICE gathering 完成才发 offer/answer 完整 SDP。等 iceGatheringState==='complete'，
-// 或到 gather 上限就用当前 pc.localDescription 兜底发出。
-// gather 上限可配（设置页 p2pGatherTimeoutSec，默认 30s）：STUN 正常时 gathering 1–2s 就 complete、
-// 立刻发（LAN/快网不受影响）；只有慢网（如手机蜂窝 srflx 迟迟不来）才等满。太短会在 srflx 还没
-// gather 出来时就发 SDP → srflx 丢失 → 跨网只能中转。connect 计时器已设为 gather+connect，不会误判。
+// 非 trickle（P0-2）：一次性发含全部候选的完整 SDP，不逐个 trickle。
+//
+// 但**不等 `iceGatheringState==='complete'`**：那个状态的语义是「所有 STUN 都答完或超时」，
+// 实测 Chrome 要 ~40s（被 gather 上限截成 30s），而能用的候选 0.2 秒就齐了——整整半分钟
+// 的建链等待，全花在等那几台不回话的服务器上。
+//
+// 改成：**拿到第一个 srflx 就只再宽限 500ms** 发出去。宽限是给同一批里稍慢的那台留的：
+// 几台 STUN 并行查询，最快的那台先回，慢一点的通常也在几十毫秒内到，而它们报的多半是
+// 同一个公网地址（浏览器自己去重）。一个 srflx 都没有时才等满上限——那种情况确实无从
+// 判断它是不是马上要来（比如手机蜂窝，srflx 迟迟不来；太早发 SDP 会丢掉 srflx → 只能中转）。
+const SRFLX_GRACE_MS = 500
 const DEFAULT_GATHER_TIMEOUT_MS = 30_000
 function gatherTimeoutMs() {
   const s = getPreferences().p2pGatherTimeoutSec
   return typeof s === 'number' && s >= 3 && s <= 300 ? s * 1000 : DEFAULT_GATHER_TIMEOUT_MS
 }
 // exported for unit test（非产品 API）；timeoutMs 缺省用 gatherTimeoutMs()（设置页可配）。
-export function waitForIceGathering(peer: RTCPeerConnection, timeoutMs = gatherTimeoutMs()): Promise<void> {
+export function waitForIceGathering(
+  peer: RTCPeerConnection,
+  timeoutMs = gatherTimeoutMs(),
+  graceMs = SRFLX_GRACE_MS,
+): Promise<void> {
   if (peer.iceGatheringState === 'complete') return Promise.resolve()
   return new Promise((resolve) => {
     let done = false
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
     const finish = () => {
       if (done) return
       done = true
       peer.removeEventListener('icegatheringstatechange', onChange)
+      peer.removeEventListener('icecandidate', onCand)
       clearTimeout(timer)
+      clearTimeout(graceTimer)
       resolve()
     }
     const onChange = () => { if (peer.iceGatheringState === 'complete') finish() }
+    // 第一个反射候选到手就起宽限；后面再来的 srflx 不重置它，否则一台慢服务器就能把
+    // 宽限一路往后推，又变回死等。
+    const onCand = (e: RTCPeerConnectionIceEvent) => {
+      if (graceTimer || e.candidate?.type !== 'srflx') return
+      graceTimer = setTimeout(finish, graceMs)
+    }
     peer.addEventListener('icegatheringstatechange', onChange)
+    peer.addEventListener('icecandidate', onCand)
     // 上限兜底：超时用已 gather 的候选（当前 localDescription）发出，不无限等。
     const timer = setTimeout(finish, timeoutMs)
   })

--- a/scripts/dev/p2p/connect-timing.mjs
+++ b/scripts/dev/p2p/connect-timing.mjs
@@ -1,0 +1,73 @@
+// 建链要多久：从建 PeerConnection 到 connectionState==='connected'。
+//
+// 顺带打印选中的候选对，以及**发出去的 SDP 里到底有没有 srflx**——后者是这个改动的关键：
+// 早发 offer 换来的速度，不能以丢掉反射候选（跨网只能中转）为代价。
+//
+//   TARGET=https://127.0.0.1:13579 PW=口令 [NODE_ID=n_xxx] node scripts/dev/p2p/connect-timing.mjs
+import { chromium } from '/home/ai/.local/share/ttmux/chrome/node_modules/playwright-core/index.mjs'
+
+const TARGET = process.env.TARGET || 'https://127.0.0.1:13579'
+const PW = process.env.PW || ''
+const NODE = process.env.NODE_ID || ''
+const WAIT_S = Number(process.env.WAIT_S || 70)
+
+const browser = await chromium.launch({
+  executablePath: process.env.CHROME || '/usr/bin/google-chrome',
+  headless: true,
+  args: ['--ignore-certificate-errors', '--no-sandbox'],
+})
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1440, height: 900 } })
+// 在页面脚本之前包一层 RTCPeerConnection：应用建的每条 PC 都记下来，并给它挂上计时。
+await ctx.addInitScript(({ node }) => {
+  if (node) localStorage.setItem('roam.nodeId', node)
+  const Orig = window.RTCPeerConnection
+  window.__pcs = []; window.__t0 = 0; window.__conn = -1
+  window.RTCPeerConnection = function (...a) {
+    const pc = new Orig(...a)
+    window.__pcs.push(pc)
+    if (!window.__t0) window.__t0 = performance.now()
+    pc.addEventListener('connectionstatechange', () => {
+      if (pc.connectionState === 'connected' && window.__conn < 0) window.__conn = performance.now() - window.__t0
+    })
+    return pc
+  }
+  window.RTCPeerConnection.prototype = Orig.prototype
+}, { node: NODE })
+
+const page = await ctx.newPage()
+await page.goto(TARGET + '/', { waitUntil: 'domcontentloaded' })
+await page.locator('input[type="password"]').first().fill(PW)
+await page.locator('button[type="submit"]').first().click()
+
+let ms = -1
+for (let i = 0; i < WAIT_S * 2; i++) {
+  ms = await page.evaluate(() => window.__conn)
+  if (ms > 0) break
+  await page.waitForTimeout(500)
+}
+if (ms <= 0) {
+  console.error(`${WAIT_S}s 内没连上（节点 p2p_enabled 开了吗？偏好 p2pEnabled 呢？）`)
+  await browser.close()
+  process.exit(1)
+}
+console.log(`control PC 从建 PC 到 connected：${(ms / 1000).toFixed(2)}s`)
+
+const info = await page.evaluate(async () => {
+  const pc = window.__pcs.find((p) => p.connectionState === 'connected')
+  const stats = await pc.getStats()
+  const cand = {}
+  stats.forEach((r) => { if (r.type === 'local-candidate' || r.type === 'remote-candidate') cand[r.id] = r })
+  let pair = '?'
+  stats.forEach((r) => {
+    if (r.type === 'candidate-pair' && (r.nominated || r.selected)) {
+      pair = `${cand[r.localCandidateId]?.candidateType}/${cand[r.remoteCandidateId]?.candidateType} rtt=${r.currentRoundTripTime}`
+    }
+  })
+  const count = (sdp, typ) => (sdp.match(new RegExp('typ ' + typ, 'g')) || []).length
+  const l = pc.localDescription?.sdp || ''
+  const r = pc.remoteDescription?.sdp || ''
+  return { pair, sdp: `发出去的 offer: host×${count(l, 'host')} srflx×${count(l, 'srflx')} | 收到的 answer: host×${count(r, 'host')} srflx×${count(r, 'srflx')}` }
+})
+console.log('选中候选对：', info.pair)
+console.log(info.sdp)
+await browser.close()


### PR DESCRIPTION
每次进控制台，头 30 秒所有流量都走中转——不是网络慢，是我们在**干等**。

能用的候选 0.2 秒就齐了，但两端都在等 `iceGatheringState === 'complete'`。那个状态的语义是
**所有 STUN 都答完或超时**，实测 Chrome 要 ~40s（被 gather 上限截成 30s）。整整半分钟的建链
等待，全花在等那几台不回话的服务器上，而该有的候选早就在手里。

## 改法

**拿到第一个 srflx 就只再宽限 500ms**，到点发 offer/answer。

- 宽限是给同一批里稍慢的那台留的：几台 STUN 并行查询，最快的先回，慢的通常也在几十毫秒内到。
- **一个 srflx 都没有时才等满上限**。那种情况确实无从判断它是不是马上要来（手机蜂窝就属于
  这种），太早发 SDP 会丢掉 srflx，跨网就只能中转——这正是 #121 当初改成非 trickle 要避免的。
- 两端对称改（浏览器 `waitForIceGathering` / 后端 `waitGathered`），因为 answer 慢一样是慢。

## 实测：同一台机器、同一个浏览器，只差这次改动

![改前 30.21s，改后 0.72s；两边的 srflx 都还在](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-266/timing-out.png)

| | 建链 | 发出去的 offer | 收到的 answer |
|---|---|---|---|
| 改前 | **30.21s** | host×1 srflx×1 | host×18 srflx×10 |
| 改后 | **0.72s** | host×1 srflx×1 | host×18 srflx×2 |

**要看的是后两列**，不是第一列。早发不能以丢候选为代价——两端的 srflx 都还在。answer 里
srflx 从 10 条减到 2 条是预期的：那 10 条是五台 STUN 各报一遍，对全锥 NAT 一条就够，对对称
NAT 十条也没用（每台看到的映射端口都不一样，谁也预测不了对端要用哪个）。

五次重复：0.72 / 0.72 / 0.85 / 0.58 / 0.59s。

**那 30 秒全在浏览器这一侧**：拿旧后端 + 新前端单独量了一次，0.59s——pion 的 gathering
本来就收得快（answer 里 srflx 依旧 ×10）。所以后端那半边改动**当下不减一秒**，留着是因为
节点侧一旦配上不回话的 STUN，同样的坑会在 answer 上重演一遍；两端对称也省得下次再查一遍
「到底是谁在等」。顺带一个部署上的好处：只发前端就能拿到全部收益，不用重启节点后端。

## 旋钮只有一个

`SRFLX_GRACE_MS`（前端）/ `srflxGraceDur`（后端），都是 500ms。宽限直接加在建链时间上，
调大只在「候选来得特别参差」的网络上才有意义。上限仍走设置页的 `p2pGatherTimeoutSec`。

新增 `scripts/dev/p2p/connect-timing.mjs`：量建链耗时，并打印发出去的 SDP 里到底有没有
srflx——这个改动的正确性靠后面这句，不能只看快了。

单测：前端 3 条（宽限到点即发 / 后来的 srflx 不重置宽限 / 无 srflx 等满上限），Go 1 条
（完成、宽限、等满三条路，靠把两个时长改成 `var` 调小来跑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
