### PR TITLE
feat(p2p): 图片、视频、PDF 也走直连 —— Service Worker 拦 /api/file/raw，调用点一行不改

### DIFF
--- a/backend/p2p/bytes.go
+++ b/backend/p2p/bytes.go
@@ -1,0 +1,196 @@
+// bytes.go：浏览器向节点要「某个文件的某一段」——图片、视频、PDF、Office 预览都从这条路拿。
+//
+// 与 transfer.go 的整份下载是两回事：
+//   - transfer.go 是「点下载按钮」，一次一个 PC、一整个文件、落盘。
+//   - 这里是**一问一答**：一条 DataChannel 一次 {path,offset,length}，回 meta + 数据帧 + eof。
+//     `<video>` 拖一次进度条就是一次新的 Range 请求，所以通道开在**常驻 PC** 上，
+//     绝不为每一段重新打洞（打一次洞 0.7s，拖进度条会拖出十几次）。
+//
+// 谁来调用：前端 Service Worker 拦到 /api/file/raw 就走这里（见 frontend/src/p2p/file-bytes.ts）。
+// 任何一步出错都回 error 帧，前端原样去走 HTTP —— 直连只是快路，不是唯一的路。
+package p2p
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"ttmux-web/api"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// bytesReq 是通道上的第一帧（text）：要哪个文件的哪一段。
+type bytesReq struct {
+	Path   string `json:"path"`
+	Offset int64  `json:"offset"`
+	Length int64  `json:"length"` // 0 = 从 offset 一直到文件末尾
+}
+
+// bytesMeta 是回给前端的第一帧（text）。size 是**整个文件**多大——
+// 少了它，Service Worker 拼不出 206 的 Content-Range，浏览器就不让拖进度条。
+type bytesMeta struct {
+	T           string `json:"t"`
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	Offset      int64  `json:"offset"`
+	Length      int64  `json:"length"`
+	Mtime       int64  `json:"mtime"`
+	ContentType string `json:"contentType"`
+	Chunk       int    `json:"chunk"`
+}
+
+// serveBytes 处理一条 label 前缀为 "bytes" 的通道：只收一个请求，发完即关。
+func serveBytes(dc *webrtc.DataChannel) {
+	var once sync.Once
+	var closed int32
+	dc.OnClose(func() { atomic.StoreInt32(&closed, 1) })
+	dc.OnError(func(error) { atomic.StoreInt32(&closed, 1) })
+	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+		if !msg.IsString {
+			return // 数据帧只往一个方向走；二进制进来了当没看见
+		}
+		data := append([]byte(nil), msg.Data...)
+		// 起 goroutine：OnMessage 在 SCTP 读循环上，堵在这儿会卡住整条 PC 的收包。
+		once.Do(func() { go handleBytes(dc, data, &closed) })
+	})
+}
+
+func handleBytes(dc *webrtc.DataChannel, raw []byte, closed *int32) {
+	defer func() { _ = dc.Close() }()
+
+	var req bytesReq
+	if err := json.Unmarshal(raw, &req); err != nil {
+		_ = dc.SendText(errFrameText("bad-request"))
+		return
+	}
+	// 与 HTTP 下载同一把锁：共享校验逐字节一致，直连不能成为绕过校验的后门。
+	path, err := api.ValidateDownloadPath(req.Path)
+	if err != nil {
+		_ = dc.SendText(errFrameText("bad-path"))
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		_ = dc.SendText(errFrameText("stat-error"))
+		return
+	}
+	if info.IsDir() || !info.Mode().IsRegular() {
+		// 目录和字符设备（/dev/urandom 会无限流）一律不发
+		_ = dc.SendText(errFrameText("not-regular-file"))
+		return
+	}
+	size := info.Size()
+	offset := req.Offset
+	if offset < 0 || offset > size {
+		_ = dc.SendText(errFrameText("bad-range"))
+		return
+	}
+	length := size - offset
+	if req.Length > 0 && req.Length < length {
+		length = req.Length
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		_ = dc.SendText(errFrameText("open-error"))
+		return
+	}
+	defer f.Close()
+
+	ctype := contentTypeOf(f, path)
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			_ = dc.SendText(errFrameText("seek-error"))
+			return
+		}
+	}
+
+	mb, _ := json.Marshal(bytesMeta{
+		T: "meta", Name: info.Name(), Size: size, Offset: offset, Length: length,
+		Mtime: info.ModTime().Unix(), ContentType: ctype, Chunk: chunkBytes,
+	})
+	if err := dc.SendText(string(mb)); err != nil {
+		return
+	}
+
+	// 背压：和 transfer.go 同款（高水位停、OnBufferedAmountLow 唤醒）。
+	dc.SetBufferedAmountLowThreshold(hiWater / 2)
+	resume := make(chan struct{}, 1)
+	dc.OnBufferedAmountLow(func() {
+		select {
+		case resume <- struct{}{}:
+		default:
+		}
+	})
+
+	buf := make([]byte, chunkBytes)
+	frame := make([]byte, 4+chunkBytes)
+	var seq uint32
+	var sent int64
+	for sent < length {
+		if atomic.LoadInt32(closed) == 1 {
+			// 浏览器取消了（拖进度条、关页面）：别再往一条没人听的通道里灌
+			log.Printf("p2p: bytes %s canceled at %d/%d", info.Name(), sent, length)
+			return
+		}
+		want := int64(chunkBytes)
+		if r := length - sent; r < want {
+			want = r
+		}
+		n, readErr := f.Read(buf[:want])
+		if n > 0 {
+			binary.LittleEndian.PutUint32(frame, seq)
+			copy(frame[4:], buf[:n])
+			if err := dc.Send(frame[:4+n]); err != nil {
+				return
+			}
+			seq++
+			sent += int64(n)
+			for dc.BufferedAmount() > hiWater {
+				if atomic.LoadInt32(closed) == 1 {
+					return
+				}
+				<-resume
+			}
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				_ = dc.SendText(errFrameText("read-error"))
+				return
+			}
+			break
+		}
+	}
+	if sent != length {
+		// 读到的比说好的少（文件被截断/换掉）：明确报错，别让前端拼出一个短文件当成功
+		_ = dc.SendText(errFrameText("short-read"))
+		return
+	}
+	_ = dc.SendText(`{"t":"eof"}`)
+	log.Printf("p2p: bytes %s offset=%d sent=%d type=%s", info.Name(), offset, sent, ctype)
+}
+
+// contentTypeOf 先按扩展名判，判不出再嗅前 512 字节（与 http.ServeFile 的顺序一致，
+// 免得同一个文件在 HTTP 和直连两条路上拿到两种 Content-Type）。
+func contentTypeOf(f *os.File, path string) string {
+	if t := mime.TypeByExtension(filepath.Ext(path)); t != "" {
+		return t
+	}
+	var head [512]byte
+	n, _ := f.Read(head[:])
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "application/octet-stream"
+	}
+	if n == 0 {
+		return "application/octet-stream"
+	}
+	return http.DetectContentType(head[:n])
+}

