### PR TITLE
fix(statusbar): 格子别在眼皮底下跑 —— 30 秒里最大位移 81px → 0px

### DIFF
--- a/frontend/src/components/shell/status-cells.test.ts
+++ b/frontend/src/components/shell/status-cells.test.ts
@@ -134,15 +134,15 @@ describe('窄窗折叠', () => {
     expect(kept).toContain('hm/net')
     expect(kept).not.toContain('git/branch')
   })
-  it('挤不下时告警格提到机器格右边', () => {
+  it('告警格就地上色，不挪位 —— 宽屏窄屏都在同一个位置', () => {
     const cs = bar().map((c) => (c.id === 'hm/disk' ? { ...c, severity: 'danger' as Severity } : c))
-    const kept = ids(pickCells(cs, 300))
-    expect(kept[0]).toBe('core/machine')
-    expect(kept[1]).toBe('hm/disk')
-  })
-  it('宽屏里不挪位 —— 挪位会让格子在眼皮底下跑', () => {
-    const cs = bar().map((c) => (c.id === 'hm/disk' ? { ...c, severity: 'danger' as Severity } : c))
-    expect(ids(pickCells(cs, 2000))[1]).toBe('git/branch')
+    const wide = ids(pickCells(cs, 2000))
+    const tight = ids(pickCells(cs, 300))
+    expect(wide[1]).toBe('git/branch')
+    // 挤到只剩几格时它仍在原来的相对位置，不会瞬移到机器格右边：
+    // 触发条件一旦挂在「这一帧有没有格被丢掉」上，读数一变就来回跳。
+    expect(tight.indexOf('hm/disk')).toBe(tight.length - 1)
+    expect(tight[0]).toBe('core/machine')
   })
   it('同 priority 按 id 字典序，装插件的顺序不影响排布', () => {
     const a = cell({ id: 'zzz/x', priority: 50, width: 50 })
@@ -237,7 +237,7 @@ describe('状态条：P2P 直连格', () => {
 
   it('直连：绿点 + 路径，不变暗', async () => {
     const c = await cells({ state: 'connected', path: 'lan' })
-    expect(c?.val.text).toBe('p2p.link.direct')
+    expect(c?.spec.label).toBe('p2p.link.direct')
     expect(c?.val.stale).toBe(false)
   })
 
@@ -255,23 +255,25 @@ describe('状态条：P2P 直连格', () => {
 
   it('直连时条上带延迟；有真流量才带速率', async () => {
     const idle = await cells({ state: 'connected', path: 'lan', rttMs: 2, downBps: 400, upBps: 120 })
-    expect(idle?.val.text).toBe('p2p.link.direct p2p.link.rtt')
+    expect(idle?.val.text).toBe('p2p.link.rtt')
     expect(idle?.val.detail).toContain('p2p.link.idleRate')
 
     const busy = await cells({ state: 'connected', path: 'lan', rttMs: 2, downBps: 3 * 1024 * 1024, upBps: 120 })
-    expect(busy?.val.text).toBe('p2p.link.direct p2p.link.rtt p2p.link.rate')
+    expect(busy?.val.text).toBe('p2p.link.rtt p2p.link.rate')
     expect(busy?.val.detail).toContain('p2p.link.down')
     expect(busy?.val.detail).toContain('p2p.link.up')
   })
 
   it('局域网往返不到 1ms 时直说「不到 1ms」，不是取整成 0ms', async () => {
     const c = await cells({ state: 'connected', path: 'lan', rttMs: 0 })
-    expect(c?.val.text).toBe('p2p.link.direct p2p.link.rttSub1')
+    expect(c?.val.text).toBe('p2p.link.rttSub1')
   })
 
   it('中转/连接中不报延迟速率——那时候的往返走的是中心，不是这一格说的路', async () => {
     const c = await cells({ state: 'relay', rttMs: 90, downBps: 5 * 1024 * 1024 })
-    expect(c?.val.text).toBe('p2p.link.relay')
+    expect(c?.spec.label).toBe('p2p.link.relay')
+    expect(c?.val.text).toBe('')          // 空串 = 没数可报；不是 '--'（那是取不到）
+    expect(c?.spec.unit).toBeUndefined()  // 也不占那 13ch 预留
     expect(c?.val.detail).not.toContain('p2p.link.rttFull')
     expect(c?.val.detail).not.toContain('p2p.link.down')
   })

--- a/frontend/src/components/shell/status-cells.ts
+++ b/frontend/src/components/shell/status-cells.ts
@@ -9,7 +9,7 @@ export type CellAlign = 'left' | 'right'
 export type CellRender = 'text' | 'gauge' | 'dot' | 'progress'
 /** 折叠档位：1 最晚被丢（永不丢），4 最先丢 */
 export type CellTier = 1 | 2 | 3 | 4
-export type CellUnit = 'percent' | 'bytes' | 'bytesPerSec' | 'bytesRatio' | 'celsius' | 'count' | 'text'
+export type CellUnit = 'percent' | 'bytes' | 'bytesPerSec' | 'bytesRatio' | 'celsius' | 'count' | 'ms' | 'latencyRate' | 'text'
 
 export type Thresholds = {
   warn?: number
@@ -131,6 +131,9 @@ export function formatRatio(used: number, total: number): string {
 
 export function formatValue(v: CellValue, unit?: CellUnit): string {
   if (v.text) return v.text
+  // 显式给空串 = 这一格此刻没有数可报（不是「取不到」）。'--' 是留给后者的：
+  // 直连格中转时就是这种情况，写成 `中转 --` 等于凭空多出一个坏掉的读数。
+  if (v.text === '') return ''
   if (v.stale || v.value == null || !Number.isFinite(v.value)) return '--'
   switch (unit) {
     case 'percent': return Math.round(v.value) + '%'
@@ -154,6 +157,8 @@ export const UNIT_CH: Partial<Record<CellUnit, number>> = {
   bytesPerSec: 8,  // 999.9M/s
   bytesRatio: 9,   // 12.1/32G
   count: 3,
+  ms: 5,           // 999ms
+  latencyRate: 13, // 「8ms 31.9M/s」：延迟 + 速率两截一起预留，空闲时速率那半截留白
 }
 
 /**
@@ -198,8 +203,12 @@ function ordered(cells: Cell[]): Cell[] {
  * - 档位从 4 往 1 丢；**同档内右半先于左半**——右半描述「你在动的东西」，
  *   而那个东西本身就在屏幕正中央摆着；左半描述你看不见的东西。
  * - 档 1 永不丢。
- * - 任何 warn/danger 的格被**钉住**，跳过丢弃顺序；只有在它本来会被丢掉时
- *   才提前到左半第二位（宽屏里就地上色，不挪位——挪位会让格子在眼皮底下跑）。
+ * - 任何 warn/danger 的格被**钉住**，跳过丢弃顺序——但**就地上色，不挪位**。
+ *
+ * 曾经有一条「挤不下时把上色的格提到机器格右边」的规则，删掉了：它的触发条件是
+ * 「这一帧有没有格被丢掉」，而总宽度每 1.5 秒随读数变一次（延迟多一位数、速率
+ * 出现又消失），于是同一格在「原位」和「第二位」之间来回瞬移——正是这个文件里
+ * 那句「挪位会让格子在眼皮底下跑」说的事。钉住已经保证它不会消失，够了。
  */
 export function pickCells(cells: Cell[], availableWidth: number): Cell[] {
   const all = ordered(cells)
@@ -223,13 +232,5 @@ export function pickCells(cells: Cell[], availableWidth: number): Cell[] {
     keep.delete(c.id)
   }
 
-  const visible = all.filter((c) => keep.has(c.id))
-  // 有格子被丢掉，说明位置紧张：把上色的格提到左半第二位（机器格右边）
-  const dropped = visible.length < all.length
-  if (!dropped) return visible
-  const hoist = visible.filter((c) => c.severity !== 'ok' && c.align === 'left')
-  if (!hoist.length) return visible
-  const rest = visible.filter((c) => !hoist.includes(c))
-  const head = rest.slice(0, 1)
-  return [...head, ...hoist, ...rest.slice(1)]
+  return all.filter((c) => keep.has(c.id))
 }

--- a/frontend/src/components/shell/status-system.ts
+++ b/frontend/src/components/shell/status-system.ts
@@ -102,7 +102,8 @@ export function systemCells(i: SystemInput): SystemCell[] {
   push(
     systemCell('roam.core', 'machine', {
       label: i.node?.name || i.t('nav.thisDevice'),
-      priority: 100, tier: 1, render: 'dot',
+      // 延迟预留 5ch：6ms → 12ms 多一位数，右边所有格会跟着平移一次
+      priority: 100, tier: 1, render: 'dot', unit: 'ms',
       // 多机时点它去中心页（机器都在那儿）；单机没有可去的地方，就不是按钮
       onClick: i.clustered ? { kind: 'route', id: '#/hub' } : undefined,
     }),
@@ -138,17 +139,21 @@ export function systemCells(i: SystemInput): SystemCell[] {
     const peak = Math.max(link.downBps || 0, link.upBps || 0)
     push(
       systemCell('roam.core', 'link', {
-        label: '', priority: 88, tier: 3, render: 'dot',
+        // 路径进 label、两个数进 vl：vl 有固定预留宽度（latencyRate），
+        // 于是延迟涨一位数、速率来了又走，都不再推着右边的格子跑。
+        label: direct
+          ? i.t('p2p.link.direct', { path: i.t(pathLabelKey(link.path)) })
+          : link.state === 'relay' ? i.t('p2p.link.relay') : i.t('p2p.link.connecting'),
+        // 只有直连才有数要报，也只有那时才占那 13ch 预留
+        unit: direct ? 'latencyRate' : undefined,
+        priority: 88, tier: 3, render: 'dot',
         // 点开去 P2P 那一页：开关、STUN、超时都在那儿，是唯一能对这一格做点什么的地方
         onClick: { kind: 'route', id: '#/settings/node/p2p' },
       }),
       {
+        // 延迟与速率只在直连时说：中转/连接中报这两个数没有意义，
+        // 那时候的往返走的是中心，不是这一格说的那条路。
         text: [
-          direct
-            ? i.t('p2p.link.direct', { path: i.t(pathLabelKey(link.path)) })
-            : link.state === 'relay' ? i.t('p2p.link.relay') : i.t('p2p.link.connecting'),
-          // 延迟与速率只在直连时说：中转/连接中报这两个数没有意义，
-          // 那时候的往返走的是中心，不是这一格说的那条路。
           direct && link.rttMs != null ? rttText(i, link.rttMs) : '',
           direct && peak >= RATE_FLOOR ? i.t('p2p.link.rate', { rate: humanBytes(peak) }) : '',
         ].filter(Boolean).join(' '),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3563,6 +3563,10 @@ html[data-size="compact"] .tt-histname { flex: 1 1 auto; max-width: none; }
 .tt-statusbar .vl[data-unit="bytes"] { min-width: 6ch; }
 .tt-statusbar .vl[data-unit="bytesPerSec"] { min-width: 8ch; }
 .tt-statusbar .vl[data-unit="bytesRatio"] { min-width: 9ch; }
+.tt-statusbar .vl[data-unit="ms"] { min-width: 5ch; }
+/* 延迟 + 速率两截：左对齐，让「8ms」待在原地，速率出现时往右边那半截留白里长，
+   而不是把延迟顶着往左推。 */
+.tt-statusbar .vl[data-unit="latencyRate"] { min-width: 13ch; text-align: left; }
 .tt-statusbar .dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; background: var(--ok); }
 .tt-statusbar .dot.warn { background: var(--warn); }
 .tt-statusbar .dot.danger { background: var(--danger); }

--- a/scripts/dev/statusbar-jitter.mjs
+++ b/scripts/dev/statusbar-jitter.mjs
@@ -1,0 +1,80 @@
+// 状态条的格子有没有在原地待着：每格左边界采样 30 秒，报最大位移。
+//
+// 为什么要量：位置跳变是「看得出、说不清」的那类 bug——肉眼只记得「刚才它好像在左边」。
+// 一格挪了 81px 还是 0px，采一遍就没有争议了。
+//
+//   TARGET=http://127.0.0.1:13581 PW=口令 [WIDTH=1100] [ECHO=1] node scripts/dev/statusbar-jitter.mjs
+//
+// ECHO=1 会在采样中途从已连上的 P2P 链路灌一股流量，让直连格的速率出现又消失——
+// 那一截正是最容易推着右边所有格平移的东西。
+import { chromium } from '/home/ai/.local/share/ttmux/chrome/node_modules/playwright-core/index.mjs'
+
+const TARGET = process.env.TARGET || 'http://127.0.0.1:13581'
+const PW = process.env.PW || ''
+const WIDTH = Number(process.env.WIDTH || 1100)
+const SAMPLES = Number(process.env.SAMPLES || 40)
+
+const browser = await chromium.launch({
+  executablePath: process.env.CHROME || '/usr/bin/google-chrome',
+  headless: true,
+  args: ['--ignore-certificate-errors', '--no-sandbox'],
+})
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: WIDTH, height: 800 } })
+if (process.env.ECHO === '1') {
+  await ctx.addInitScript(() => {
+    const Orig = window.RTCPeerConnection
+    window.__pcs = []
+    window.RTCPeerConnection = function (...a) { const pc = new Orig(...a); window.__pcs.push(pc); return pc }
+    window.RTCPeerConnection.prototype = Orig.prototype
+  })
+}
+const page = await ctx.newPage()
+await page.goto(TARGET + '/', { waitUntil: 'domcontentloaded' })
+await page.locator('input[type="password"]').first().fill(PW)
+await page.locator('button[type="submit"]').first().click()
+await page.waitForSelector('.tt-statusbar', { timeout: 20000 })
+await page.waitForTimeout(4000)   // 等第一批读数到齐，否则量到的是「格子陆续出现」
+
+const samples = []
+for (let i = 0; i < SAMPLES; i++) {
+  if (i === 10 && process.env.ECHO === '1') {
+    await page.evaluate(() => {
+      const pc = (window.__pcs || []).find((p) => p.connectionState === 'connected')
+      if (!pc) return
+      const dc = pc.createDataChannel('echo#jitter')
+      dc.binaryType = 'arraybuffer'
+      // 定时器发，不用 while 死循环：那样会占满主线程，React 根本不重绘，测了个寂寞。
+      dc.onopen = () => {
+        const buf = new Uint8Array(65536)
+        const end = performance.now() + 12000
+        const t = setInterval(() => {
+          if (performance.now() > end) { clearInterval(t); dc.close(); return }
+          for (let k = 0; k < 24 && dc.bufferedAmount < (8 << 20); k++) dc.send(buf)
+        }, 50)
+      }
+    })
+  }
+  samples.push(await page.evaluate(() => [...document.querySelectorAll('.tt-statusbar .cell')]
+    .map((c) => ({ t: c.innerText.replace(/\n/g, ' '), x: Math.round(c.getBoundingClientRect().x) }))))
+  await page.waitForTimeout(750)
+}
+
+// 把数字抠成 #，才能把「同一格的不同读数」认成同一格
+const byCell = new Map()
+for (const snap of samples) {
+  for (const c of snap) {
+    const key = c.t.replace(/[\d.<]+\s*(ms|%|°C|K\/s|M\/s|G|\/\d+G)?/g, '#').trim()
+    if (!byCell.has(key)) byCell.set(key, [])
+    byCell.get(key).push(c.x)
+  }
+}
+console.log(`${TARGET} · ${samples.length} 次采样（${(samples.length * 0.75).toFixed(0)} 秒，视口 ${WIDTH}px）`)
+let worst = 0
+for (const [key, xs] of byCell) {
+  const d = Math.max(...xs) - Math.min(...xs)
+  worst = Math.max(worst, d)
+  console.log(`  ${d ? '挪了' : '没动'} ${String(d).padStart(4)}px  ${key}`)
+}
+console.log(`最大位移 ${worst}px`)
+await browser.close()
+process.exit(worst === 0 ? 0 : 1)


### PR DESCRIPTION
用户反馈：「这里他的位置经常会跳变」。两张相隔几秒的截图，「1 待确认」换了个位置：

![前一秒：待确认在最右](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-268/user-1.png)

![后一秒：它跑到了直连格左边](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-268/user-2.png)

两处原因，同一个毛病：**位置取决于一个每 1.5 秒都在变的量。**

## 一、挪位规则的触发条件挂在宽度上

`pickCells` 里有一条：「有格子被丢掉，说明位置紧张，把上色的格提到左半第二位」。

可总宽度每 1.5 秒随读数变一次——延迟多一位数、速率出现又消失——于是「这一帧丢没丢格」
在真假之间来回翻，上色的那一格就跟着在原位和第二位之间瞬移。

规则删掉。钉住（warn/danger 跳过丢弃顺序）已经保证它不会消失，位置就该待着不动。这正是
同一个文件里那句 **「挪位会让格子在眼皮底下跑」** 说的事——只是当时没料到触发条件自己
会抖。

## 二、延迟和速率没有预留宽度

条子本来就有一套按单位预留的机制（`UNIT_CH`：`CPU 8%` 涨到 `CPU 100%` 不推右边的格），
但机器格的 `6ms` 和刚加的直连格那两个数都没走它。补两个单位：

- `ms`（5ch）——机器格延迟
- `latencyRate`（13ch，**左对齐**）——直连格的「延迟 + 速率」两截一起留：左对齐才能让
  `8ms` 待在原地、速率往右边那半截留白里长，而不是右对齐把延迟顶着往左推

直连格的路径同时挪进了 `label`，两个数留在 value 里——预留只盖 value，得让变的那部分落在
里面。

## 实测：1100px 视口，40 次采样 / 30 秒，中途灌一股流量让速率出现又消失

![改前六格各挪 81px，改后全 0px](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-268/jitter-out.png)

**81px 不是「抖一下」**：延迟多一位数就让总宽越线，右半整个丢掉一格再加回来，所以是整格
宽度的位移。

新增 `scripts/dev/statusbar-jitter.mjs`：位置跳变是「看得出、说不清」的那类 bug，肉眼只
记得「刚才它好像在左边」。采一遍就没有争议了（最大位移非 0 时退出码非 0，可以当守门用）。

## 看起来

![空闲：预留的那半截是留白，看不出来](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-268/bar-idle.png)

![有流量：速率长进留白里，右边的格一个都没动](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-268/bar-busy.png)

## 一个附带的修正

中转/连接中时直连格的 value 现在是空串。`formatValue` 里显式区分了「没数可报」（空串 →
不画）和「取不到」（`--`）——否则中转那一格会凭空多出一个坏掉的读数 `中转 --`，而且还要
白占那 13ch 预留。

单测：挪位那条测试改成「宽屏窄屏都在同一个位置」；直连格的四条跟着 label/value 的新分工
更新；`check.sh quick` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