--- a/backend/p2p/link.go
+++ b/backend/p2p/link.go
@@ -36,6 +36,9 @@ type dcHandler func(dc *webrtc.DataChannel)
 //     RegisterPhoneHandler 注入，避免 p2p↔phone 循环 import。
 var linkHandlers = map[string]dcHandler{
 	"echo": serveEcho,
+	// "bytes"：浏览器要某个文件的某一段（图片/视频/PDF 的 Range 请求，见 bytes.go）。
+	// 开在常驻 PC 上——拖一次进度条就是一次新请求，不能每次重新打洞。
+	"bytes": serveBytes,
 }
 
 // RegisterScreencastHandler 注入浏览器镜像的 DataChannel handler（label 前缀 "screencast"）。

--- a/backend/p2p/pc_test.go
+++ b/backend/p2p/pc_test.go
@@ -1,7 +1,10 @@
 package p2p
 
 import (
+	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -272,5 +275,42 @@ func TestWaitGathered(t *testing.T) {
 	// 一个 srflx 都没有：等满上限——那种情况无从判断它是不是马上要来。
 	if d := elapsed(make(chan struct{}), make(chan struct{})); d < gatherMaxDur {
 		t.Errorf("无 srflx 应等满 %v，实际 %v", gatherMaxDur, d)
+	}
+}
+
+// TestContentTypeOf 直连给出的 Content-Type 必须和 HTTP 那条路一致：
+// 先按扩展名，判不出再嗅前 512 字节。不一致的话，同一个文件在两条路上会被浏览器
+// 当成两种东西（一条能播、另一条弹下载）。
+func TestContentTypeOf(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		body []byte
+		want string // 前缀匹配（mime 库可能带 charset）
+	}{
+		{"a.mp4", []byte("\x00\x00\x00\x18ftypmp42"), "video/mp4"},
+		{"a.png", []byte("\x89PNG\r\n\x1a\n"), "image/png"},
+		{"noext", []byte("%PDF-1.4\n%âãÏÓ"), "application/pdf"}, // 没扩展名 → 嗅出来
+	}
+	for _, c := range cases {
+		p := filepath.Join(dir, c.name)
+		if err := os.WriteFile(p, c.body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := contentTypeOf(f, p)
+		// 嗅探要把读游标还回开头，否则接下来发出去的字节会少 512 个
+		var head [4]byte
+		n, _ := f.Read(head[:])
+		f.Close()
+		if !strings.HasPrefix(got, c.want) {
+			t.Errorf("%s: 期望 %s，得到 %s", c.name, c.want, got)
+		}
+		if n != 4 || !bytes.Equal(head[:], c.body[:4]) {
+			t.Errorf("%s: 嗅探后游标没回到开头（读到 %q）", c.name, head[:n])
+		}
 	}
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -23,7 +23,10 @@ self.addEventListener('fetch', (event) => {
   let url
   try { url = new URL(req.url) } catch { return }
   if (url.origin !== self.location.origin) return     // 跨域：交给浏览器
-  if (url.pathname.startsWith('/api')) return          // 实时接口/WS：直连网络
+  // 文件字节（图片/视频/PDF/Office 预览）：先问页面能不能走直连。
+  // 页面说不行、或者半天不答，就照常走网络——拦截只是给它一条快路，不是把路拦死。
+  if (isFileBytes(url)) { event.respondWith(fileBytes(event)) ; return }
+  if (url.pathname.startsWith('/api')) return          // 其余实时接口/WS：直连网络
 
   // 导航（打开页面）：网络优先，失败回退缓存的外壳
   if (req.mode === 'navigate') {
@@ -53,3 +56,67 @@ self.addEventListener('fetch', (event) => {
     })())
   }
 })
+
+// ── 文件字节走直连（P2P）─────────────────────────────────────────────────
+//
+// `<img src>` / `<video src>` / iframe 要的是一个 URL，而 DataChannel 不是 URL——
+// 这就是 Service Worker 在这儿的全部意义：把直连拿到的字节塞进一个 Response 里，
+// 上面那些标签一行都不用改。SW 自己碰不到 RTCPeerConnection（它在另一个上下文），
+// 所以真正取字节的是页面：SW 把请求转给页面，页面把 chunk 传回来。
+//
+// 不拦 ?dl=1：那是「下载」，有自己的一条 P2P 流程（p2p/download.ts），
+// 而且要带 Content-Disposition，不该由这里合成。
+const FILE_BYTES = /(^|\/)api\/file\/raw$/
+
+function isFileBytes(url) {
+  return FILE_BYTES.test(url.pathname) && url.searchParams.get('dl') !== '1'
+}
+
+/** 页面多久不答就走网络。页面主线程忙的时候不能把一张图吊死在这儿 */
+const DECIDE_TIMEOUT_MS = 700
+/** 页面说「我试」之后，再等首帧多久。直连可能还在建（0.7s 左右），别在这一步前功尽弃 */
+const HEAD_TIMEOUT_MS = 6000
+
+async function fileBytes(event) {
+  const req = event.request
+  try {
+    const client = await self.clients.get(event.clientId || event.resultingClientId)
+    if (!client) return fetch(req)
+
+    const ch = new MessageChannel()
+    const head = await new Promise((resolve) => {
+      let timer = setTimeout(() => resolve(null), DECIDE_TIMEOUT_MS)
+      ch.port1.onmessage = (e) => {
+        const m = e.data
+        clearTimeout(timer)
+        // 'try'：页面认了这一单，但直连可能还在建——把等待放宽到首帧超时，
+        // 否则第一枪永远赶不上（页面在等链路，SW 已经走了网络）。
+        if (m && m.type === 'try') { timer = setTimeout(() => resolve(null), HEAD_TIMEOUT_MS); return }
+        resolve(m && m.type === 'head' ? m : null)
+      }
+      client.postMessage({
+        type: 'roam-file-bytes',
+        url: req.url,
+        range: req.headers.get('Range') || '',
+      }, [ch.port2])
+    })
+    if (!head) { try { ch.port1.postMessage({ type: 'cancel' }) } catch {} ; return fetch(req) }
+
+    const body = new ReadableStream({
+      start(controller) {
+        ch.port1.onmessage = (e) => {
+          const m = e.data
+          if (!m) return
+          if (m.type === 'chunk') controller.enqueue(new Uint8Array(m.buf))
+          else if (m.type === 'end') { controller.close(); ch.port1.close() }
+          else if (m.type === 'error') { controller.error(new Error(m.msg || 'p2p')); ch.port1.close() }
+        }
+      },
+      // 浏览器不要了（拖进度条、关页面）：告诉页面停，别让后端对着空气继续发
+      cancel() { try { ch.port1.postMessage({ type: 'cancel' }) } catch {} ; ch.port1.close() },
+    })
+    return new Response(body, { status: head.status, headers: head.headers })
+  } catch {
+    return fetch(req)
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from './theme'
 import { I18nProvider } from './i18n'
 import { spike, verify } from './p2p/download'
 import { roamP2PEcho } from './p2p/transport'
+import { readFileRange } from './p2p/file-bytes'
+import { wireFileBytesToServiceWorker } from './p2p/file-bytes-sw'
 import './index.css'
 
 // [临时/仅开发] P2P 直连的控制台自测入口（不接产品 UI，避免触发 i18n 规范）：
@@ -20,12 +22,15 @@ if (import.meta.env.DEV) {
   ;(window as any).roamP2PSpike = spike
   ;(window as any).roamP2PVerify = verify
   ;(window as any).roamP2PEcho = roamP2PEcho
+  ;(window as any).roamReadRange = readFileRange
 }
 
 // 注册 service worker：满足 PWA「添加到桌面」可安装条件 + 离线打开应用外壳。
 // 仅在安全上下文(https / localhost)注册；/api 与 WebSocket 不被其拦截（见 public/sw.js）。
 if ('serviceWorker' in navigator && (location.protocol === 'https:' || location.hostname === 'localhost')) {
   window.addEventListener('load', () => { navigator.serviceWorker.register('/sw.js').catch(() => {}) })
+  // SW 拦到 /api/file/raw 会回头问页面要字节（图片/视频/PDF 走直连，见 p2p/file-bytes-sw.ts）
+  wireFileBytesToServiceWorker()
 }
 
 // 安卓 Chrome 软键盘默认会压缩布局视口（把界面挤一下）。这里让虚拟键盘「悬浮覆盖」内容，

--- a/frontend/src/p2p/file-bytes-sw.test.ts
+++ b/frontend/src/p2p/file-bytes-sw.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../components/cluster/node-url', () => ({ currentNodeId: () => 'n_me' }))
+
+const { parseRange, pathOf, isCurrentNode } = await import('./file-bytes-sw')
+
+describe('Range 解析', () => {
+  it('认单段：起止都给 / 只给起点', () => {
+    expect(parseRange('bytes=100-199')).toEqual({ offset: 100, length: 100 })
+    expect(parseRange('bytes=100-')).toEqual({ offset: 100, length: 0 })
+    expect(parseRange(' bytes=0-0 ')).toEqual({ offset: 0, length: 1 })
+  })
+
+  it('不认的花样一律返回 null，让它走 HTTP —— 猜错一个字节就是一段坏视频', () => {
+    expect(parseRange('bytes=-500')).toBeNull()        // 后缀区间：要先知道文件多大
+    expect(parseRange('bytes=0-99,200-299')).toBeNull() // 多段：响应体得是 multipart
+    expect(parseRange('items=0-1')).toBeNull()
+    expect(parseRange('bytes=200-100')).toBeNull()      // 起点比终点大
+    expect(parseRange('')).toBeNull()
+  })
+})
+
+describe('取路径与机器归属', () => {
+  it('从 query 里取绝对路径', () => {
+    expect(pathOf('https://h/api/file/raw?path=%2Ftmp%2Fa%20b.mp4')).toBe('/tmp/a b.mp4')
+    expect(pathOf('https://h/api/file/raw')).toBe('')
+    expect(pathOf('不是个 URL')).toBe('')
+  })
+
+  it('别的机器上的文件不走直连 —— 直连只通向当前这台，拿错就是给错文件', () => {
+    expect(isCurrentNode('https://hub/n/n_me/api/file/raw?path=%2Fa')).toBe(true)
+    expect(isCurrentNode('https://hub/n/n_other/api/file/raw?path=%2Fa')).toBe(false)
+    expect(isCurrentNode('https://node/api/file/raw?path=%2Fa')).toBe(true) // 单机/本机直通口
+  })
+})

--- a/frontend/src/p2p/file-bytes-sw.ts
+++ b/frontend/src/p2p/file-bytes-sw.ts
@@ -1,0 +1,114 @@
+// 页面这一侧的接线：Service Worker 拦到 /api/file/raw 就问这里要字节。
+//
+// 为什么要分两处：SW 在另一个上下文里，碰不到 RTCPeerConnection；页面拿得到直连，
+// 但拦不住 `<img src>`。所以 SW 负责拦、页面负责取，中间走 MessageChannel。
+import { readFileRange } from './file-bytes'
+import { getPreferences } from '../preferences'
+import { currentNodeId } from '../components/cluster/node-url'
+
+/** 直连还没建起来时，为一次字节请求最多等多久 */
+const WAIT_LINK_MS = 2500
+/** 小于这个大小的东西不值得等直连：几十 KB 的图标，等建链还不如直接走 HTTP 拿回来 */
+const WORTH_IT_BYTES = 256 * 1024
+
+type SwRequest = { type: string; url: string; range: string }
+
+/** 解析 Range 头。只认单段的 `bytes=start-` / `bytes=start-end`；其余（多段、后缀）返回 null 让它走 HTTP。 */
+export function parseRange(h: string): { offset: number; length: number } | null {
+  const m = /^bytes=(\d+)-(\d*)$/.exec((h || '').trim())
+  if (!m) return null
+  const offset = Number(m[1])
+  const end = m[2] ? Number(m[2]) : -1
+  if (!Number.isFinite(offset) || offset < 0) return null
+  if (end >= 0 && end < offset) return null
+  return { offset, length: end >= 0 ? end - offset + 1 : 0 }
+}
+
+/** 从 /api/file/raw?path=... 里取出那个绝对路径 */
+export function pathOf(url: string): string {
+  try { return new URL(url).searchParams.get('path') || '' } catch { return '' }
+}
+
+/**
+ * 这条 URL 要的是不是**当前这台机器**上的文件。
+ *
+ * 多机模式下地址形如 `/n/<nodeId>/api/file/raw`，而我们的直连只通向当前机器。
+ * 不比这一下，在中心里翻别的机器的文件时会拿本机同路径的文件顶上去——
+ * 那不是慢一点的问题，是给错文件。
+ */
+export function isCurrentNode(url: string): boolean {
+  let pathname: string
+  try { pathname = new URL(url).pathname } catch { return false }
+  const m = /^\/n\/([^/]+)\//.exec(pathname)
+  if (!m) return true // 没有 /n/ 前缀 = 直连这台机器的地址（单机，或本机直通口）
+  return decodeURIComponent(m[1]) === (currentNodeId() || '')
+}
+
+function headers(meta: { size: number; offset: number; length: number; contentType: string }, ranged: boolean) {
+  const h: Record<string, string> = {
+    'Content-Type': meta.contentType,
+    'Content-Length': String(meta.length),
+    // 不报 Accept-Ranges，`<video>` 就不给拖进度条
+    'Accept-Ranges': 'bytes',
+    'Cache-Control': 'no-cache',
+    // 标记这一条是从直连来的：出问题时「到底走了哪条路」不该靠猜（DevTools 里直接看得见）
+    'X-Roam-Transport': 'p2p',
+  }
+  if (ranged) h['Content-Range'] = `bytes ${meta.offset}-${meta.offset + meta.length - 1}/${meta.size}`
+  return h
+}
+
+async function serve(req: SwRequest, port: MessagePort) {
+  const path = pathOf(req.url)
+  const range = req.range ? parseRange(req.range) : { offset: 0, length: 0 }
+  // 偏好关着、路径解析不出、Range 是我们不认的花样、要的是别的机器上的文件 → 让 SW 走网络
+  if (!path || !range || !getPreferences().p2pEnabled || !isCurrentNode(req.url)) {
+    port.postMessage({ type: 'net' })
+    return
+  }
+
+  const ac = new AbortController()
+  port.onmessage = (e) => { if (e.data?.type === 'cancel') ac.abort() }
+  // 先应一声「我试」：直连可能还在建，SW 那边等首帧的耐心要放宽，
+  // 否则第一枪永远是 HTTP —— 而第一枪往往正是最大的那一枪（整段视频）。
+  port.postMessage({ type: 'try' })
+
+  try {
+    // 只有「要的量够大」才值得等直连建起来：请求带 Range 的基本都是视频/大文件，
+    // 不带 Range 的第一枪不知道多大，也给它等——真小文件也就多等一次，之后链路就在了。
+    const waitMs = range.length === 0 || range.length >= WORTH_IT_BYTES ? WAIT_LINK_MS : 0
+    const { meta, stream } = await readFileRange(path, { ...range, waitMs, signal: ac.signal })
+    port.postMessage({
+      type: 'head',
+      status: req.range ? 206 : 200,
+      headers: headers(meta, !!req.range),
+    })
+    const reader = stream.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      // buffer 转移所有权：几 MB 的视频段来回拷贝会把主线程拖出可见卡顿
+      const buf = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)
+      port.postMessage({ type: 'chunk', buf }, [buf])
+    }
+    port.postMessage({ type: 'end' })
+  } catch (e) {
+    // 头还没发出去 → SW 会退回网络；已经发了 → 只能把这条流判失败（浏览器自己会重试）
+    port.postMessage({ type: 'error', msg: String((e as Error)?.message || e) })
+  }
+}
+
+let wired = false
+
+/** 挂上监听。多调用几次无所谓（幂等），SW 没注册成功时什么也不做。 */
+export function wireFileBytesToServiceWorker() {
+  if (wired || typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return
+  wired = true
+  navigator.serviceWorker.addEventListener('message', (ev: MessageEvent) => {
+    const data = ev.data as SwRequest | undefined
+    if (!data || data.type !== 'roam-file-bytes') return
+    const port = ev.ports?.[0]
+    if (!port) return
+    void serve(data, port)
+  })
+}

--- a/frontend/src/p2p/file-bytes.ts
+++ b/frontend/src/p2p/file-bytes.ts
@@ -1,0 +1,115 @@
+// 从直连那条路取「某个文件的某一段」。后端在 backend/p2p/bytes.go。
+//
+// 为什么要有这一层：图片、视频、PDF、Office 预览全都是 `<img src>` / `<video src>` /
+// iframe 直接打 /api/file/raw，那是经中心/frp 转发的普通 HTTP（实测 0.3–0.4 MB/s）。
+// 这里把「一段字节」做成可以被 Service Worker 当作 fetch 响应体的东西，那些标签
+// 一行都不用改（见 file-bytes-sw.ts）。
+import { connect, holdMediaFor, whenMediaReady } from './transport'
+import { parseDataFrame, SeqValidator } from './download-proto'
+
+export interface BytesMeta {
+  name: string
+  /** 整个文件多大——206 的 Content-Range 要用，少了它浏览器不让拖进度条 */
+  size: number
+  offset: number
+  /** 这一段有多少字节 */
+  length: number
+  mtime: number
+  contentType: string
+}
+
+export interface BytesRange {
+  offset?: number
+  /** 0/缺省 = 从 offset 一直到文件末尾 */
+  length?: number
+  signal?: AbortSignal
+  /** 直连还没建起来时最多等多久（毫秒）。0=不等，直接判不可用让调用方走 HTTP */
+  waitMs?: number
+}
+
+/** meta 迟迟不来就认栽走 HTTP：卡在这儿等于让一张图永远转圈 */
+const META_TIMEOUT_MS = 4000
+/** 一次字节请求之后，链路再留这么久（翻下一张图就不用重新打洞了） */
+const HOLD_LINK_MS = 60_000
+
+/**
+ * 取一段字节。返回 meta 和一条可读流；任何一步不成就 reject，调用方去走 HTTP。
+ *
+ * 流没有反压：DataChannel 收到就 enqueue，消费慢了只会堆在流的内部队列里。
+ * 对「一段 Range」（几 MB）是合适的；真要整份大文件还是走下载那条路（download.ts）。
+ */
+export async function readFileRange(path: string, opts: BytesRange = {}): Promise<{ meta: BytesMeta; stream: ReadableStream<Uint8Array> }> {
+  holdMediaFor(HOLD_LINK_MS)
+  if (opts.waitMs) await whenMediaReady(opts.waitMs)
+  return new Promise((resolve, reject) => {
+    const tp = connect('bytes')
+    if (tp.kind !== 'p2p') { tp.close(); reject(new Error('p2p-unavailable')); return }
+
+    let settled = false
+    let ctrl: ReadableStreamDefaultController<Uint8Array> | null = null
+    const seq = new SeqValidator()
+    let got = 0
+    let meta: BytesMeta | null = null
+
+    const fail = (why: string) => {
+      if (!settled) { settled = true; reject(new Error(why)) }
+      try { ctrl?.error(new Error(why)) } catch { /* 已经关了 */ }
+      ctrl = null
+      cleanup()
+    }
+    const timer = setTimeout(() => fail('meta-timeout'), META_TIMEOUT_MS)
+    const onAbort = () => fail('aborted')
+    const cleanup = () => {
+      clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onAbort)
+      try { tp.close() } catch { /* 已经关了 */ }
+    }
+    opts.signal?.addEventListener('abort', onAbort)
+
+    tp.onopen = () => {
+      tp.send(JSON.stringify({ path, offset: opts.offset ?? 0, length: opts.length ?? 0 }))
+    }
+    tp.onclose = () => {
+      // eof 之前断了 = 半截数据。宁可让调用方回退去走 HTTP，也不能把半个文件当成功交出去。
+      if (!settled) fail('closed-before-meta')
+      else if (ctrl) fail('closed-before-eof')
+    }
+    tp.onmessage = (d) => {
+      if (typeof d === 'string') {
+        let m: { t?: string; msg?: string } & Partial<BytesMeta>
+        try { m = JSON.parse(d) } catch { fail('bad-frame'); return }
+        if (m.t === 'error') { fail(m.msg || 'server-error'); return }
+        if (m.t === 'meta') {
+          clearTimeout(timer)
+          meta = {
+            name: m.name || '', size: m.size ?? 0, offset: m.offset ?? 0,
+            length: m.length ?? 0, mtime: m.mtime ?? 0, contentType: m.contentType || 'application/octet-stream',
+          }
+          settled = true
+          resolve({
+            meta,
+            stream: new ReadableStream<Uint8Array>({
+              start(c) { ctrl = c },
+              cancel() { cleanup() }, // 浏览器不要了（拖进度条/关页面）→ 关通道，让后端停发
+            }),
+          })
+          return
+        }
+        if (m.t === 'eof') {
+          if (meta && got !== meta.length) { fail('size-mismatch'); return }
+          try { ctrl?.close() } catch { /* 已经关了 */ }
+          ctrl = null
+          cleanup()
+        }
+        return
+      }
+      // 数据帧：[seq:u32 LE][payload]，seq 必须从 0 连续递增，缺号/乱序一律判失败
+      let frame
+      try { frame = parseDataFrame(d) } catch { fail('bad-data-frame'); return }
+      const bad = seq.check(frame.seq)
+      if (bad) { fail(bad); return }
+      got += frame.payload.byteLength
+      try { ctrl?.enqueue(frame.payload) } catch { fail('enqueue-failed') }
+    }
+  })
+}

--- a/frontend/src/p2p/transport.ts
+++ b/frontend/src/p2p/transport.ts
@@ -85,7 +85,7 @@ export interface DuplexTransport {
 }
 
 // 本阶段支持的服务名（echo 验证 + 后续消费者占位）。
-export type Service = 'echo' | 'term' | 'screencast' | 'phone' | 'file'
+export type Service = 'echo' | 'term' | 'screencast' | 'phone' | 'file' | 'bytes'
 
 // control 链路对外可观察状态（左边栏数据源）。
 export type LinkState = 'disabled' | 'connecting' | 'connected' | 'relay'
@@ -627,6 +627,48 @@ function releaseMedia() {
   }, RELEASE_GRACE_MS)
 }
 
+/**
+ * 把 media PC 多留一会儿（每次调用重新计时）。
+ *
+ * 字节请求是一阵一阵来的：翻一张图、隔十秒再翻一张。默认那 3 秒宽限（为镜像重挂设的）
+ * 太短，两次之间 PC 就被拆了，下一张图又要重新打洞——实测这种间隔下每次都在付 0.7 秒
+ * 的建链钱。留 60 秒，一轮翻图/一段视频就都落在同一条链路上。
+ *
+ * 净引用恒为 1：第一次调用 +1，之后只是重新计时；到点还回去。
+ */
+let bytesHoldTimer = 0
+export function holdMediaFor(ms: number) {
+  if (!bytesHoldTimer) ensureMediaLink()
+  else clearTimeout(bytesHoldTimer)
+  bytesHoldTimer = window.setTimeout(() => {
+    bytesHoldTimer = 0
+    releaseMedia()
+  }, ms)
+}
+
+/**
+ * 等 media PC 连上（最多 timeoutMs），期间保持引用计数，让它有机会连起来。
+ *
+ * 给字节请求用：第一张图/第一段视频到得比 PC 快，如果那一刻直接判「没直连」就走 HTTP，
+ * 那条快路等于永远用不上第一次。建链现在 0.7s 左右，值得等一下——但只在调用方说值得时
+ * 才等（小图片等 0.7s 不如直接走 HTTP 拿回来）。
+ */
+export async function whenMediaReady(timeoutMs: number): Promise<boolean> {
+  if (isMediaConnected()) return true
+  if (timeoutMs <= 0) return false
+  ensureMediaLink()
+  try {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      if (isMediaConnected()) return true
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    return isMediaConnected()
+  } finally {
+    releaseMedia() // 归还这次「为了等」而加的引用；真正的通道会自己再加一次
+  }
+}
+
 // media PC 是否已连（connect('screencast') 据此决定走不可靠 DataChannel 还是 frp WS）。
 function isMediaConnected(): boolean {
   return status.media === 'connected' && !!mediaPc && mediaPc.connectionState === 'connected'
@@ -1009,6 +1051,21 @@ export function connect(service: Service, opts: ConnectOptions = {}): DuplexTran
       } catch { /* 建通道失败 → 落到下面 frp 回退 */ }
     }
     return withRelease(frp()) // media 未连/建通道失败：本次走 frp，但保留 media 引用继续重连
+  }
+  // 'bytes'：文件字节（图片/视频/PDF 的 Range）走 media PC 上的**可靠·有序**通道。
+  //
+  // 借 media PC 而不是 control PC：一部视频几百 MB，塞进终端那条 SCTP 会把按键堵在后面
+  // （head-of-line）。media 本来就是为「重流量、与终端隔离」建的那条。通道语义是按通道设的，
+  // 所以镜像走不可靠、字节走可靠，两者共用一条 PC 互不矛盾。
+  if (service === 'bytes') {
+    ensureMediaLink()
+    if (!isMediaConnected() || !mediaPc) return withRelease(frpPlaceholder())
+    try {
+      const id = crypto.randomUUID().slice(0, 8)
+      return withRelease(wrapChannel(mediaPc.createDataChannel(`bytes#${id}`, { ordered: true })))
+    } catch {
+      return withRelease(frpPlaceholder())
+    }
   }
   // 其余服务走 control PC 的可靠通道。
   if (!isControlConnected() || !pc) return opts.frpUrl ? wrapWebSocket(new WebSocket(opts.frpUrl)) : frpPlaceholder()


### PR DESCRIPTION
「通过这个传输视频还是很慢」——查下来不是链路慢，是**那条路根本没接 P2P**。

直连今天只接了「下载」按钮一处（`p2p/download.ts`）。而 `<video src>`、`<img src>`、PDF、
Office 预览、对话里贴的图，全都是直接打 `/api/file/raw` —— 经中心/frp 转发的普通 HTTP，
实测 0.3–0.4 MB/s。所以视频不是慢，是压根没走那条快路，而且**不止视频**：一条路上跑着
图片、PDF、Office 预览、聊天里的图。

## 为什么是 Service Worker

`<video src>` 要的是一个 URL，而 DataChannel 不是 URL。SW 在这儿的全部意义就是：
**拦住那个 URL，把直连拿到的字节塞进 Response**。于是上面那些标签一行都不用改，
谁都不知道字节是从哪来的。

三块：

**1. 后端 `p2p/bytes.go`** —— label 前缀 `bytes` 的一问一答通道：`{path,offset,length}` →
meta + 数据帧 + eof。meta 里带**整个文件多大**（206 的 `Content-Range` 要用，少了它浏览器
不给拖进度条）和 Content-Type（先按扩展名、判不出再嗅前 512 字节，与 `http.ServeFile`
同序——否则同一个文件在两条路上会被当成两种东西，一条能播另一条弹下载）。共享校验走同一个
`api.ValidateDownloadPath`：直连不能成为绕过校验的后门。

**2. 通道开在常驻 PC 上**，不为每一段重新打洞。拖一次进度条就是一次新的 Range 请求，而打
一次洞 0.7 秒——真按每段一个 PC 算，拖十次就是十次建链。借的是 media 那条（本来就是为
「重流量、与终端隔离」建的）：一部视频几百 MB，塞进终端那条 SCTP 会把按键堵在后面。通道
语义是按通道设的，所以镜像走不可靠、字节走可靠，共用一条 PC 并不矛盾。链路取完字节再留
60 秒，翻下一张图就不用重新打洞。

**3. SW 与页面两头接线** —— SW 碰不到 `RTCPeerConnection`（另一个上下文），页面拦不住
`<img src>`，所以 SW 负责拦、页面负责取，中间 MessageChannel。页面先应一声「我试」，SW 才
把等待从 700ms 放宽到首帧 6s：否则第一枪永远赶不上（页面在等链路建好，SW 已经走了 HTTP），
而第一枪往往正是最大的那一枪。

## 实测

![三种范围都走直连且与 HTTP 逐字节一致；连取十段；关掉偏好立刻让开](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-269/bytes-out.png)

真的 `<video>`：播到 2.5 秒，拖到第 90 秒，落在 92.0——缓冲段是 `0-19s` 和 `83-95s`
**两段**，说明拖动确实触发了一次独立的 Range 请求，而且回来了。

![拖到 90 秒之后继续播，无报错](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-269/video-only.png)

播放时状态条上就能看见这些字节在走直连（这条也顺带验证了上一个 PR 那个速率读数是真的）：

![直连 · 局域网 <1ms 3.1M/s](https://raw.githubusercontent.com/ybz21/Roami/pr-shots/pr-269/video-bar.png)

## 几条边界，都是故意的

- **别的机器上的文件不走直连**（`isCurrentNode`）。多机地址形如 `/n/<id>/api/file/raw`，
  而直连只通向当前那台——不比这一下，在中心里翻别的机器的文件会拿本机同路径的文件顶上去。
  那不是慢一点的问题，是给错文件。
- **`?dl=1` 不拦**：那是「下载」，有自己的 P2P 流程，而且要带 `Content-Disposition`，
  不该由这里合成。
- **后缀区间（`bytes=-500`）和多段区间一律走 HTTP**：前者要先知道文件多大，后者响应体
  得是 multipart。猜错一个字节就是一段坏视频，宁可让它走老路。
- **首帧发出去之后链路才断**的话，这一条只能判失败（浏览器自己会重试）——响应体已经开始
  流了，没法中途换回 HTTP。
- **HTML 预览 `/file/serve/*` 和 Office 转 PDF `/file/preview` 这一版没接**，仍走 HTTP：
  前者的相对引用要跟着一起拦，后者是后端现生成的临时文件，都得单独设计。

单测：Range 解析 / 路径提取 / 跨机器判定 4 条；Go 侧 Content-Type 探测 1 条（含
「嗅探后游标要还回开头」——不还就少发 512 字节，那种 bug 只会表现为「视频偶尔花屏」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
